### PR TITLE
docs: add branding page

### DIFF
--- a/docs/reference/branding.md
+++ b/docs/reference/branding.md
@@ -1,0 +1,7 @@
+---
+title: "Branding & Logos"
+sidebar_position: 999
+type: "docs"
+---
+
+Assets for wasmCloud, including visual guidelines and logos, can be found in the [branding repository](https://github.com/wasmCloud/branding).


### PR DESCRIPTION
This adds a simple branding page, which links to https://github.com/wasmCloud/branding