### PR TITLE
chore(examples): pin examples to 0.81

### DIFF
--- a/docs/developer/actors/generate.mdx
+++ b/docs/developer/actors/generate.mdx
@@ -16,7 +16,7 @@ We provide example templates for creating [actors](/docs/concepts/actors) in Rus
 Creating the scaffold for a new actor in Rust is easy. We will create an actor that accepts an HTTP request and responds with "Hello World". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The last term on the command `hello` is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
 ```shell
-wash new actor --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world hello
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world --branch v0.81.0
 ```
 
 Let's change into the newly-created folder `hello` and take a look at the generated project. The file `src/lib.rs` includes a `wit-bindgen` generate macro, an imports section, a struct `HttpServer`, and an `impl` block that implements the `Guest` trait for the actor struct. Let's walk through these sections in detail.
@@ -67,7 +67,7 @@ Within the `handle` method, the actor receives the HTTP request, creates an `Out
   <TabItem value="tinygo" label="TinyGo">
 
 ```shell
-wash new actor --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world hello
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world --branch v0.81.0
 ```
 
 Let's change into the newly-created folder `hello` and take a look at the generated project. The file `hello.go` will include imports, a `main` function, a `Hello` struct, and an HTTP handler. Let's walk through these pieces in depth.

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -12,35 +12,7 @@ Going from "Hello World" to a full-fledged application requires just identifying
 ## Adding Functionality
 
 <Tabs groupId="lang" queryString>
-  <TabItem value="rustmod" label="Rust" default>
-:::info[Rust & WebAssembly]
-To perform the steps in this guide, you'll need to have a [Rust toolchain](https://www.rust-lang.org/tools/install) installed locally and the wasm32 target installed:
-
-```shell
-rustup target add wasm32-wasi
-```
-
-:::
-
-Let's extend this application to do more than just say "Hello World". We can use the `HttpRequest` struct and check the request for a name provided in a query string, and then return a greeting with that name.
-
-```rust
-async fn handle_request(&self, ctx: &Context, req: &HttpRequest) -> RpcResult<HttpResponse> {
-    let name = match req.query_string.split("=").collect::<Vec<&str>>()[..] {
-        // query string is "name=<name>" e.g. localhost:8080?name=Bob
-        ["name", name] => name.to_string(),
-        // query string is anything else or empty e.g. localhost:8080
-        _ => "World".to_string(),
-    };
-
-    Ok(HttpResponse::ok(format!("Hello, {}!", name,)))
-}
-```
-
-Using a simple pattern match, we can check to see if we can split the query string on a name parameter, and if so, use that name in the response. If not, we'll just use "World" as the name. This won't support adding multiple query parameters but it's a perfectly good start for our goals. 
-
-  </TabItem>
-  <TabItem value="rust" label="Rust Component">
+  <TabItem value="rust" label="Rust">
 
 :::caution
 Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
@@ -99,7 +71,7 @@ impl Guest for HttpServer {
 ```
 
   </TabItem>
-  <TabItem value="tinygo" label="TinyGo Component">
+  <TabItem value="tinygo" label="TinyGo">
 :::caution
 Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
 :::
@@ -166,7 +138,7 @@ func main() {}
 ```
 
   </TabItem>
-  <TabItem value="typescript" label="TypeScript Component">
+  <TabItem value="typescript" label="TypeScript">
 :::caution
 Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
 :::
@@ -229,7 +201,7 @@ export const incomingHandler = {
 
   </TabItem>
 
-  <TabItem value="python" label="Python Component">
+  <TabItem value="python" label="Python">
 
 :::caution
 Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
@@ -304,16 +276,7 @@ Whenever you make a change to your actor that you want to deploy, be sure to run
 :::
 
 <Tabs groupId="lang" queryString>
-  <TabItem value="rustmod" label="Rust" default>
-
-```bash
-> curl localhost:8080
-Hello, World!
-> curl 'localhost:8080?name=Bob'
-Hello, Bob!
-```
-  </TabItem>
-  <TabItem value="rust" label="Rust Component">
+  <TabItem value="rust" label="Rust">
 
 ```bash
 > curl localhost:8081
