### PR TITLE
fix: links to k8s projects

### DIFF
--- a/docs/deployment/k8s/index.md
+++ b/docs/deployment/k8s/index.md
@@ -5,16 +5,28 @@ sidebar_position: 6
 draft: false
 ---
 
-Although we think WebAssembly is the future, we know that there are plenty of things running in
-Kubernetes, and that people often have easy access to run in a Kubernetes cluster somewhere. To make
-it easy for you to try out wasmCloud and/or integrate it with what you already have running, we have
-an [official Helm chart](https://github.com/wasmCloud/wasmcloud-otp/tree/main/wasmcloud_host/chart).
-See its documentation for specific configuration and usage examples.
+Although we think WebAssembly is the future, we know that there are plenty of things running in Kubernetes, and that people often have easy access to run in a Kubernetes cluster somewhere.
+
+## Official wasmCloud Helm Chart
+
+To make it easy for you to try out wasmCloud and/or integrate it with what you already have running, we've created an [official Helm chart][helm-chart].
+
+To get started quickly and see usage examples, read the ["Running the Chart" guide][helm-chart-quickstart], on the [chart README][helm-chart-docs].
+
+For a complete listing of configuration for the Helm chart, jump straight to the [`values.yaml`][helm-chart-values.yaml].
+
+[helm-chart]: https://github.com/wasmCloud/wasmCloud/blob/main/chart/Chart.yaml
+[helm-chart-docs]: https://github.com/wasmCloud/wasmCloud/tree/main/chart
+[helm-chart-values.yaml]: https://github.com/wasmCloud/wasmCloud/blob/main/chart/values.yaml
+[helm-chart-quickstart]: https://github.com/wasmCloud/wasmCloud/tree/main/chart#running-the-chart
 
 ## Kubernetes Service Applier
 
-Cosmonic has open sourced a basic connector that allows you to bridge services currently running in
-Kubernetes with services that you run in wasmCloud. The interface, provider, and actor can be found
-at https://github.com/cosmonic/kubernetes-applier. You can also check out the project's
-[docs](https://github.com/cosmonic/kubernetes-applier/tree/main/service-applier#readme) for a
+Cosmonic has open sourced a basic connector that allows you to bridge services currently running in Kubernetes with services that you run in wasmCloud.
+
+The interface, provider, and actor can be found at [on Github under `cosmonic/kubernetes-applier`][k8s-applier].
+You can also check out the project's [documentation][k8s-applier-readme] for a
 complete example architecture and instructions on how to run it.
+
+[k8s-applier]: https://github.com/cosmonic/kubernetes-applier
+[k8s-applier-readme]: https://github.com/cosmonic/kubernetes-applier/tree/main/service-applier#readme


### PR DESCRIPTION
# Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit updates the Kubernetes documentation to properly link to the official helm chart along with other related resources to help understand the Helm chart, while marking the service applier code as Legacy.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
