### PR TITLE
Added agenda and simple script to replace menial commands

### DIFF
--- a/agenda.sh
+++ b/agenda.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+# Nice little helper script to run the few commands
+
+[ -z "$1" ] && echo "did not supply MM-DD for script" && exit 1
+
+echo "Creating new agenda for $1"
+git checkout main
+git fetch
+git pull
+git checkout -b mtg/$1-meeting-agenda
+
+DST_FILE=community/2023-$1-community-meeting.md
+cp community/template.txt $DST_FILE
+# TODO: sed
+echo "Done! Edit $DST_FILE"

--- a/community/2023-03-08-community-meeting.md
+++ b/community/2023-03-08-community-meeting.md
@@ -24,7 +24,7 @@ import ReactPlayer from 'react-player/youtube';
 	- Triage: Figuring out priority and work needed
 	- Discussion: Maintainers have seen the issue but still discussing from triage
 	- Todo: Task is assigned to a project and assigned at least a priority of "soon". At this step, anyone in the community should feel empowered to take this work if it's interesting to them
-- Feel free to give us feedback on how we
+- Feedback welcome!
 #### wasmCloud Rust common library
 - currently we use an Elixir library that wraps a Rust NIF that uses wasmtime under the hood
 - There are really interesting things going on in wasmtime, new specs being implemented, and new experimental features. We want to be able to really iterate quickly on these and that requires working directly in Rust that we can work with directly tailored to wasmCloud users.

--- a/community/2023-03-08-community-meeting.md
+++ b/community/2023-03-08-community-meeting.md
@@ -15,6 +15,23 @@ import ReactPlayer from 'react-player/youtube';
 <!--truncate-->
 
 ### Meeting Notes
+#### wadm demo in Rust
+- Successfully handling events from the lattice event stream
+- Properly pushing that work onto essentially a queue
+#### Projects
+- Projects in wasmcloud, Kanban style. You can find them by looking at the Projects tab in each repository, or by going to the org projects view: https://github.com/orgs/wasmCloud/projects?query=is:open
+- We put issues into a few statuses:
+	- Triage: Figuring out priority and work needed
+	- Discussion: Maintainers have seen the issue but still discussing from triage
+	- Todo: Task is assigned to a project and assigned at least a priority of "soon". At this step, anyone in the community should feel empowered to take this work if it's interesting to them
+- Feel free to give us feedback on how we
+#### wasmCloud Rust common library
+- currently we use an Elixir library that wraps a Rust NIF that uses wasmtime under the hood
+- There are really interesting things going on in wasmtime, new specs being implemented, and new experimental features. We want to be able to really iterate quickly on these and that requires working directly in Rust that we can work with directly tailored to wasmCloud users.
+- We also have multiple wasmCloud hosts being implemented (javascript, Go, Rust, Elixir) and want to have shared logic that can be used across different hosts
+- The demo centered around building, signing, engine compiling, and instantiating multiple instances of the `echo` actor directly in wasmtime
+- Will likely work on a Rust host to be used for embedded devices and for testing
+- Going to be pushed to a PR in the wasmcloud/wasmcloud
 
 ### Recording
-Recording is being uploaded to YouTube and will be displayed promptly
+<ReactPlayer url='https://youtu.be/SWD4B7f6veo' controls />

--- a/community/2023-03-08-community-meeting.md
+++ b/community/2023-03-08-community-meeting.md
@@ -1,0 +1,20 @@
+---
+title: 2023-03-08 Community Meeting
+authors: [brooks]
+tags: [community, meeting]
+description: Agenda, notes, and recording for the 2023-03-08 community meeting
+---
+
+import ReactPlayer from 'react-player/youtube';
+
+### Agenda
+- (DEMO) wadm Rust implementation and processing events/commands
+- wasmCloud GitHub projects (OSS Roadmap)
+- wasmCloud host Rust initial implementation
+
+<!--truncate-->
+
+### Meeting Notes
+
+### Recording
+Recording is being uploaded to YouTube and will be displayed promptly


### PR DESCRIPTION
This PR adds a small agenda and a little script so you can generate an agenda a little easier. `sed` is a little annoying because it takes a different argument on Linux/Mac so I'm leaving it out now, would just replace the `YYYY-MM-DD` with the actual date

Usage: `./agenda.sh 03-08`