### PR TITLE
docs: add TypeScript and Python to the Create page

### DIFF
--- a/docs/developer/actors/generate.mdx
+++ b/docs/developer/actors/generate.mdx
@@ -13,7 +13,7 @@ We provide example templates for creating [actors](/docs/concepts/actors) in Rus
 
 <Tabs groupId="lang" queryString>
   <TabItem value="rust" label="Rust" default>
-Creating the scaffold for a new actor in Rust is easy. We will create an actor that accepts an HTTP request and responds with "Hello World". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The last term on the command `hello` is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
+Creating the scaffold for a new actor in Rust is easy. We will create an actor that accepts an HTTP request and responds with "Hello from Rust!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
 ```shell
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world --branch v0.81.0
@@ -65,6 +65,7 @@ Within the `handle` method, the actor receives the HTTP request, creates an `Out
 
   </TabItem>
   <TabItem value="tinygo" label="TinyGo">
+Creating the scaffold for a new actor in TinyGo is easy. We will create an actor that accepts an HTTP request and responds with "Hello from Go!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
 ```shell
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world --branch v0.81.0
@@ -123,6 +124,101 @@ func main() {}
 
 Lastly, this Go directive will ensure that when we build our project with `tinygo build`, the `wit-bindgen` tool will be run to generate the types and bindings for our actor. 
 
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+Creating the scaffold for a new actor in TypeScript is easy. We will create an actor that accepts an HTTP request and responds with "Hello from TypeScript!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
+
+```shell
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/typescript/actors/http-hello-world --branch v0.81.0
+```
+
+Let's change into the newly-created folder `hello` and take a look at the generated project. The file `index.ts` will include imports and a `handle` function exported under `incomingHandler`. Let's walk through these pieces in depth.
+
+```typescript
+import {
+  IncomingRequest,
+  ResponseOutparam,
+  OutgoingResponse,
+  Fields,
+} from "wasi:http/types@0.2.0-rc-2023-12-05";
+```
+
+The import section of this file is simple, we just import our generated types (from `jco`) for the WASI HTTP interface.
+
+```typescript
+// Implementation of wasi-http incoming-handler
+//
+// NOTE: To understand the types involved, take a look at wit/deps/http/types.wit
+function handle(req: IncomingRequest, resp: ResponseOutparam) {
+  // Start building an outgoing response
+  const outgoingResponse = new OutgoingResponse(new Fields());
+
+  // Access the outgoing response body
+  let outgoingBody = outgoingResponse.body();
+  // Create a stream for the response body
+  let outputStream = outgoingBody.write();
+  // // Write hello world to the response stream
+  outputStream.blockingWriteAndFlush(
+    new Uint8Array(new TextEncoder().encode("hello from Typescript"))
+  );
+
+  // Set the status code for the response
+  outgoingResponse.setStatusCode(200);
+
+  // Set the created response
+  ResponseOutparam.set(resp, { tag: "ok", val: outgoingResponse });
+}
+```
+
+The business logic of our actor is contained within the `handle` function. Within the `handle` function, the actor receives the HTTP request, creates an `OutgoingResponse` and writes that response back out to the requesting HTTP client (such as a `curl` command or a web browser).
+
+```typescript
+export const incomingHandler = {
+  handle,
+};
+```
+
+Lastly, this export statement includes the `handle` function under the `incomingHandler` interface, which matches the `wasi:http/incoming-handler` interface declared in the application's [wit file](https://github.com/wasmCloud/wasmCloud/blob/main/examples/typescript/actors/http-hello-world/wit/index.wit).
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+Creating the scaffold for a new actor in Python is easy. We will create an actor that accepts an HTTP request and responds with "Hello from Python!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
+
+```shell
+wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/python/actors/http-hello-world --branch v0.81.0
+```
+
+Let's change into the newly-created folder `hello` and take a look at the generated project. The file `app.py` will include imports and a `handle` function on a `IncomingHandler` class. Let's walk through these pieces in depth.
+
+```python
+from hello import exports
+from hello.types import Ok
+from hello.imports.types import (
+    IncomingRequest, ResponseOutparam,
+    OutgoingResponse, Fields, OutgoingBody
+)
+```
+
+The import section of this file is simple, we just import our generated types (from `componentize-py`) for the WASI HTTP interface.
+
+```python
+class IncomingHandler(exports.IncomingHandler):
+    def handle(self, _: IncomingRequest, response_out: ResponseOutparam):
+        # Construct the HTTP response to send back 
+        outgoingResponse = OutgoingResponse(Fields.from_list([]))
+        # Set the status code to OK
+        outgoingResponse.set_status_code(200)
+        outgoingBody = outgoingResponse.body()
+        # Write our Hello World message to the response body
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello from Python!\n", "utf-8"))
+        OutgoingBody.finish(outgoingBody, None)
+        # Set and send the HTTP response
+        ResponseOutparam.set(response_out, Ok(outgoingResponse))
+```
+
+The business logic of our actor is contained within the `handle` method. Within the `handle` method, the actor receives the HTTP request, creates an `OutgoingResponse` and writes that response back out to the requesting HTTP client (such as a `curl` command or a web browser).
+
+This method is defined on the `IncomingHandler` class, which matches the `wasi:http/incoming-handler` interface declared in the application's [wit file](https://github.com/wasmCloud/wasmCloud/blob/main/examples/python/actors/http-hello-world/wit/world.wit).
   </TabItem>
   <TabItem value="unlisted" label="My Language Isn't Listed">
 


### PR DESCRIPTION
This adds TypeScript and Python to the [Create](https://wasmcloud.com/docs/developer/actors/generate) page in the Developer Guide