### PR TITLE
feat: added python quickstart

### DIFF
--- a/docs/developer/actors/build.mdx
+++ b/docs/developer/actors/build.mdx
@@ -51,6 +51,48 @@ rm ./build/embed.wasm ./build/module.wasm
 ```
 
     </TabItem>
+
+    <TabItem value="typescript" label="TypeScript">
+In a TypeScript project, the wash build command must be overridden in the [wasmcloud.toml](/docs/reference/config) actor section to use external tools. TypeScript builds require an [npm](https://github.com/npm/cli) installation and, after running `npm install`, use [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS/) to compile transpiled JavaScript code into a WebAssembly Component.
+
+```toml
+[actor]
+build_command = "npm run build"
+```
+
+In our quickstart example, `wash build` runs a few commands for you in order to turn TypeScript code into a WebAssembly component:
+
+```bash
+# You must run `npm install` first
+npm install
+# Transpile TypeScript code to JavaScript
+tsc
+# Componentize JavaScript code
+jco componentize -w wit -o dist/index.wasm dist/index.js
+# Sign the Wasm component with your generated keys, using information in wasmcloud.toml
+wash build --sign-only --config-path wasmcloud.toml
+```
+
+    </TabItem>
+
+    <TabItem value="python" label="Python">
+In a Python project, the wash build command must be overridden in the [wasmcloud.toml](/docs/reference/config) actor section to use external tools. Python builds require a [Python](https://www.python.org/), [pip](https://pip.pypa.io/en/stable/installation/) installation and a [componentize-py](https://github.com/bytecodealliance/componentize-py/) to compile Python code into a WebAssembly Component.
+
+```toml
+[actor]
+build_command = "componentize-py -d ./wit -w hello componentize app -o build/http_hello_world.wasm"
+```
+
+In our quickstart example, `wash build` runs a few commands for you in order to turn Python code into a WebAssembly component:
+
+```bash
+# Componentize Python code into a WebAssembly Component
+componentize-py -d ./wit -w hello componentize app -o build/http_hello_world.wasm
+# Sign the Wasm component with your generated keys, using information in wasmcloud.toml
+wash build --sign-only --config-path wasmcloud.toml
+```
+    </TabItem>
+
     <TabItem value="unlisted" label="My Language Isn't Listed">
 
 `wash build` has an escape hatch in the `wasmcloud.toml` specification which will let you specify your own build command for languages that we don't have official support for. For example, following the [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS/blob/main/EXAMPLE.md) example to build a JavaScript Component, you can set up your `wasmcloud.toml` file like so:

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -228,6 +228,63 @@ export const incomingHandler = {
 ```
 
   </TabItem>
