### PR TITLE
docs: add content to the production deployment guide

### DIFF
--- a/docs/deployment/nats/cluster-config.mdx
+++ b/docs/deployment/nats/cluster-config.mdx
@@ -4,10 +4,211 @@ description: "How to set up a NATS server/cluster"
 sidebar_position: 1
 ---
 
+A wasmCloud deployment requires at least one NATS server configured to use
+JetStream. A production deployment should use at least one NATS _cluster_ with
+three or five servers depending on your reliability requirements.
+
+:::info
+It is difficult to provide a one size fits all guide for deploying NATS since
+the topology of a cluster can vary wildly depending on your requirements. We
+recommend getting familiar with the [NATS
+Configuration](https://docs.nats.io/running-a-nats-service/configuration)
+options and the topology examples in provided by [NATS by
+Example](https://natsbyexample.com/).
+:::
+
+This guide will walk you through the process of running a single server as an
+example and then show you how to configure a three node NATS cluster suitable
+for production use cases. Advanced topics such as configuring a NATS operator
+hierarchy or enabling TLS are strongly recommended, but outside of the scope of
+this guide.
+
+## A single server deployment
+
+A minimal example of a configuration file is provided below:
+
+```text
+# Use an appropriate server name for your environment
+server_name: myserver
+
+jetstream: enabled
+jetstream {
+  store_dir = /path/to/data/directory
+  # Use a domain suitable for your environment
+  domain    = wasmcloud
+}
+```
+
+This configures a single nats server with JetStream with data stored in a known
+location. It also sets a JetStream domain so that you are all set to fan out
+your deployment using leaf nodes if you choose. We recommend pairing a leaf
+node with a wasmCloud host in order to mimimize latency for actors or providers
+running on the same host.
+
+You can run a simple NATS server with this config:
+
+```bash
+nats-server -c sample.conf
+```
+
+## Configuring a NATS Cluster
+
+In production we recommend running a [NATS
+_cluster_](https://docs.nats.io/running-a-nats-service/configuration/clustering)
+for high availability and resiliency. A production deployment requires at least
+a single NATS cluster consisting of at least three or five nodes. This is so
+that you can replicate the NATS key-value bucket that stores link definitions
+for lattices on more than one server so that you do not have a single point of
+failure.
+
 :::info
 
-🚧 Under construction 🚧
-
-This page is currently under construction and will be updated soon.
+The reason you need at least 3-5 servers in a cluster is because JetStream uses
+[RAFT](https://raft.github.io/) as a consensus algorithm for ensuring data
+consistency. This means that you need an odd number of servers that are part of
+your JetStream-enabled cluster for the algorithm to function as intended.
 
 :::
+
+### Clustering NATS
+
+A NATS cluster is a set of servers that are configured to communicate with one
+another and will gossip the existence of new members of the cluster. The
+following will show you how to configure three servers that are clustered
+together on three different hosts.
+
+The first server acts as the _seed_ for the cluster. The is nothing
+particularly special about a seed cluster other than the fact that it just
+starts the discovery process for other nodes.
+
+```text
+server_name: wasmcloud-0
+host: 0.0.0.0
+cluster {
+  name: wasmcloud
+}
+
+jetstream {
+  store_dir = /path/to/data/directory
+  # Use a domain suitable for your environment
+  domain    = wasmcloud
+}
+```
+
+Bring this server up with the following:
+
+```bash
+nats-server -c server-0.conf
+```
+
+Next, bring up two additional servers on different machines:
+
+```text
+server_name: wasmcloud-1
+host: 0.0.0.0
+cluster {
+  name: wasmcloud
+  routes: [
+    nats://wasmcloud-0.dns.or.ip
+  ]
+}
+
+jetstream {
+  store_dir = /path/to/data/directory
+  # Use a domain suitable for your environment
+  domain    = wasmcloud
+}
+```
+
+```text
+server_name: wasmcloud-2
+host: 0.0.0.0
+cluster {
+  name: wasmcloud
+  routes: [
+    nats://wasmcloud-0.dns.or.ip
+  ]
+}
+
+jetstream {
+  store_dir = /path/to/data/directory
+  # Use a domain suitable for your environment
+  domain    = wasmcloud
+}
+```
+
+:::info
+You can provide the same set of NATS routes in the cluster configuration block
+in every server configuration file. NATS is smart enough to disambiguate
+between duplicate routes.
+:::
+
+Start these two new servers and you should have a three node cluster!
+
+```bash
+nats-server -c server-1.conf
+nats-server -c server-2.conf
+```
+
+### Kubernetes
+
+If you are running Kubernetes in your environment, then we strongly recommend
+deploying NATS using the [official Helm
+charts](https://artifacthub.io/packages/helm/nats/nats).
+
+A sample `values.yaml` file that would work well for a simple wasmCloud
+deployment might look like the following:
+
+```yaml
+config:
+  cluster:
+    enabled: true
+    replicas: 3
+  jetstream:
+    enabled: true
+    domain: wasmcloud
+    # Decide on how large you need your volumes to be
+    fileStore:
+      pvc:
+        size: 10Gi
+
+podTemplate:
+  topologySpreadConstraints:
+    kubernetes.io/hostname:
+      maxSkew: 1
+      whenUnsatisfiable: DoNotSchedule
+```
+
+You can then start the cluster by running
+
+```bash
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+helm upgrade --install nats nats/nats -f sample.yaml
+```
+
+### JetStream
+
+Once you have a running cluster, you will want to ensure that the lattice data
+and wadm key-value buckets are replicated across more than one NATS server.
+This is to ensure that your wasmCloud cluster is resilient in the face of node
+or instance failures.
+
+A wasmCloud host and a wadm server will create their required buckets when they
+first start, as described
+[here](docs/deployment/lattice/metadata#default-configuration). We recommend
+you pre-create these buckets and ensure that they are properly configured.
+
+Assuming you are using the default lattice name (`default`):
+
+```bash
+nats --domain wasmcloud kv add --replicas 3 LATTICEDATA_default
+nats --domain wasmcloud kv add --replicas 3 wadm_manifests
+```
+
+If you have an existing lattice data bucket you can run the following to the
+increase the number of replicas:
+
+```bash
+nats --domain wasmcloud stream edit --replicas 3 KV_LATTICEDATA_default
+nats --domain wasmcloud stream edit --replicas 3 wadm_manifests
+```


### PR DESCRIPTION
Update the NATS server configuration page with an overview of how to deploy a production-grade NATS cluster.

There are some topics such as bootstrapping a NATS operator hierarchy or TLS support which are out of scope for now, but we should consider adding content for down the line.
