### PR TITLE
docs: remove requirement to add tap

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -38,7 +38,6 @@ snap install wash --devmode --edge
   <TabItem value="mac" label="MacOS">
 
 ```bash
-brew tap wasmcloud/wasmcloud
 brew install wash
 ```
 


### PR DESCRIPTION
As of wash v0.23.0, we install from published artifacts and no longer need this tap