### PR TITLE
fix: add full path to brew install

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -511,7 +511,7 @@ snap install wash --devmode --edge
   <TabItem value="mac" label="MacOS">
 
 ```bash
-brew install wash
+brew install wasmcloud/wasmcloud/wash
 ```
 
   </TabItem>


### PR DESCRIPTION
This PR specifies the full tap path for installing wash

