### PR TITLE
Modified community action to support livestream url

### DIFF
--- a/.github/workflows/agenda.yml
+++ b/.github/workflows/agenda.yml
@@ -6,6 +6,10 @@ on:
         description: "Date of next community meeting, in the form of YYYY-MM-DD"
         required: true
         type: string
+      livestream_url:
+        description: "URL of YouTube livestream for community meeting"
+        required: true
+        type: string
 jobs:
   create_agenda:
     runs-on: ubuntu-latest
@@ -13,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Create Community Agenda
         run: |
-          bash agenda.sh ${{ inputs.date }}
+          bash agenda.sh ${{ inputs.date }} ${{ inputs.livestream_url }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/agenda.sh
+++ b/agenda.sh
@@ -10,5 +10,5 @@ git fetch
 git pull
 
 DST_FILE=community/$1-community-meeting.md
-cat community/template.txt | sed "s/YYYY-MM-DD/$1/" | sed "s/VIDEOURL/$2/" > $DST_FILE
+cat community/template.txt | sed "s/YYYY-MM-DD/$1/" | sed "s,VIDEOURL,$2," > $DST_FILE
 echo "Done! Add agenda items, demos, and awesome stuff to $DST_FILE"

--- a/agenda.sh
+++ b/agenda.sh
@@ -4,10 +4,11 @@
 [ -z "$1" ] && echo "did not supply YYYY-MM-DD for script" && exit 1
 
 echo "Creating new agenda for $1"
+echo "Livestream link $2"
 git checkout main
 git fetch
 git pull
 
 DST_FILE=community/$1-community-meeting.md
-cat community/template.txt | sed "s/YYYY-MM-DD/$1/" > $DST_FILE
+cat community/template.txt | sed "s/YYYY-MM-DD/$1/" | sed "s/VIDEOURL/$2/" > $DST_FILE
 echo "Done! Add agenda items, demos, and awesome stuff to $DST_FILE"

--- a/community/template.txt
+++ b/community/template.txt
@@ -19,4 +19,4 @@ import ReactPlayer from 'react-player/youtube';
 
 ### Recording
 
-Recording is being uploaded to YouTube and will be displayed promptly
+<ReactPlayer url='VIDEOURL' controls />


### PR DESCRIPTION
## Feature or Problem
This PR adds one more input for the create community agenda action where you can supply the Youtube livestream link to avoid editing it in later.

You can see a successful run of this action at https://github.com/wasmCloud/wasmcloud.com-dev/actions/runs/5602669023