### PR TITLE
chore: update subjects for events

### DIFF
--- a/docs/hosts/lattice-protocols/control-interface.md
+++ b/docs/hosts/lattice-protocols/control-interface.md
@@ -721,7 +721,7 @@ lattice event stream for the `linkdef_deleted` event.
 
 ## Lattice Events
 
-Lattice events are published on the stream `wasmbus.evt.{lattice}` where `lattice` is
+Lattice events are published on `wasmbus.evt.{lattice}.>` subjects, where `lattice` is
 the lattice name (also referred to as the "lattice ID"). Lattice events are
 JSON-serialized [CloudEvents](https://github.com/cloudevents/spec/blob/v1.0.1/json-format.md) for
 easy, standardized consumption. This means that the `data` field in the cloud event envelope is just

--- a/docs/reference/cloud-event-list.md
+++ b/docs/reference/cloud-event-list.md
@@ -5,7 +5,7 @@ description: "List of CloudEvents Used in a Lattice"
 sidebar_position: 5
 type: "docs"
 ---
-The following is a list of all of the [CloudEvents](https://cloudevents.io) emitted by wasmCloud hosts in a lattice. The events are published to `wasmbus.evt.{lattice-id}`, and so will publish to `wasmbus.evt.default` by default.
+The following is a list of all of the [CloudEvents](https://cloudevents.io) emitted by wasmCloud hosts in a lattice. The events are published to `wasmbus.evt.{lattice-id}.{event-type}`, and so will publish to `wasmbus.evt.default.>` by default.
 
 All of the events in the table below are namespaced by the prefix `com.wasmcloud.lattice`, so the `actor_started` event has the Cloud Event type of `com.wasmcloud.lattice.actor_started`. These event types do _not_ include the lattice identifier.
 


### PR DESCRIPTION
The host publishes events on `wasmbus.evt.{lattice-id}.{event-type}`, so this updates the docs to reflect that

(Events are still also published on `wasmbus.evt.{lattice-id}` for backwards compatibility reasons, but this will be removed prior to 1.0)