### PR TITLE
Added info for wasmCloud v0.63 burrito running

### DIFF
--- a/docs/fundamentals/debugging/host.md
+++ b/docs/fundamentals/debugging/host.md
@@ -20,7 +20,7 @@ The wasmCloud host logs include the following:
 
 ## Finding the logs (release tarball)
 
-If you followed the [installation](/docs/installation) guide then you likely started the host by running a command like `./bin/wasmcloud_host start` or `./bin/wasmcloud_host daemon`. In the same directory where you unpacked the tarball you'll be able to find the logs in `./tmp/log/erlang.log.X`, where `X` starts at `1` and will increment monotonically as the log file grows too large.
+If you followed the [installation](/docs/installation) guide then you likely started the host by running a command like `wash up` or `wash up --detached`. If you ran the host using `wash up` the logs will be printed to the screen, otherwise they will be located in the `~/.wash/downloads` directory.
 
 If you take a look at the top of one of these logfiles (using `head` for example on Unix systems) you'll see something like:
 
@@ -74,61 +74,9 @@ At the time of writing this, the main wasmCloud host runtime is an Elixir/OTP ap
 
 ### Elixir + Actors
 
-Elixir supports log levels of `error`, `warn`, `info`, and `debug`. In order to change the log level you'll need to use the integrated Elixir terminal using one of the methods below. Because actors log through the host runtime, this will also affect their log level.
+Elixir supports log levels of `error`, `warn`, `info`, and `debug`. You'll need to set the log level before you launch the host by setting the environment variable `WASMCLOUD_LOG_LEVEL` to one of the supported log level.
 
-<Tabs>
-  <TabItem value="local" label="Local Development" default>
-
-When you launch your host, do so with the integrated terminal attached. In the `wasmcloud_host` directory:
-
-```shell
-iex -S mix phx.server
-```
-
-Then you can set the log level in the `iex` terminal
-
-```elixir
-Logger.configure(level: :debug)
-```
-
-As mentioned above, you can replace `debug` with `info`, `warn`, or `error`.
-
-  </TabItem>
-  <TabItem value="release" label="Release Tarball">
-
-Use the following command to attach to the Elixir integrated terminal
-
-```shell
-./bin/wasmcloud_host remote
-```
-
-Then use the `Logger` module to configure the log level
-
-```elixir
-Logger.configure(level: :debug)
-```
-
-As mentioned above, you can replace `debug` with `info`, `warn`, or `error`. You are now free to quit out of the console by inputting `CTRL+c` twice.
-
-  </TabItem>
-  <TabItem value="docker" label="Docker">
-
-Use the `docker` CLI to `exec` into your container:
-
-```shell
-docker exec -it <your_container_id> /opt/app/bin/wasmcloud_host remote
-```
-
-Then use the `Logger` module to configure the log level
-
-```elixir
-Logger.configure(level: :debug)
-```
-
-As mentioned above, you can replace `debug` with `info`, `warn`, or `error`. You are now free to quit out of the console by inputting `CTRL+c` twice.
-
-  </TabItem>
-</Tabs>
+For example, running `WASMCLOUD_LOG_LEVEL=debug wash up` will show the most verbose logs.
 
 ### Rust Capability Providers
 

--- a/docs/hosts/elixir/running.md
+++ b/docs/hosts/elixir/running.md
@@ -5,61 +5,24 @@ sidebar_position: 11
 draft: false
 ---
 
