### PR TITLE
Removed mentions of openssl

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -13,29 +13,17 @@ install, run, and develop with wasmCloud.
 <Tabs queryString="os">
   <TabItem value="ubuntudebian" label="Ubuntu/Debian" default>
 
-:::caution
-wasmCloud requires an OpenSSL 1.1 compatible version on Linux. If you're running Ubuntu
-22.04+ or equivalent, you'll need to follow the steps in [this
-issue](https://github.com/wasmCloud/wash/issues/366) to install a compatible OpenSSL version.
-:::
-
 ```bash
 curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.deb.sh | sudo bash
-sudo apt install wash openssl
+sudo apt install wash
 ```
 
   </TabItem>
   <TabItem value="fedora" label="Fedora">
 
-:::caution
-wasmCloud requires an OpenSSL 1.1 compatible version on Linux. If you're running Fedora 36+ or
-equivalent, you'll need to follow the steps in [this
-issue](https://github.com/wasmCloud/wash/issues/366) to install a compatible OpenSSL version.
-:::
-
 ```bash
 curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.rpm.sh | sudo bash
-sudo dnf install wash openssl
+sudo dnf install wash
 ```
 
   </TabItem>
@@ -50,7 +38,7 @@ snap install wash --devmode --edge
 
 ```bash
 brew tap wasmcloud/wasmcloud
-brew install wash openssl@1.1
+brew install wash
 ```
 
   </TabItem>
@@ -63,8 +51,7 @@ choco install wash
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-If your platform isn't listed, `wash` can be installed with `cargo` and a Rust toolchain. **Ensure
-you install OpenSSL 1.1 on your system as well to run the wasmCloud host.**
+If your platform isn't listed, `wash` can be installed with `cargo` and a Rust toolchain.
 
 ```bash
 cargo install wash-cli


### PR DESCRIPTION
As of wash 0.18, this is no longer a requirement. 

This change was made in #112 but that branch is still a WIP, and I want to release this