### PR TITLE
chore: update references to outdated docker compose file

### DIFF
--- a/docs/developer/providers/testing.md
+++ b/docs/developer/providers/testing.md
@@ -11,7 +11,7 @@ The first method loads the provider into a test harness, and issues rpc calls to
 
 A second method for testing a provider is to run it in a realistic environment, interacting with a real host and real actors. To set up the environment,
 
-1. Start a new local OCI registry. You can download the [Docker Compose YAML file](https://github.com/wasmCloud/examples/blob/main/docker/docker-compose.yml) and run `docker compose up -d registry`. You'll also need to [allow unauthenticated OCI registry access](/docs/developer/workflow/#allowing-unauthenticated-oci-registry-access) before starting the wasmCloud host.
+1. Start a new local OCI registry. You can download the [Docker Compose YAML file](https://github.com/wasmCloud/wasmCloud/blob/main/examples/docker/docker-compose-full.yml) and run `docker compose up -d registry`. You'll also need to [allow unauthenticated OCI registry access](/docs/developer/workflow/#allowing-unauthenticated-oci-registry-access) before starting the wasmCloud host.
 
 2. Upload the newly-created _provider archive_ to the local OCI registry (You can use `wash push ...`, or if you have one of the provider project Makefiles, `make push`) `make start` to start it.
 

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -59,7 +59,7 @@ When the library is ready to release, it can be published. For example, interfac
 
 While it isn't called out as a specific pre-requisite, _many_ of the steps in the developer iteration loops involve interacting with an OCI registry. Unless you've got a public one that you can use, you'll likely want to use a local one for testing.
 
-To start a local OCI registry, download the [sample Docker Compose file](https://raw.githubusercontent.com/wasmCloud/examples/main/docker/docker-compose.yml) into the current folder and run
+To start a local OCI registry, download the [sample Docker Compose file](https://github.com/wasmCloud/wasmCloud/blob/main/examples/docker/docker-compose-full.yml) into the current folder and run
 
 ```bash
 docker compose up -d registry

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -556,7 +556,7 @@ wasmCloud via the washboard.
 :::
 
 Download the [sample Docker Compose
-file](https://raw.githubusercontent.com/wasmCloud/examples/main/docker/docker-compose.yml) and put
+file](https://github.com/wasmCloud/wasmCloud/blob/main/examples/docker/docker-compose-full.yml) and put
 it into your work directory. This compose file will run NATS, a local OCI registry, a Redis
 container, Grafana and Tempo for OTEL, and the `wasmcloud_host` container. In this format it's easy
 to run all the necessary services for a wasmCloud host with only a docker installation.


### PR DESCRIPTION
I noticed we referenced the outdated docker compose file in a few places, so I updated the links to point to the updated file in the main repo