### PR TITLE
refactor: change community meeting template to mdx

### DIFF
--- a/agenda.sh
+++ b/agenda.sh
@@ -9,6 +9,6 @@ git checkout main
 git fetch
 git pull
 
-DST_FILE=community/$1-community-meeting.md
+DST_FILE=community/$1-community-meeting.mdx
 cat community/template.txt | sed "s/YYYY-MM-DD/$1/" | sed "s,VIDEOURL,$2," > $DST_FILE
 echo "Done! Add agenda items, demos, and awesome stuff to $DST_FILE"

--- a/community/template.txt
+++ b/community/template.txt
@@ -13,7 +13,7 @@ import ReactPlayer from 'react-player/youtube';
 - 
 - 
 
-<!--truncate-->
+{/* truncate */}
 
 ### Meeting Notes
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Given the corrections necessary in the following review comment:

https://github.com/wasmCloud/wasmcloud.com-dev/pull/216#discussion_r1402950836

The template for the community agenda *should* be .mdx by default (it's currently .md) and the truncate directive should be written in comments for .mdx files.

This commit updates the community meeting template to be converted to an mdx file, and fixes the truncate directive-as-comment inside.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
