### PR TITLE
docs(wash): Adds documentation for wash spy, capture, and dev

### DIFF
--- a/docs/fundamentals/actors/create-actor/update.md
+++ b/docs/fundamentals/actors/create-actor/update.md
@@ -22,7 +22,7 @@ changes, recompile, and update the actor in the host.
 This is a great way to get started with wasmCloud development, and we recommend it for all new
 actors.
 
-Currently, `wash dev` only will starts the actor, so you'll have to follow the steps in the [running
+Currently, `wash dev` only will start the actor, so you'll have to follow the steps in the [running
 the actor](./run) section to start the providers your actor needs. We hope to automate as much of
 that away in the future.
 

--- a/docs/fundamentals/actors/create-actor/update.md
+++ b/docs/fundamentals/actors/create-actor/update.md
@@ -8,6 +8,28 @@ draft: false
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+This section describes how you can iteratively build and test your actor functionality.
+
+## `wash dev`
+
+As of wash 0.18.0 you can use the experimental `wash dev` command to rapidly iterate on your actor.
+This command will start a local wasmCloud host (if you don't already have one started) and
+automatically register your actor with it. It will also watch your actor file for changes and
+automatically recompile and update the actor in the host. This is a great way to get started with
+wasmCloud development, and we recommend it for all new actors. Currently, it only will start the
+actor, so you'll have to follow the steps in the [running the actor](./run) section to start the
+providers your actor needs. We hope to automate as much of that away in the future.
+
+Before running `wash dev`, you'll need to enable experimental mode for wash:
+
+```shell
+export WASH_EXPERIMENTAL=true
+```
+
+Then you can just run the `wash dev` command in the directory of your actor!
+
+## Hot Reloading
+
 ### Prerequisites
 
 To use the hot reloading feature you'll need to install one more [utility](https://github.com/falood/file_system#system-support) to ensure the host can monitor your actor file for changes. The following instructions for your operating system will ensure you are ready for the next section.
@@ -71,7 +93,7 @@ You should now see your actor with a `hot reloading` status badge, and you're re
 
 ![hotreloading](./hotreloading.png)
 
-### Making modifications (Rust)
+## Making modifications (Rust)
 
 Our new actor has come pre-equipped with a message handler that generates a text string in the body of the response. By default, the text is "Hello World", and the greeting changes if the URL contains a name parameter. We will modify the business logic of the actor to select the greeting, using a second URL paramter. In this exercise, you will go through the process of editing code, recompiling, and updating the actor in a live running system.
 
@@ -109,7 +131,9 @@ The new parameter that selects the greeting will be called `msg`. If msg is "hel
 
 In `src/lib.rs`, replace handle_request with the code above. Since we aren't releasing a new version of the actor yet, we don't need to change the version number in `Cargo.toml`.
 
-Run `wash build` to build the actor and re-sign it. The host replaces all running instances of the actor with the new version, thanks to the hot reload feature, and re-links them with the HttpServer capability provider using the link parameters already provided. It is not necessary to re-issue a link command.
+If you are using hot reloading, run `wash build` to build the actor and re-sign it. The host replaces all running instances of the actor with the new version, thanks to the hot reload feature, and re-links them with the HttpServer capability provider using the link parameters already provided. It is not necessary to re-issue a link command.
+
+If you are using `wash dev`, wash will build and relaunch your actor for you
 
 Let's try out the new actor:
 

--- a/docs/fundamentals/actors/create-actor/update.md
+++ b/docs/fundamentals/actors/create-actor/update.md
@@ -12,13 +12,19 @@ This section describes how you can iteratively build and test your actor functio
 
 ## `wash dev`
 
-As of wash 0.18.0 you can use the experimental `wash dev` command to rapidly iterate on your actor.
-This command will start a local wasmCloud host (if you don't already have one started) and
-automatically register your actor with it. It will also watch your actor file for changes and
-automatically recompile and update the actor in the host. This is a great way to get started with
-wasmCloud development, and we recommend it for all new actors. Currently, it only will start the
-actor, so you'll have to follow the steps in the [running the actor](./run) section to start the
-providers your actor needs. We hope to automate as much of that away in the future.
+As of wash 0.18.0 you can use the experimental `wash dev` command to rapidly build and iterate on
+your actor.
+
+`wash dev` starts a local wasmCloud host (if you don't already have one started), builds your actor,
+and automatically registers your actor with the host. It will also watch your actor source code for
+changes, recompile, and update the actor in the host. 
+
+This is a great way to get started with wasmCloud development, and we recommend it for all new
+actors.
+
+Currently, `wash dev` only will starts the actor, so you'll have to follow the steps in the [running
+the actor](./run) section to start the providers your actor needs. We hope to automate as much of
+that away in the future.
 
 Before running `wash dev`, you'll need to enable experimental mode for wash:
 

--- a/docs/fundamentals/debugging/actors.md
+++ b/docs/fundamentals/debugging/actors.md
@@ -160,8 +160,8 @@ Then, you can run `wash spy` to see all messages sent between actors and provide
 $ wash spy <actor name or ID>
 ```
 
-You can pass the actual actor ID if you wish, but for ease of use, if a non-key is provided, wash
-will attempt to resolve it to an ID by checking if the `actor_name` or `call_alias`` fields from the
+You can pass the actual actor ID if you wish, but for ease of use  wash
+will attempt to resolve it to an ID by checking if the `actor_name` or `call_alias` fields from the
 actor's claims contains the given string. If more than one matches, then an error will be returned
 indicating the options to choose from. Note that this matching is case-insensitive.
 
@@ -218,13 +218,12 @@ and output it to JSON, but if it is unable to, it will output the raw bytes inst
 ### `wash capture`
 
 As of wash 0.18, there is a new experimental debugging command called `wash capture`. This command
-enables to debug an issue after it occurs by capturing a window of all invocations in the lattice (1
-hour by default). A helpful comparison is that this is similar to many gaming tools that constantly
-capture your video while you game, and then at a press of a button you can save the last 60s for
-later usage/reply. This is useful for debugging issues that are difficult to reproduce, or for
-debugging issues that occur in production. Right now, the functionality is extremely simple, but if
-the community finds it useful, we plan on adding even more useful features to it (such as replaying
-invocation or setting up a lattice for reproducing the issue).
+enables you to debug an issue after it occurs by capturing a window of all invocations in the
+lattice (1 hour by default). A helpful comparison is that this is similar to many gaming tools that
+constantly capture your video while you game, and then at a press of a button you can save the last
+60s for later usage/reply. This is useful for debugging issues that are difficult to reproduce, or
+for debugging issues that occur in production. Right now, the functionality is extremely simple, but
+if the community finds it useful, we plan on adding even more useful features to it.
 
 To use it, you'll need to enable experimental mode for wash and then enable capture mode for your
 lattice:

--- a/docs/fundamentals/workflow/index.md
+++ b/docs/fundamentals/workflow/index.md
@@ -28,6 +28,8 @@ The developer's _iteration loop_ for building an actor looks something like this
    1. Leverage the `wasmcloud:testing` interface and the [test provider](https://github.com/wasmCloud/wasmcloud-test)
 1. _Repeat_
 
+As of wash 0.18.0, there is now a `wash dev` command that automates this process for you. See the [Customizing the actor](../actors/create-actor/update) section for more details on how to use it.
+
 ### Building Providers
 
 The workflow for building a capability provider is similar to that of building an actor. Once you've located and declared a dependency on the _interface_ implemented by your capability provider, the _iteration loop_ looks something like this:


### PR DESCRIPTION
This includes documentation for how to enable experimental mode as well as examples for running the commands
