### PR TITLE
feat: support direct community meeting edit

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,6 +55,7 @@ const config = {
         routeBasePath: 'community',
         path: './community',
         showReadingTime: false,
+        editUrl: 'https://github.com/wasmCloud/wasmcloud.com-dev/edit/main/',
         blogSidebarCount: 100,
         blogTitle: 'wasmCloud Community Content',
         blogDescription: 'wasmCloud community meetings agendas, notes, and recordings',


### PR DESCRIPTION
This PR allows contributors to click "edit this page" at the bottom of a community meeting page to easily add edits to a community agenda