@@ -323,7 +286,7 @@ Hello, Bob!
 ```
 
   </TabItem>
-  <TabItem value="tinygo" label="TinyGo Component">
+  <TabItem value="tinygo" label="TinyGo">
 
 ```bash
 > curl localhost:8080
@@ -332,7 +295,7 @@ Hello, World!
 Hello, Bob!
 ```
   </TabItem>
-  <TabItem value="typescript" label="TypeScript Component">
+  <TabItem value="typescript" label="TypeScript">
 
 ```bash
 > curl localhost:8080
@@ -341,7 +304,7 @@ Hello, World!
 Hello, Bob!
 ```
   </TabItem>
-  <TabItem value="python" label="Python Component">
+  <TabItem value="python" label="Python">
 
 ```bash
 > curl localhost:8080
@@ -365,71 +328,7 @@ claims = ["wasmcloud:httpserver", "wasmcloud:keyvalue", "wasmcloud:builtin:loggi
 ```
 
 <Tabs groupId="lang" queryString>
-  <TabItem value="rustmod" label="Rust" default>
-
-```bash
-# Add the key-value interface to your Cargo project
-cargo add wasmcloud-interface-keyvalue
-```
-
-Now we can make use of the key-value capability. Add a few imports at the top of your file:
-
-```rust
-use wasmcloud_interface_keyvalue::{KeyValue, KeyValueSender, SetAddRequest};
-```
-
-Then, add this line after you parse the name from the query string:
-
-```rust
-async fn handle_request(&self, ctx: &Context, req: &HttpRequest) -> RpcResult<HttpResponse> {
-    let name = match req.query_string.split("=").collect::<Vec<&str>>()[..] {
-        ["name", name] => {
-            KeyValueSender::new()
-                .set_add(
-                    ctx,
-                    &SetAddRequest {
-                        set_name: "names".to_string(),
-                        value: name.to_string(),
-                    },
-                )
-                .await?;
-            name.to_string()
-        }
-        _ => "World".to_string(),
-    };
-}
-```
-
-The modified code will now, whenever a name is provided, add it to the set of greeted names in our key-value store. We still need a way to retrieve the names, so let's add another arm to our match statement to check if the query string is just `names`, and return each name:
-
-```rust
-    async fn handle_request(&self, ctx: &Context, req: &HttpRequest) -> RpcResult<HttpResponse> {
-        let name = match req.query_string.split("=").collect::<Vec<&str>>()[..] {
-            ["name", name] => {
-                KeyValueSender::new()
-                    .set_add(
-                        ctx,
-                        &SetAddRequest {
-                            set_name: "names".to_string(),
-                            value: name.to_string(),
-                        },
-                    )
-                    .await?;
-                name.to_string()
-            }
-            ["names"] => KeyValueSender::new()
-                .set_query(ctx, "names")
-                .await?
-                .join(", "),
-            _ => "World".to_string(),
-        };
-
-        Ok(HttpResponse::ok(format!("Hello, {}!", name,)))
-    }
-```
-
-  </TabItem>
-  <TabItem value="rust" label="Rust Component">
+  <TabItem value="rust" label="Rust">
 
   In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
 ```wit
@@ -480,7 +379,7 @@ Let's use the atomic increment function to keep track of how many times we've gr
   ```
 
   </TabItem>
-  <TabItem value="tinygo" label="TinyGo Component">
+  <TabItem value="tinygo" label="TinyGo">
 
   In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
 ```wit
@@ -523,7 +422,7 @@ func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWrite
 ```
 
   </TabItem>
-  <TabItem value="typescript" label="TypeScript Component">
+  <TabItem value="typescript" label="TypeScript">
 
   In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
 ```wit
@@ -596,7 +495,7 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
 
   </TabItem>
 
-    <TabItem value="python" label="Python Component">
+    <TabItem value="python" label="Python">
 
   In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
 ```wit
@@ -731,20 +630,7 @@ spec:
 For the last step, we can deploy the `v0.0.3` version of our application. Then, again, we can test our new functionality.
 
 <Tabs groupId="lang" queryString>
-  <TabItem value="rustmod" label="Rust" default>
-
-```bash
-> wash app deploy wadm.yaml
-> curl localhost:8080?name=Bob
-Hello, Bob!
-> curl localhost:8080?name=Alice
-Hello, Alice!
-> curl localhost:8080?names
-Hello, Bob, Alice!
-```
-
-  </TabItem>
-  <TabItem value="rust" label="Rust Component">
+  <TabItem value="rust" label="Rust">
 
 ```bash
 > wash app deploy wadm.yaml
@@ -757,7 +643,7 @@ Hello x1, Alice!
 ```
 
   </TabItem>
-  <TabItem value="tinygo" label="TinyGo Component">
+  <TabItem value="tinygo" label="TinyGo">
 
 ```bash
 > wash app deploy wadm.yaml
@@ -770,7 +656,7 @@ Hello x1, Alice!
 ```
 
   </TabItem>
-  <TabItem value="typescript" label="TypeScript Component">
+  <TabItem value="typescript" label="TypeScript">
 
 ```bash
 > wash app deploy wadm.yaml
@@ -783,7 +669,7 @@ Hello x1, Alice!
 ```
 
   </TabItem>
-  <TabItem value="python" label="Python Component">
+  <TabItem value="python" label="Python">
 
 ```bash
 > wash app deploy wadm.yaml

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -94,7 +94,7 @@ rustup target add wasm32-wasi
 
 This command generates a new actor project in the `./hello` directory:
 ```shell
-wash new actor --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world hello
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world --branch v0.81.0
 ```
 
 This actor is a simple Rust project with a few extra goodies included for wasmCloud. At a high level, the important pieces are:
@@ -120,7 +120,7 @@ rustup target add wasm32-wasi
 
 This command generates a new actor project in the `./hello` directory:
 ```shell
-wash new actor --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world hello
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world  --branch v0.81.0
 ```
 
 This actor is a simple Go project with a few extra goodies included for wasmCloud. At a high level, the important pieces are:
@@ -142,7 +142,7 @@ Component examples are experimental and likely to require recompilation with eac
 
 This command generates a new actor project in the `./hello` directory:
 ```shell
-wash new actor --git wasmcloud/wasmcloud --subfolder examples/typescript/actors/http-hello-world hello
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/typescript/actors/http-hello-world  --branch v0.81.0
 ```
 
 This actor is a simple TypeScript project with a few extra goodies included for wasmCloud. At a high level, the important pieces are:
@@ -164,7 +164,7 @@ Component examples are experimental and likely to require recompilation with eac
 
 This command generates a new actor project in the `./hello` directory:
 ```shell
-wash new actor --git wasmcloud/wasmcloud --subfolder examples/python/actors/http-hello-world hello
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/python/actors/http-hello-world --branch v0.81.0
 ```
 
 This actor is a simple Python project with a few extra goodies included for wasmCloud. At a high level, the important pieces are:

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -65,29 +65,7 @@ Pick your language of choice below to follow
 
 
 <Tabs groupId="lang" queryString>
-  <TabItem value="rustmod" label="Rust" default>
-
-This command generates a new actor project in the `./hello` directory:
-```shell
-wash new actor -t hello hello
-```
-
-This actor is a simple Rust project with a few extra goodies included for wasmCloud. At a high level, the important pieces are:
-
-1. `src/lib.rs`: Where the business logic is implemented
-2. `wasmcloud.toml`: Actor metadata and capability permissions
-3. `wadm.yaml`: A declarative manifest for running the full application
-
-:::info[Rust dependencies]
-You don't need any Rust dependencies installed to run this example, but if you want to build it yourself you'll need to install the [Rust toolchain](https://www.rust-lang.org/tools/install) and the `wasm32-wasi` target.
-
-```shell
-rustup target add wasm32-wasi
-```
-:::
-
-  </TabItem>
-  <TabItem value="rust" label="Rust Component" default>
+  <TabItem value="rust" label="Rust" default>
   :::caution
   Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
   :::
@@ -112,7 +90,7 @@ rustup target add wasm32-wasi
 :::
 
   </TabItem>
-  <TabItem value="tinygo" label="TinyGo Component">
+  <TabItem value="tinygo" label="TinyGo">
 
   :::caution
   Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
@@ -134,7 +112,7 @@ You don't need any Go dependencies installed to run this example, but if you wan
 :::
 
   </TabItem>
-  <TabItem value="typescript" label="TypeScript Component">
+  <TabItem value="typescript" label="TypeScript">
 
 :::caution
 Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
@@ -156,7 +134,7 @@ You don't need any TypeScript/JavaScript dependencies installed to run this exam
 :::
 
   </TabItem>
-  <TabItem value="Python" label="Python Component">
+  <TabItem value="Python" label="Python">
 
 :::caution
 Component examples are experimental and likely to require recompilation with each new release of wasmCloud.
@@ -276,29 +254,7 @@ Congratulations, you just ran a WebAssembly application in wasmCloud!
 When you send your HTTP request to `localhost:8080`, that request is received by the HTTP Server capability provider. The HTTP Server capability provider then forwards that request to the actor, which responds with the string "Hello, world!". This loose coupling of capability providers and actors provides flexibility, security, and it lets our actor code be purely business logic instead of compiling in vendor specific code. Let's take a look at your application code now:
 
 <Tabs groupId="lang" queryString>
-  <TabItem value="rustmod" label="Rust" default>
-
-```rust
-use wasmbus_rpc::actor::prelude::*;
-use wasmcloud_interface_httpserver::{HttpRequest, HttpResponse, HttpServer, HttpServerReceiver};
-
-#[derive(Debug, Default, Actor, HealthResponder)]
-#[services(Actor, HttpServer)]
-struct HelloActor {}
-
-/// Implementation of the HttpServer capability contract
-#[async_trait]
-impl HttpServer for HelloActor {
-    async fn handle_request(&self, _ctx: &Context, _req: &HttpRequest) -> RpcResult<HttpResponse> {
-        Ok(HttpResponse::ok("Hello, World!"))
-    }
-}
-```
-
-This actor is set up to receive requests from the HttpServer capability, with a single function handle_request that matches what the capability provider expects. All you need to worry about as an applicaiton developer is what functional logic you want to apply when you receive an HttpRequest, and what HttpResponse you want to return. There's no mention of ports, certificates, HTTP libraries, and if those things change this actor will work all the same.
-
-  </TabItem>
-  <TabItem value="rust" label="Rust Component">
+  <TabItem value="rust" label="Rust">
 
 ```rust
 wit_bindgen::generate!({
@@ -416,7 +372,7 @@ This actor has a single function, `handle`, that implements the `incoming-handle
 
   </TabItem>
 
-  <TabItem value="Python" label="Python Component">
+  <TabItem value="Python" label="Python">
     ```python
 from hello import exports
 from hello.types import Ok


### PR DESCRIPTION
## Feature or Problem
This PR both pins our examples to the `0.81` branch to avoid breaking them as we update to WASI preview 2 examples and removes the generation of a wasmbus module from the Rust options, allowing us to drop the `Component` suffix on each of our tabs.

## Related Issues
Incoming issue that will suggest we update our project favorites to point to wasmcloud/wasmcloud 😄 https://github.com/wasmCloud/wasmCloud/issues/1500

## Release Information
asap 

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I verified that using a tag for the `--branch` argument works as expected, and that reordering the name to be first doesn't affect project generation
