### PR TITLE
update version of wasmbus-rpc in example

### DIFF
--- a/docs/app-dev/create-provider/rust.md
+++ b/docs/app-dev/create-provider/rust.md
@@ -103,7 +103,7 @@ resolver = "2"
 [dependencies]
 async-trait = "0.1"
 log = "0.4"
-wasmbus-rpc = "0.10"
+wasmbus-rpc = "0.11"
 wasmcloud-examples-payments = { path="../payments/rust" }
 
 [[bin]]


### PR DESCRIPTION
## Feature or Problem
The docs reference an older version of wasmbus-rpc than is used by the interface generated by `wash new interface ...`

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
Users should be able to follow along with the documentation now

## Testing
I admit I didn't test this. I feel reasonably confident in this one-character change :) 