### PR TITLE
chore: update references to old versions of the host

### DIFF
--- a/docs/cli/dev.md
+++ b/docs/cli/dev.md
@@ -33,7 +33,7 @@ wash dev --experimental --host-id=<your-host-id>
 
 `--nats-js-domain` NATS Server Jetstream domain, defaults to `core` [env: NATS_JS_DOMAIN=]
 
-`--wasmcloud-version` wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud-otp/releases for releases [env: WASMCLOUD_VERSION=] [default: v0.79.0]
+`--wasmcloud-version` wasmCloud host version to download, e.g. `v0.80.0`. See https://github.com/wasmCloud/wasmCloud/releases for releases [env: WASMCLOUD_VERSION=] [default: v0.80.0]
 
 `--lattice-prefix` (Alias `-x`) A lattice prefix is a unique identifier for a lattice, and is frequently used within NATS topics to isolate messages from different lattices [env: WASMCLOUD_LATTICE_PREFIX=] [default: default]
 

--- a/docs/cli/up.md
+++ b/docs/cli/up.md
@@ -52,7 +52,7 @@ NATS websocket port to use. Websocket support will not be enabled if this option
 NATS Server Jetstream domain, defaults to `core` [env: NATS_JS_DOMAIN=]
 
 #### --wasmcloud-version  
-wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud-otp/releases for releases [env: WASMCLOUD_VERSION=] [default: v0.78.0-rc6]
+wasmCloud host version to download, e.g. `v0.80.0`. See https://github.com/wasmCloud/wasmCloud/releases for releases [env: WASMCLOUD_VERSION=] [default: v0.80.0]
 
 #### --lattice-prefix  
 Alias: `-x`.

--- a/docs/deployment/lattice/security-patterns.md
+++ b/docs/deployment/lattice/security-patterns.md
@@ -27,4 +27,4 @@ You should never connect anonymously or without TLS to a remote NATS installatio
 
 ### User/password not supported?
 
