### PR TITLE
Removed actor workflows that use `make` in favor of `wash build`

### DIFF
--- a/blog/example_creating_webassembly_actor_in_go_with_tinygo.md
+++ b/blog/example_creating_webassembly_actor_in_go_with_tinygo.md
@@ -140,10 +140,11 @@ There are still quite a few places in TinyGo where importing a certain package w
 
 TinyGo is rapidly plugging these holes and providing packages that don't require a JavaScript host runtime, but we still need to watch out for things like this. To keep this example simple rather than hunting for an alternative JSON encoder, we just created a string that contains valid JSON.
 
-Now, just like any other wasmCloud actor, we can modify the `CLAIMS` variable in the actor's `Makefile` to contain both the HTTP server contract and the Key-Value contract:
+Now, just like any other wasmCloud actor, we can modify the `claims` variable in the actor's `wasmcloud.toml` to contain both the HTTP server contract and the Key-Value contract:
 
 ```
-CLAIMS   = --http_server --keyvalue
+[actor]
+claims = ["wasmcloud:httpserver", "wasmcloud:keyvalue"]
 ```
 
 With our new TinyGo actor in hand, we can start the actor, start two capability providers (HTTP and Key-Value), provide a link definition, and finally curl the running endpoint:

--- a/docs/app-dev/create-actor/run.md
+++ b/docs/app-dev/create-actor/run.md
@@ -14,7 +14,7 @@ We assume you've already [installed](/docs/installation.mdx) wash, the wasmCloud
 
 ### Build the actor
 
-Building the actor is as easy as running `make` in the project's root directory. This will compile the actor and sign it with a freshly generated seed key. The `Makefile` that comes with the newly generated project lists claims for the actor including `wasmcloud:httpserver`, so it can work with the HTTP Server capability provider.
+Building the actor is as easy as running `wash build` in the project's root directory. This will compile the actor using your local toolchain and automatically [sign it](https://wasmcloud.com/docs/reference/host-runtime/security) for you. The `wasmcloud.toml` file that comes with the newly generated project lists claims for the actor including `wasmcloud:httpserver`, so it can work with the HTTP Server capability provider.
 
 ### Launch the Actor
 

--- a/docs/app-dev/create-actor/update.md
+++ b/docs/app-dev/create-actor/update.md
@@ -61,13 +61,9 @@ Let's start by scaling down our `hello` actor if it's still running from a previ
 
 ![scaledown](./scaledown.png)
 
-Now, let's start the actor again using the "Start Actor" dropdown, but this time let's use the _From File (Hot Reload)_ option. You'll be required to supply the absolute path [^1] to your actor file, and you can choose a number of replicas to start as well. Luckily, we have an easy way for you to get the absolute path of your actor. Simply navigate to your actor project directory and run:
+Now, let's start the actor again using the "Start Actor" dropdown, but this time let's use the _From File (Hot Reload)_ option. You'll be required to supply the absolute path [^1] to your actor file, and you can choose a number of replicas to start as well.
 
-```shell
-make target-path-abs
-```
-
-Copy the path printed by this command into the and enter it in the _Start Actor_ form along with any number of replicas, and hit submit.
+Enter the absolute path in the _Start Actor_ form along with any number of replicas, and hit submit.
 
 ![starthotreload](./starthotreload.png)
 

--- a/docs/app-dev/create-actor/update.md
+++ b/docs/app-dev/create-actor/update.md
@@ -109,7 +109,7 @@ The new parameter that selects the greeting will be called `msg`. If msg is "hel
 
 In `src/lib.rs`, replace handle_request with the code above. Since we aren't releasing a new version of the actor yet, we don't need to change the version number in `Cargo.toml`.
 
-Run `make` to build the actor and re-sign it. The host replaces all running instances of the actor with the new version, thanks to the hot reload feature, and re-links them with the HttpServer capability provider using the link parameters already provided. It is not necessary to re-issue a link command.
+Run `wash build` to build the actor and re-sign it. The host replaces all running instances of the actor with the new version, thanks to the hot reload feature, and re-links them with the HttpServer capability provider using the link parameters already provided. It is not necessary to re-issue a link command.
 
 Let's try out the new actor:
 

