### PR TITLE
docs: add redirects from old pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,20 @@
+# [[redirects]]
+#   from = "/old-path"
+#   to = "/new-path"
+#   status = 301
+
+[[redirects]]
+  from = "/cloud"
+  to = "/docs/production/k8s/"
+  status = 301
+
+[[redirects]]
+  from = "/docs"
+  to = "/docs/intro"
+  status = 301
+
+[[redirects]]
+  from = "/docs/app-dev"
+  to = "/docs/fundamentals/interface_driven_development"
+  status = 301
+


### PR DESCRIPTION
This PR adds a `netlify.toml` to the root of the repo. I opted to use this file rather than `__redirects` because I didn't want to mess with the CI to stick the `__redirects` in the build folder. Unlike `__redirects`, `netlify.toml` works at the root of the repo.

I verified that trailing slashes are normalized by netlify.