### PR TITLE
chore: add deprecated notice to OTP sub-pages

### DIFF
--- a/docs/hosts/elixir/architecture.md
+++ b/docs/hosts/elixir/architecture.md
@@ -7,6 +7,10 @@ type: "docs"
 sidebar_position: 0
 ---
 
+:::warning
+wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
+:::
+
 The following diagram illustrates the composition of the Elixir OTP host:
 
 ![host architecture diagram](./otp_host_arch.png)

--- a/docs/hosts/elixir/healthchecks.md
+++ b/docs/hosts/elixir/healthchecks.md
@@ -5,6 +5,10 @@ sidebar_position: 12
 draft: false
 ---
 
+:::warning
+wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
+:::
+
 There are a number of different health check mechanisms available within the wasmCloud host. One health check type is internal, which will periodically send a health check message to an actor or capability provider to see if it is still responding. The second type involves exposing liveness and readiness probe endpoints that can be used when running in containerized or orchestrated (e.g. Kubernetes) environments.
 
 #### Internal Health Checks

--- a/docs/hosts/elixir/host-configure.md
+++ b/docs/hosts/elixir/host-configure.md
@@ -5,6 +5,10 @@ sidebar_position: 3
 draft: false
 ---
 
+:::warning
+wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
+:::
+
 The wasmcloud host is configured by environment variables, which can be set in the environment or `.env` files.
 Real environment variables take precedence over values found in `.env` files.
 Some of the values contain secrets and should be protected accordingly.

--- a/docs/hosts/elixir/running.md
+++ b/docs/hosts/elixir/running.md
@@ -5,6 +5,10 @@ sidebar_position: 11
 draft: false
 ---
 
+:::warning
+wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
+:::
+
 The wasmCloud host runtime is an [Elixir burrito](https://github.com/burrito-elixir/burrito) that allows us to package cross-platform Elixir releases. It's a self-extracting tarball that contains statically linked assets for the most portability, and for all intents and purposes it acts like a single binary. Executing a burrito works just like any other binary, except for the first time you execute it the burrito will extract the Elixir application files to an application directory on your machine.
 
 ## Installing

--- a/docs/hosts/elixir/safeshutdown.md
+++ b/docs/hosts/elixir/safeshutdown.md
@@ -5,6 +5,10 @@ sidebar_position: 12
 draft: false
 ---
 
+:::warning
+wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
+:::
+
 In most cases, initiating a safe shutdown of the wasmCloud host runtime is quick and easy.
 
 ### Stopping the Background Daemon


### PR DESCRIPTION
We have this warning on the index page, but not the sub-pages