--- a/docs/app-dev/create-provider/consuming.md
+++ b/docs/app-dev/create-provider/consuming.md
@@ -65,7 +65,7 @@ async fn checkout(&self, ctx: &Context, order: &Order) -> RpcResult<()> {
 In the preceding sample, any (authorized) actor could simply perform an actor-to-actor invocation using the shared actor interface in the `commerce` crate to trigger a shopping cart checkout, which in turn makes use of the payment capability provider, all without any actor developer ever having to know how payments are processed in production, and, even better, allowing actor developers to simulate arbitrary payment environments for unit tests, acceptance tests, and feedback loop/REPL experimentation on their workstation.
 
 :::caution
-Make sure your actor is signed by adding `wasmcloud:examples:payments` to the CLAIMS declaration in the actor project's Makefile, or your actor(s) will not be authorized to link with or communicate with the provider we wrote.
+Make sure your actor is signed by adding `wasmcloud:examples:payments` to the `claims` declaration in the actor project's `wasmcloud.toml`, or your actor(s) will not be authorized to link with or communicate with the provider we wrote.
 :::
 
 [^1]: _better_ is of course, subjective. Your needs and mileage may vary.

--- a/docs/app-dev/create-provider/testing.md
+++ b/docs/app-dev/create-provider/testing.md
@@ -15,8 +15,7 @@ A second method for testing a provider is to run it in a realistic environment, 
 
 2. Upload the newly-created _provider archive_ to the local OCI registry (You can use `wash reg push ...`, or if you have one of the provider project Makefiles, `make push`) `make start` to start it.
 
-3. Upload an actor that utilizes the provider to the local OCI registry (`make` and `make push` from the actor source folder to compile it, sign it, and push it to the registry), An example of doing this can be found in [Running the actor](../create-actor/run/#launch-the-actor). `make start` to start it.
-   .
+3. Upload an actor that utilizes the provider to the local OCI registry (`wash build` from the actor source folder to compile it, sign it, and then use `wash reg push` to upload it to the registry). Then, use `wash ctl start` to start the actor from the local registry.
 4. Link the actor with `wash ctl link` [on the command line](/docs/app-dev/create-actor/run/#add-a-link-definition) or via the dashboard web UI. For the fakepay provider, no extra configuration parameters values are required for the link command. Note that even if you don't supply configuration values, an actor must be linked to a provider, and be signed with sufficient claims, before it can communicate with the provider.
 
 5. Invoke the actor by sending a JSON payload, either on the command line with `wash call actor -o json --data input.json` or the dashboard UI. The method name invoked, and the parameters in input.json must exactly match the interface implemented by your actor. In the previous section we used `CheckoutRequest` that might have a JSON body as follows:

--- a/docs/app-dev/debugging/actors.md
+++ b/docs/app-dev/debugging/actors.md
@@ -63,7 +63,7 @@ wasmcloud:
 
 ### Missing Capability Claims
 
-When a wasmCloud actor needs access to a capability provider, we require cryptographically signed claims embedded in that actor. The host runtime operates on a deny-by-default and require claims to be an allow-list to ensure our actors are secure. Adding these capability claims is mostly managed for you with `wash` when you build your actor and the space-separated list of capability claims in the `Makefile` included with any actor project.
+When a wasmCloud actor needs access to a capability provider, we require cryptographically signed claims embedded in that actor. The host runtime operates on a deny-by-default and require claims to be an allow-list to ensure our actors are secure. Adding these capability claims is mostly managed for you with `wash` when you build your actor and the list of capability claims in `wasmcloud.toml` included with any actor project.
 
 This can be illustrated with the `KVCounter` example actor fairly easily. The actor needs to be signed with the `wasmcloud:httpserver` capability to receive HTTP requests, and the `wasmcloud:keyvalue` capability to issue requests to a keyvalue database. Omitting either of these will cause errors due to the inability to receive a request or the inability to issue one, so we'll cover both of those scenarios here.
 

--- a/docs/app-dev/std-caps/_index.en.md
+++ b/docs/app-dev/std-caps/_index.en.md
@@ -31,14 +31,13 @@ use wasmcloud_interface_keyvalue::*;
 
 ### Sign the actor
 
-Before an actor can use a capability provider, it needs to be signed with the capability id. The signing process takes a WebAssembly file (with `.wasm` extension), generates a JWT containing the list of capability claims, signs the JWT with your private signing key, and generates a file ending in `_s.wasm` containing the original WebAssembly plus the JWT.
+Before an actor can use a capability provider, it needs to be signed with the capability id. The signing process takes a WebAssembly file (with `.wasm` extension), generates a JWT containing the list of capability claims, signs the JWT with your private signing key, and generates a file ending in `_s.wasm` containing the original WebAssembly plus the JWT. When using `wash build`, the signing is done automatically for you, using the claims declared in `wasmcloud.toml`:
 
-Using the wasmCloud Makefiles (which you can get from a project in the [examples](https://github.com/wasmCloud/examples) repository, or a from project generated with `wash new actor`), the signing is done automatically for you, using the claims declared in the Makefile
-
-```make
-CLAIMS = wasmcloud:httpserver
+```toml
+[actor]
+claims = ["wasmcloud:httpserver"]
 ```
 
-Whenever you type `make`, the Makefile's rules execute the command `wash claims sign ...` to sign the actor module.
+Whenever you type `wash build`, `wash` will both use your local language toolchain to compile the `.wasm` file and then use `wash claims sign ...` to sign the actor module.
 
 You can use the command `wash claims inspect` to show the capability claims of a signed actor.

--- a/docs/app-dev/workflow/index.md
+++ b/docs/app-dev/workflow/index.md
@@ -18,12 +18,12 @@ Once you've established a dependency on a library that exposes the interface abs
 The developer's _iteration loop_ for building an actor looks something like this:
 
 1. Make code changes
-1. Compile and sign the WebAssembly module, creating a `_s.wasm` file (using `make` in an actor project)
+1. Compile and sign the WebAssembly module, creating a `_s.wasm` file (using `wash build` in an actor project)
 1. Test the module
    1. In the wasmCloud web dashboard
       1. Use the _From File (Hot reload)_ form to automatically watch actor files for changes
       1. Script `wash call` commands to invoke the actor
-      1. Modify your actor code, run `make` to recompile and re-sign the actor, repeat the above step
+      1. Modify your actor code, run `wash build` to recompile and re-sign the actor, repeat the above step
    1. Leverage the `wasmcloud:testing` interface and the [test provider](https://github.com/wasmCloud/wasmcloud-test)
 1. _Repeat_
 

--- a/docs/app-dev/workflow/index.md
+++ b/docs/app-dev/workflow/index.md
@@ -62,7 +62,12 @@ To start a local OCI registry, download the [sample Docker Compose file](https:/
 docker compose up -d registry
 ```
 
-Once it's running, you can push actors and capability providers to the registry via the `wash reg` set of commands (or `make push`, if using the wasmCloud Makefiles).
+Once it's running, you can push actors and capability providers to the registry via the `wash reg` set of commands. For example:
+
+```bash
+wash reg push localhost:5000/myactor:0.1.0 ./build/my_actor_s.wasm
+wash reg push localhost:5000/myprovider:0.1.0 ./build/my_provider.par.gz
+```
 
 ### Allowing unauthenticated OCI registry access
 

--- a/docs/interfaces/code-generation.md
+++ b/docs/interfaces/code-generation.md
@@ -20,7 +20,7 @@ We have developed libraries to support two popular styles of code generation. If
 - **Visitor pattern**
   - A `Generator` class in `weld_codegen::gen` parses the smithy model and invokes callbacks to generate interface definitions, structures, methods, and data types. Each callback function appends its output to a buffer, which is written to the output file after the entire schema has been processed. A base trait implements common, language-independent, functions, and a rust generator extends the base trait to implement specialize generators for Rust output.
 
-The Rust code generator uses both techniques: the Visitor pattern is used for generating `.rs` files, and the handlebars templates are used for generating `Cargo.toml` files and `Makefile`s.
+The Rust code generator uses both techniques: the Visitor pattern is used for generating `.rs` files, and the handlebars templates are used for generating `Cargo.toml` and `wasmcloud.toml` files.
 
 There is a documentation generator that turns `.smithy` files into html. It uses the sample code generation libraries, and is invoked by passing `html` as the output language instead of `rust`.
 


### PR DESCRIPTION
## Feature or Problem
This PR removes some of the final references to using Makefiles within actor projects, officially encouraging `wash build`.

## Related Issues
https://github.com/wasmCloud/project-templates/pull/65