-You may have noticed that while NATS supports clear text username and password authentication, we do not support this for wasmCloud lattice authentication. We have chosen instead to support either anonymous connections or de-centralized authentication connections. If you feel that there is suitable justification to support username and password lattice authentication, please [file an issue](https://github.com/wasmCloud/wasmcloud-otp/issues) with the team.
+You may have noticed that while NATS supports clear text username and password authentication, we do not support this for wasmCloud lattice authentication. We have chosen instead to support either anonymous connections or de-centralized authentication connections. If you feel that there is suitable justification to support username and password lattice authentication, please [file an issue](https://github.com/wasmCloud/wasmCloud/issues) with the team.

--- a/docs/deployment/tracing.md
+++ b/docs/deployment/tracing.md
@@ -44,7 +44,7 @@ As you can see, we retrieved the list of vets in our database in just under 40ms
 
 In order to enable tracing we'll take a look at the above example to show you what to set up. At a high level, you'll need:
 
-1. wasmCloud [v0.55.1](https://github.com/wasmCloud/wasmcloud-otp/releases/tag/v0.55.1) or later with the following environment variables:
+1. wasmCloud [v0.78.0](https://github.com/wasmCloud/wasmCloud/releases) or later with the following environment variables:
    - `OTEL_TRACES_EXPORTER=otlp` To set the exporter to `otlp`
    - `OTEL_EXPORTER_OTLP_ENDPOINT=<tracing exporter backend>` To export traces to your backend, e.g. `http://localhost:55681` for Tempo.
 1. A tracing backend that supports [otlp](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md), [Grafana Tempo](https://github.com/grafana/tempo) was what we chose for its simplicity for Docker compose, but [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/) are open source and also visualize traces. There are also commercial / "production-grade" offerings like [DataDog](https://www.datadoghq.com/knowledge-center/distributed-tracing/#distributed-tracing-tools) and [Honeycomb](https://www.honeycomb.io/trace/) too.

--- a/docs/deployment/tracing.md
+++ b/docs/deployment/tracing.md
@@ -44,7 +44,7 @@ As you can see, we retrieved the list of vets in our database in just under 40ms
 
 In order to enable tracing we'll take a look at the above example to show you what to set up. At a high level, you'll need:
 
-1. wasmCloud [v0.78.0](https://github.com/wasmCloud/wasmCloud/releases) or later with the following environment variables:
+1. [The wasmCloud host](https://github.com/wasmCloud/wasmCloud/releases) with the following environment variables:
    - `OTEL_TRACES_EXPORTER=otlp` To set the exporter to `otlp`
    - `OTEL_EXPORTER_OTLP_ENDPOINT=<tracing exporter backend>` To export traces to your backend, e.g. `http://localhost:55681` for Tempo.
 1. A tracing backend that supports [otlp](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md), [Grafana Tempo](https://github.com/grafana/tempo) was what we chose for its simplicity for Docker compose, but [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/) are open source and also visualize traces. There are also commercial / "production-grade" offerings like [DataDog](https://www.datadoghq.com/knowledge-center/distributed-tracing/#distributed-tracing-tools) and [Honeycomb](https://www.honeycomb.io/trace/) too.

--- a/docs/developer/debugging/host.md
+++ b/docs/developer/debugging/host.md
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 Host troubleshooting largely revolves around checking host logs and determining the issue from there. With wasmCloud we aim to log relevant information so that you can diagnose the source of the problem.
 
-The primary wasmCloud host runtime is the [wasmCloud](https://github.com/wasmCloud/wasmCloud/tree/main/crates/host) host, and this is what you'll be using if you're running the host from the release tarball or with the [wasmcloud](https://hub.docker.com/r/wasmcloud/wasmcloud) docker image. The Javascript host has different log messages and it's recommended to create an issue [here](https://github.com/wasmCloud/wasmcloud-js/issues/new) if you are running into errors in the browser.
+The primary wasmCloud host runtime is the [`wasmcloud-host`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/host), which you'll be using if you're running the host from the release tarball or with the [wasmcloud](https://hub.docker.com/r/wasmcloud/wasmcloud) docker image. The Javascript host has different log messages and it's recommended to create an issue [here](https://github.com/wasmCloud/wasmcloud-js/issues/new) if you are running into errors in the browser.
 
 The wasmCloud host logs include the following:
 

--- a/docs/developer/debugging/host.md
+++ b/docs/developer/debugging/host.md
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 Host troubleshooting largely revolves around checking host logs and determining the issue from there. With wasmCloud we aim to log relevant information so that you can diagnose the source of the problem.
 
-The primary wasmCloud host runtime is the [wasmcloud-otp](https://github.com/wasmCloud/wasmcloud-otp) host, and this is what you'll be using if you're running the host from the release tarball or with the [wasmcloud_host](https://hub.docker.com/repository/docker/wasmcloud/wasmcloud_host) docker image. The Javascript host has different log messages and it's recommended to create an issue [here](https://github.com/wasmCloud/wasmcloud-js/issues/new) if you are running into errors in the browser.
+The primary wasmCloud host runtime is the [wasmCloud](https://github.com/wasmCloud/wasmCloud/tree/main/crates/host) host, and this is what you'll be using if you're running the host from the release tarball or with the [wasmcloud](https://hub.docker.com/r/wasmcloud/wasmcloud) docker image. The Javascript host has different log messages and it's recommended to create an issue [here](https://github.com/wasmCloud/wasmcloud-js/issues/new) if you are running into errors in the browser.
 
 The wasmCloud host logs include the following:
 

--- a/docs/developer/debugging/index.md
+++ b/docs/developer/debugging/index.md
@@ -12,4 +12,4 @@ The following sections detail ways to track down errors with specific wasmCloud 
 - [Actor Troubleshooting](./actors)
 - [Provider Troubleshooting](./providers)
 
-If you find any issues that are not resolved by this documentation, please file an [issue here](https://github.com/wasmCloud/wasmcloud-otp/issues/new?assignees=&labels=bug%2C+help+wanted&template=bug_report.md&title=%5BBUG%5D+%3CIssue%3E) and we can assist you with the problem as well as look to add it to this section of the documentation.
+If you find any issues that are not resolved by this documentation, please file an [issue here](https://github.com/wasmCloud/wasmCloud/issues/new?assignees=&labels=bug%2C+help+wanted&template=bug_report.md&title=%5BBUG%5D+%3CIssue%3E) and we can assist you with the problem as well as look to add it to this section of the documentation.

--- a/docs/hosts/elixir/index.md
+++ b/docs/hosts/elixir/index.md
@@ -7,8 +7,10 @@ type: "docs"
 sidebar_position: 6
 ---
 
-wasmCloud's [Elixir host](https://github.com/wasmcloud/wasmcloud-otp) is the primary, fully supported, actively maintained host runtime. This application can be used for development on your laptop and globally distributed deployments in production clouds.
+:::caution
+wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
+:::
+
+This application can be used for development on your laptop and globally distributed deployments in production clouds.
 
 Elixir (and Erlang and the BEAM VM beneath it) is extremely good at supporting internal concurrency without forcing developers to deal with low-level concepts like mutexes and OS threads. The [OTP runtime](https://www.erlang.org/doc/design_principles/des_princ.html) has had decades of battle testing under the most crushing production workloads and wasmCloud can leverage that expertise by default.
-
-New features and developments for host runtimes are first made available in the shared [Rust wasmCloud runtime](https://github.com/wasmcloud/wasmcloud), and then added to the Elixir host if applicable.

--- a/docs/hosts/lattice-protocols/rpc.md
+++ b/docs/hosts/lattice-protocols/rpc.md
@@ -21,10 +21,7 @@ Lattice RPC supports the following interaction modes:
 All RPC interactions within the lattice involve sending an `Invocation` and receiving an `InvocationResponse`. Even
 if the operation is "fire and forget", the `InvocationResponse` is required to indicate a successful acknowledgement of the invocation.
 
-Because these structures are used in multiple places by multiple languages, you can find them in different places throughout the code base. Here are a couple of locations:
-
-- The Smithy [Interface](https://github.com/wasmCloud/interfaces/blob/main/core/wasmcloud-core.smithy#L143) - smithy models are considered authoritative as language-specific implementations should be generated from these IDL models.
-- The [wasmCloud OTP Host Runtime](https://github.com/wasmCloud/wasmcloud-otp/blob/main/host_core/native/hostcore_wasmcloud_native/src/inv.rs#L23) - There is a Rust implementation of the `Invocation` and `InvocationResponse` structs used by the host.
+Because these structures are used in multiple places by multiple languages, you can find them in different places throughout the code base. The primary source of truth is in the [core crate](https://github.com/wasmCloud/wasmCloud/blob/main/crates/core/src/lib.rs), used by the host runtime and Rust clients.
 
 The following is a description of the fields on an `Invocation`:
 


### PR DESCRIPTION
I found some more references to the OTP host