### PR TITLE
chore: fix outdated references to wash

### DIFF
--- a/docs/developer/debugging/actors.mdx
+++ b/docs/developer/debugging/actors.mdx
@@ -134,7 +134,7 @@ When you see this error, ensure that you've both signed your actor and linked yo
 
 When link definitions are misconfigured, you'll find errors like the ones above for missing link definitions. The host runtime looks at a link definition as a unique binding between an actor and a capability provider on a specific link name to communicate over a specific capability contract.
 
-The command line wasmCloud shell (aka [wash](https://github.com/wasmCloud/wash)) attempts to safeguard against misspellings, though it is unable to determine if a link definition is between the intended actor and provider. If the actor ID, provider ID, link name, or contract ID are misspelled or omitted then the runtime will deny the invocation as if it does not exist. This is as designed, no typo should be accepted in favor of compromising security.
+The command line wasmCloud shell (aka [wash](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-cli)) attempts to safeguard against misspellings, though it is unable to determine if a link definition is between the intended actor and provider. If the actor ID, provider ID, link name, or contract ID are misspelled or omitted then the runtime will deny the invocation as if it does not exist. This is as designed, no typo should be accepted in favor of compromising security.
 
 If you are establishing a link definition but still see errors that indicate that it's missing, first verify that the link definition specifies the correct actor, provider, link name, and contract ID. You can query all established link definitions in your lattice using `wash get link`.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -532,12 +532,12 @@ cargo install wash-cli
   </TabItem>
   <TabItem value="source" label="Source">
 
-The [wash repository](https://github.com/wasmcloud/wash) is open-source and can be cloned from
+The [wash project](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-cli) is open-source and can be cloned from
 GitHub and built locally with a Rust toolchain.
 
 ```bash
-git clone https://github.com/wasmcloud/wash.git
-cd wash
+git clone https://github.com/wasmCloud/wasmCloud.git
+cd crates/wash-cli
 cargo build --release
 ./target/release/wash
 ```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -30,7 +30,7 @@ This is a fairly minimal configuration for a wasmCloud Rust `echo` actor. It def
 
 The partner-in-crime to `wasmcloud.toml` is `wash build`. This command takes all the options set in the `wasmcloud.toml` file to build and sign the actor/provider/interface.
 
-See the `build` docs in the [wash repo](https://github.com/wasmCloud/wash#build) for more info.
+See the [`build` docs](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-cli#build) for more info.
 
 ## `wasmcloud.toml` Spec
 


### PR DESCRIPTION
## Feature or Problem
While running through our docs I found a few more links to the archived wash repo. I updated these to point to the updated URL