+
+  <TabItem value="python" label="Python Component">
+
+:::caution
+Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
+:::
+
+:::info[Python & WebAssembly]
+To perform the steps in this guide, you'll need you'll need to install [Python 3.10](https://www.python.org/) or later, [pip](https://pip.pypa.io/en/stable/installation/), and `componentize-py` to compile Python code to WebAssembly.
+
+```shell
+pip install componentize-py==0.9.2
+```
+::: 
+
+Let's extend this application to do more than just say "hello." Using the `path_with_query` method on the incoming request, we can check the request for a name provided in a query string, and then return a greeting with that name. If there isn't one or the path isn't in the format we expect, we'll default to saying "hello world!". We'll also add a helper function to keep our code readable.
+
+:::info
+If you're using an IDE or would like to look at the imports, you can generate the bindings using `componentize-py` to get IDE suggestions and autofills.
+```shell
+componentize-py bindings .
+```
+:::
+
+```python
+class IncomingHandler(exports.IncomingHandler):
+#highlight-start
+    # Make sure to change the variable name for the request from _ to request in the handle function.
+    def handle(self, request: IncomingRequest, response_out: ResponseOutparam):
+#highlight-end
+        # Construct the HTTP response to send back 
+        outgoingResponse = OutgoingResponse(Fields.from_list([]))
+        # Set the status code to OK
+        outgoingResponse.set_status_code(200)
+        outgoingBody = outgoingResponse.body()
+
+        # Write our Hello message to the response body
+#highlight-start
+        name = get_name_from_path(request.path_with_query())
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello {}!\n".format(name), "utf-8"))
+#highlight-end
+        OutgoingBody.finish(outgoingBody, None)
+        # Set and send the HTTP response
+        ResponseOutparam.set(response_out, Ok(outgoingResponse))
+
+#highlight-start
+def get_name_from_path(path: str) -> str:
+    parts = path.split("=")
+    if len(parts) == 2:
+        return parts[-1]
+    else:
+        return "World"
+#highlight-end
+```
+
+  </TabItem>
+
 </Tabs>
 
 After changing the code, you can use `wash` to build the local actor:
@@ -261,7 +318,7 @@ Hello, Bob!
 ```bash
 > curl localhost:8081
 Hello, World!
-> curl localhost:8081/Bob
+> curl 'localhost:8081?name=Bob'
 Hello, Bob!
 ```
 
@@ -276,6 +333,15 @@ Hello, Bob!
 ```
   </TabItem>
   <TabItem value="typescript" label="TypeScript Component">
+
+```bash
+> curl localhost:8080
+Hello, World!
+> curl 'localhost:8080?name=Bob'
+Hello, Bob!
+```
+  </TabItem>
+  <TabItem value="python" label="Python Component">
 
 ```bash
 > curl localhost:8080
@@ -431,6 +497,8 @@ world hello {
 }
 ```
 
+Let's use the atomic increment function to keep track of how many times we've greeted each person.
+
 ```go
 func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWriter) {
 	// Construct HttpResponse to send back
@@ -471,6 +539,8 @@ world hello {
   export wasi:http/incoming-handler@0.2.0-rc-2023-12-05;
 }
 ```
+
+Let's use the atomic increment function to keep track of how many times we've greeted each person.
 
 ```typescript
 import {
@@ -523,6 +593,62 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
 }
 
 ```
+
+  </TabItem>
+
+    <TabItem value="python" label="Python Component">
+
+  In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
+```wit
+package wasmcloud:hello;
+
+world hello {
+  // highlight-start
+  import wasi:keyvalue/atomic;
+  import wasi:keyvalue/readwrite;
+  import wasi:logging/logging;
+  // highlight-end
+
+  export wasi:http/incoming-handler@0.2.0-rc-2023-12-05;
+}
+```
+
+Let's use the atomic increment function to keep track of how many times we've greeted each person.
+
+```python
+from hello import exports
+from hello.types import Ok
+from hello.imports.types import (
+    IncomingRequest, ResponseOutparam,
+#highlight-start
+    OutgoingResponse, Fields, OutgoingBody, open_bucket
+)
+from hello.imports.atomic import increment
+from hello.imports.logging import (log, Level)
+#highlight-end
+
+class IncomingHandler(exports.IncomingHandler):
+    def handle(self, request: IncomingRequest, response_out: ResponseOutparam):
+        # Construct the HTTP response to send back 
+        outgoingResponse = OutgoingResponse(Fields.from_list([]))
+        # Set the status code to OK
+        outgoingResponse.set_status_code(200)
+        outgoingBody = outgoingResponse.body()
+
+        # Write our Hello message to the response body
+        name = get_name_from_path(request.path_with_query())
+#highlight-start
+        log(Level.INFO, "", "Greeting {}".format(name))
+        bucket = open_bucket("")
+        count = increment(bucket, name, 1)
+
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello x{}, {}!\n".format(count, name), "utf-8"))
+#highlight-end
+        OutgoingBody.finish(outgoingBody, None)
+        # Set and send the HTTP response
+        ResponseOutparam.set(response_out, Ok(outgoingResponse))
+```
+
 
   </TabItem>
 </Tabs>
@@ -645,6 +771,19 @@ Hello x1, Alice!
 
   </TabItem>
   <TabItem value="typescript" label="TypeScript Component">
+
+```bash
+> wash app deploy wadm.yaml
+> curl localhost:8080?name=Bob
+Hello x1, Bob!
+> curl localhost:8080?name=Bob
+Hello x2, Bob!
+> curl localhost:8080?name=Alice
+Hello x1, Alice!
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python Component">
 
 ```bash
 > wash app deploy wadm.yaml

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -156,6 +156,31 @@ You don't need any TypeScript/JavaScript dependencies installed to run this exam
 :::
 
   </TabItem>
+  <TabItem value="Python" label="Python Component">
+
+:::caution
+Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
+:::
+
+This command generates a new actor project in the `./hello` directory:
+```shell
+wash new actor --git wasmcloud/wasmcloud --subfolder examples/python/actors/http-hello-world hello
+```
+
+This actor is a simple Python project with a few extra goodies included for wasmCloud. At a high level, the important pieces are:
+
+1. `app.py`: Where the business logic is implemented
+2. `wasmcloud.toml`: Actor metadata and capability permissions
+3. `wadm.yaml`: A declarative manifest for running the full application
+
+:::info[Dependencies]
+You don't need any Python dependencies installed to run this example, but if you want to build it yourself you'll need to install [Python 3.10 or later](https://www.python.org/) and [pip](https://pypi.org/project/pip/). After you have those, you'll need to install [componentize-py](https://github.com/bytecodealliance/componentize-py/tree/main?tab=readme-ov-file#getting-started):
+```
+pip install componentize-py==0.9.2
+```
+:::
+
+  </TabItem>
   <TabItem value="unlisted" label="My Language Isn't Listed">
 
   If you prefer working in a language that isn't listed here, let us know!
@@ -193,7 +218,7 @@ Then, replace the `image` property in `wadm.yaml` with the path to your actor. F
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: rust-http-hello-world
+  name: http-hello-world
   annotations:
     version: v0.0.1
     description: "HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
@@ -229,11 +254,17 @@ wash app deploy wadm.yaml
 
 ![wash app deploy diagram](../images/washappdeploy.png)
 
-`wadm` will take care of taking this manifest and scheduling the resources on the host that you launched earlier. You should see output in the host logs when your actor and capability start up, and then you can query it yourself:
+`wadm` will take care of taking this manifest and scheduling the resources on the host that you launched earlier. You should see output in the host logs when your actor and capability start up, which should happen after just a few seconds. After you see that the HTTP server set up the listener in the host logs, or once the application is `Deployed` when you check `wash app list`, you can query it yourself:
+```shell
+➜ wash app list
+
+Name             Latest Version   Deployed Version   Deploy Status   Description
+http-hello-world v0.0.1           v0.0.1                  Deployed   HTTP Hello World
+```
 
 ```shell
 $ curl localhost:8080
-Hello, world!
+Hello, World!
 ```
 
 Congratulations, you just ran a WebAssembly application in wasmCloud!
@@ -242,7 +273,7 @@ Congratulations, you just ran a WebAssembly application in wasmCloud!
 
 ![hello app architecture](../images/helloapp.png)
 
-When you send your HTTP request to `localhost:8080`, that request is received by the HTTP Server capability provider. The HTTP Server capability provider then forwards that request to the actor, which responds with the string "Hello, world!". This loose coupling of capability providers and actors provides flexibility, security, and it lets our actor code be purely business logic instead of compiling in vendor specific code. Let's take a look at that code now in `src/lib.rs`:
+When you send your HTTP request to `localhost:8080`, that request is received by the HTTP Server capability provider. The HTTP Server capability provider then forwards that request to the actor, which responds with the string "Hello, world!". This loose coupling of capability providers and actors provides flexibility, security, and it lets our actor code be purely business logic instead of compiling in vendor specific code. Let's take a look at your application code now:
 
 <Tabs groupId="lang" queryString>
   <TabItem value="rustmod" label="Rust" default>
@@ -382,6 +413,33 @@ export const incomingHandler = {
 ```
 
 This actor has a single function, `handle`, that implements the `incoming-handler` interface. This function is called by the HTTP Server capability provider when it receives an incoming HTTP request. The `handle` function constructs an `OutgoingResponse` and sends it back to the HTTP Server capability provider, which then sends it back to the client. There's no mention of ports, certificates, HTTP libraries, and if those things change this actor will work all the same.
+
+  </TabItem>
+
+  <TabItem value="Python" label="Python Component">
+    ```python
+from hello import exports
+from hello.types import Ok
+from hello.imports.types import (
+      IncomingRequest, ResponseOutparam,
+      OutgoingResponse, Fields, OutgoingBody
+)
+
+class IncomingHandler(exports.IncomingHandler):
+      def handle(self, _: IncomingRequest, response_out: ResponseOutparam):
+          # Construct the HTTP response to send back 
+          outgoingResponse = OutgoingResponse(Fields.from_list([]))
+          # Set the status code to OK
+          outgoingResponse.set_status_code(200)
+          outgoingBody = outgoingResponse.body()
+          # Write our Hello World message to the response body
+          outgoingBody.write().blocking_write_and_flush(bytes("Hello from Python!\n", "utf-8"))
+          OutgoingBody.finish(outgoingBody, None)
+          # Set and send the HTTP response
+          ResponseOutparam.set(response_out, Ok(outgoingResponse))
+    ```
+
+    This actor has a single class, `IncomingHandler`, that implements the `handle` function. This function is called by the HTTP Server capability provider when it receives an incoming HTTP request. The `handle` function constructs an HttpResponse and sends it back to the HTTP Server capability provider, which then sends it back to the client. There's no mention of ports, certificates, HTTP libraries, and if those things change this actor will work all the same.
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
- feat: added python quickstart
- chore: update build section with more languages

## Feature or Problem
This PR adds Python as a quickstart language for wasmCloud using componentize-py.

## Related Issues
Depends on https://github.com/wasmCloud/wasmCloud/pull/1399

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I ran through this tutorial on my end and it worked great 😄 
