### PR TITLE
More clarity around openssl

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -12,17 +12,25 @@ We will guide you through installation of `wash`, the wasmCloud Shell, which giv
 <Tabs>
   <TabItem value="ubuntudebian" label="Ubuntu/Debian" default>
 
+:::caution
+wasmCloud requires an OpenSSL 1.1 compatible version on Linux. If you're running Ubuntu 22.04+ or equivalent, you'll need to follow the steps in [this issue](https://github.com/wasmCloud/wash/issues/366) to install a compatible OpenSSL version.
+:::
+
 ```bash
 curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.deb.sh | sudo bash
-sudo apt install wash
+sudo apt install wash openssl
 ```
 
   </TabItem>
   <TabItem value="fedora" label="Fedora">
 
+:::caution
+wasmCloud requires an OpenSSL 1.1 compatible version on Linux. If you're running Fedora 36+ or equivalent, you'll need to follow the steps in [this issue](https://github.com/wasmCloud/wash/issues/366) to install a compatible OpenSSL version.
+:::
+
 ```bash
 curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.rpm.sh | sudo bash
-sudo dnf install wash
+sudo dnf install wash openssl
 ```
 
   </TabItem>
@@ -37,7 +45,7 @@ snap install wash --devmode --edge
 
 ```bash
 brew tap wasmcloud/wasmcloud
-brew install wash
+brew install wash openssl@1.1
 ```
 
   </TabItem>
@@ -50,7 +58,7 @@ choco install wash
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-If your platform isn't listed, `wash` can be installed with `cargo` and a properly installed Rust toolchain.
+If your platform isn't listed, `wash` can be installed with `cargo` and a properly installed Rust toolchain. Ensure you install OpenSSL 1.1 on your system as well to run the wasmCloud host.
 
 ```bash
 cargo install wash-cli


### PR DESCRIPTION
This PR adds more clarity in around our openssl dependency and how to install it, including a link to the issue tracking 3.0 support.