-The wasmCloud host runtime is an [Elixir mix release](https://hexdocs.pm/mix/Mix.Tasks.Release.html) that includes various scripts for running and managing an application. By running `bin/wasmcloud_host`, you'll see a variety of commands and options:
+The wasmCloud host runtime is an [Elixir burrito](https://github.com/burrito-elixir/burrito) that allows us to package cross-platform Elixir releases. It's a self-extracting tarball that contains statically linked assets for the most portability, and for all intents and purposes it acts like a single binary. Executing a burrito works just like any other binary, except for the first time you execute it the burrito will extract the Elixir application files to an application directory on your machine.
 
-```plain
-./bin/wasmcloud_host
-Usage: wasmcloud_host COMMAND [ARGS]
+## Installing
 
-The known commands are:
+If you'd like to run the host without using [wash](/docs/installation), simply download the host according to your machine's operating system and architecture from the [wasmcloud-otp Releases page](https://github.com/wasmCloud/wasmcloud-otp/releases), add the executable flag, and then run it.
 
-    start          Starts the system
-    start_iex      Starts the system with IEx attached
-    daemon         Starts the system as a daemon
-    daemon_iex     Starts the system as a daemon with IEx attached
-    eval "EXPR"    Executes the given expression on a new, non-booted system
-    rpc "EXPR"     Executes the given expression remotely on the running system
-    remote         Connects to the running system via a remote shell
-    restart        Restarts the running system via a remote command
-    stop           Stops the running system via a remote command
-    pid            Prints the operating system PID of the running system via a remote command
-    version        Prints the release name and version to be booted
+For example, on a Linux machine with the x86_64 architecture:
+
+```bash
+curl -fLO https://github.com/wasmCloud/wasmcloud-otp/releases/download/v0.63.0/wasmcloud_host_x86_64_linux_gnu
+chmod +x wasmcloud_host_x86_64_linux_gnu
+./wasmcloud_host_x86_64_linux_gnu
 ```
 
-There are a variety of commands and options to get used to here, we generally only focus on the commands that manage starting, stopping, and debugging a wasmCloud application.
+## Uninstalling
 
-- To start the host running in the current terminal, which is recommended to easily view logs, you can use `start`
+Elixir burritos have support for deleting extracted files with the `maintenance` command. Simply run the following command to remove extracted files:
 
-  ```bash
-  bin/wasmcloud_host start
-  ```
-
-- Alternately, you can start it in the background as a daemon with `daemon`
-
-  ```bash
-  bin/wasmcloud_host daemon
-  ```
-
-  and stop it with
-
-  ```bash
-  bin/wasmcloud_host stop
-  ```
-
-  or restart it with
-
-  ```bash
-  bin/wasmcloud_host restart
-  ```
-
-  If you choose this option, host logs will be located under `tmp/log` and can be viewed with:
-
-  ```bash
-  tail tmp/log/erlang.log.1
-  ```
-
-- If you're already familiar with Elixir and **iex**, Elixir's interactive shell, and want to dive into the host's internals, execute Elixir statements, and set breakpoints, start the host including an interactive console with:
-
-  ```bash
-  bin/wasmcloud_host start_iex
-  ```
+```bash
+./wasmcloud_host_x86_64_linux_gnu maintenance uninstall
+```

--- a/docs/hosts/elixir/safeshutdown.md
+++ b/docs/hosts/elixir/safeshutdown.md
@@ -9,11 +9,11 @@ In most cases, initiating a safe shutdown of the wasmCloud host runtime is quick
 
 ### Stopping the Background Daemon
 
-If you started the wasmCloud host runtime as a background process/daemon, then you can simply use the `wasmcloud_host` binary to terminate the process by executing `wasmcloud_host stop`.
+If you started the wasmCloud host runtime via [wash](/docs/installation), you can simply run `wash down` in order to clean up running processes in the background. If you started the host runtime using the [manual host guide](/docs/hosts/elixir/running), you'll need to send the process a `SIGTERM`.
 
 ### Exiting a Console
 
-If you start the wasmCloud host runtime as a console, either through the use of the `iex` application or by running `wasmcloud_host start_iex`, then you are in an interactive mode application that typically only supports termination through `ctrl-c`.
+If you start the wasmCloud host runtime as a console through the use of the `iex` application, then you are in an interactive mode application that typically only supports termination through `ctrl-c`.
 
 Before you use `ctrl-c` to exit the application, you can invoke an Elixir function in the `Host` module to attempt to purge all running entities, performing a graceful shutdown (which sends the "quit" message to all running capability providers, etc).
 


### PR DESCRIPTION
This PR modifies the information that we had for mix releases in order to support burrito execution as of v0.63. Since we are able to modify the docker image and wash, there's nothing that changes in those instructions.

In a future PR, once `wash` 0.19.0 is out and the hosts are burritos, we will want to remove the install requirement for openssl.