### PR TITLE
Fix/codeowners team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # wasmcloud documentation reviewers
-* @autodidaddict @brooksmtownsend @LiamRandall @ricochet
+* @docs-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # wasmcloud documentation reviewers
-* @docs-maintainers
+* @wasmCloud/docs-maintainers


### PR DESCRIPTION
This PR ensures that the CODEOWNERS file references the team, not just individual folks, for easier maintenance. Thank you @ricochet for pointing out this oversight from #42 