### PR TITLE
docs: add link CONTRIBUTING.md on site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -107,6 +107,10 @@ const config = {
                 href: 'https://github.com/wasmcloud/',
               },
               {
+                label: 'Contributing',
+                href: 'https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md',
+              },
+              {
                 label: 'Slack',
                 href: 'https://slack.wasmcloud.com',
               },


### PR DESCRIPTION
OpenSSF best practices requirement:
>  The project website MUST provide information on how to: obtain,
> provide feedback (as bug reports or enhancements),
> and contribute to the software

Simple fix to have the wasmCloud website meet all
[basic requirements](https://bestpractices.coreinfrastructure.org/en/projects/6363)