### PR TITLE
chore: improve a11y for code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,7 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const draculaTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -170,8 +169,8 @@ const config = {
       },
       prism: {
         additionalLanguages: ['rust', 'powershell', 'toml', 'elixir'],
-        theme: lightCodeTheme,
-        darkTheme: darkCodeTheme,
+        theme: draculaTheme,
+        darkTheme: draculaTheme,
       },
     }),
 };


### PR DESCRIPTION
This one has better a11y, and there are some other improvements but they probably should be done upstream to `prism-react-renderer/themes/dracula` package