### PR TITLE
Align Langauge Support with available PrismJS languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Repository for the wasmCloud homepage including our community, team, docs, links
 
 ## Running the site locally
 
-```console
+```bash
 npm ci
 npm run start
 ```
@@ -15,7 +15,7 @@ This command starts a local development server and opens up a browser window. Mo
 
 ### Build
 
-```console
+```bash
 npm run build
 ```
 
@@ -25,6 +25,6 @@ This command generates static content into the `build` directory and can be serv
 
 To serve the generated static content:
 
-```console
+```bash
 npm run serve
 ```

--- a/blog/2022-05-23_ghcr-actions.md
+++ b/blog/2022-05-23_ghcr-actions.md
@@ -1,12 +1,12 @@
 ---
 slug: 2022-05-23_ghcr-actions
-title: "Deploying wasmCloud Actors from Github Packages"
-image: "/img/ghcr-actions/github-packages.png"
+title: 'Deploying wasmCloud Actors from Github Packages'
+image: '/img/ghcr-actions/github-packages.png'
 date: 2022-05-23T9:00:00-04:00
-author: "Brooks Townsend"
-author_profile: "https://linkedin.com/in/brooks-townsend"
-description: "Simplifying the deployment experience for WebAssembly modules."
-categories: ["webassembly", "wasmcloud", "developer experience"]
+author: 'Brooks Townsend'
+author_profile: 'https://linkedin.com/in/brooks-townsend'
+description: 'Simplifying the deployment experience for WebAssembly modules.'
+categories: ['webassembly', 'wasmcloud', 'developer experience']
 draft: false
 ---
 
@@ -50,7 +50,7 @@ wash claims inspect build/hello_s.wasm
 
 Your output should be something like this, just with different `Account` and `Module` keys
 
-```plain
+```
                               Hello - Module
   Account       ABYFZKXEHQWJIMBKVAVG3Y5LGEBT3MQXRYVTQBF7RVHUIG62LUK3N5EQ
   Module        MAMP52XKSBHNDMWK4OR4BZVBDQNNZQ5FXDXUAX7KIT7KNOKK2N3CCLZ2
@@ -82,7 +82,7 @@ wash reg push ghcr.io/$WASH_REG_USER/hello:0.1.0 build/hello_s.wasm
 
 You should see output like the following:
 
-```plain
+```
 wash reg push ghcr.io/$WASH_REG_USER/hello:0.1.0 build/hello_s.wasm
 
 🚿 Successfully validated and pushed to ghcr.io/brooksmtownsend/hello:0.1.0

--- a/blog/auto-update-oci-urls-wasmcloud-webhooks.md
+++ b/blog/auto-update-oci-urls-wasmcloud-webhooks.md
@@ -1,9 +1,9 @@
 ---
-title: "Automatically Updating OCI URLs with wasmCloud and Azure Webhooks"
+title: 'Automatically Updating OCI URLs with wasmCloud and Azure Webhooks'
 date: 2023-07-20T9:00:00-05:00
-image: "/img/webhookwasmcloud.png"
-author: "Brooks Townsend"
-tags: ["wasmcloud", "developer", "wasm", "cloud", "Azure"]
+image: '/img/webhookwasmcloud.png'
+author: 'Brooks Townsend'
+tags: ['wasmcloud', 'developer', 'wasm', 'cloud', 'Azure']
 ---
 
 ![Azure webhook and wasmcloud logo](/img/webhookwasmcloud.png)
@@ -66,7 +66,7 @@ The full, completed, source code for this example can be found in the GitHub rep
 
 I started using the wasmCloud "hello world" template, since it scaffolds out a basic HTTP server handler. If you're following along with this blog, make sure you have [wash](https://wasmcloud.com/docs/installation) installed.
 
-```shell
+```bash
 wash new actor webhook-handler --template-name hello
 ```
 
@@ -97,7 +97,7 @@ The neat part is that, here, I don't have to worry about what libraries or datab
 
 We can use `cargo add` to add the interfaces for `keyvalue` and `logging`, and then ensure that this actor has the capability claim to use these interfaces. While we're at it, we're also going to need some deserialization logic for the payload later, so we can add the `serde` and `serde_json` libraries now as well.
 
-```shell
+```bash
 cargo add wasmcloud-interface-keyvalue wasmcloud-interface-logging
 cargo add serde serde_json
 ```

--- a/blog/better-together-building-efficient-microservices-in-kubernetes-with-webassembly.md
+++ b/blog/better-together-building-efficient-microservices-in-kubernetes-with-webassembly.md
@@ -1,10 +1,10 @@
 ---
-title: "Better Together: Building Efficient Microservices in Kubernetes using WebAssembly"
-image: "images/blogs/adobe-kubernetes/header.png"
+title: 'Better Together: Building Efficient Microservices in Kubernetes using WebAssembly'
+image: 'images/blogs/adobe-kubernetes/header.png'
 date: 2022-11-17T11:00:00-05:00
-author: "Sean Isom and Colin Murphy, Adobe"
-description: "Bringing two major CNCF projects together – wasmCloud and Kubernetes – promises greater agility and major efficiencies"
-categories: ["webassembly", "wasmcloud", "kubernetes", "Cloud Native", "CNCF"]
+author: 'Sean Isom and Colin Murphy, Adobe'
+description: 'Bringing two major CNCF projects together – wasmCloud and Kubernetes – promises greater agility and major efficiencies'
+categories: ['webassembly', 'wasmcloud', 'kubernetes', 'Cloud Native', 'CNCF']
 draft: false
 ---
 
@@ -63,18 +63,18 @@ Normally, you can follow the single step in the documentation for installing was
 wasmcloud:
   enableApplierSupport: true
   customLabels:
-    wasmcloud.dev/route-to: "true"
+    wasmcloud.dev/route-to: 'true'
 ```
 
 Then you can deploy via helm (with your choice of RELEASE_NAME)
 
-```shell
+```bash
 helm install <RELEASE_NAME> wasmcloud/wasmcloud-host -f values.yaml
 ```
 
 Finally, to verify the install, you can grab the name of the deployment:
 
-```shell
+```bash
 $ kubectl get deployments
 NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
 wasmcloud-test-wasmcloud-host   1/1     1            1           4m32s
@@ -82,7 +82,7 @@ wasmcloud-test-wasmcloud-host   1/1     1            1           4m32s
 
 And then forward port 4000 to localhost:
 
-```shell
+```bash
 $ kubectl port-forward deployment/wasmcloud-test-wasmcloud-host 4000
 Forwarding from 127.0.0.1:4000 -> 4000
 Forwarding from [::1]:4000 -> 4000
@@ -99,13 +99,14 @@ We’re also using a handy wasmCloud Actor written by Taylor Thomas at Cosmonic,
 
 Let’s set up the example `echo` actor to get things running. We’ll need to create several providers and actors, then wire them up with link definitions. First start the actors and providers [with the current latest versions](https://github.com/wasmCloud/capability-providers#first-party-capability-providers):
 
-```shell
+```bash
 wash start provider wasmcloud.azurecr.io/applier:0.3.0
 wash start provider wasmcloud.azurecr.io/nats_messaging:0.17.0
 wash start provider wasmcloud.azurecr.io/httpserver:0.17.0
 wash start actor wasmcloud.azurecr.io/service_applier:0.3.0
 wash start actor wasmcloud.azurecr.io/echo:0.3.8
 ```
+
 :::info
 Previous guides used `wash ctl start`, which is now deprecated and will be removed in a future version.
 See [the wash command refactoring RFC](https://github.com/wasmCloud/wash/issues/538) for more information and to provide feedback
@@ -125,7 +126,7 @@ Finally, link the Echo actor to the httpserver actor, using the Contract ID (`wa
 
 Note that this (and the previous commands) could also be done via wash:
 
-```shell
+```bash
 $ wash ctl link put MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver 'ADDRESS=0.0.0.0:8080'
 ⡃⠀ Defining link between MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 and VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M ...
 Published link (MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5) <-> (VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M) successfully
@@ -133,7 +134,7 @@ Published link (MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5) <-> (V
 
 This link will create a Kubernetes service automatically on port 8080:
 
-```shell
+```bash
 $ kubectl get svc
 NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S) AGE
 mbcfopm6jw2apjlxjd3z5o4cn7cpyj2b4ftkljur5yr5mitiu7hd3wd5 ClusterIP 10.96.170.75 <none> 8080/TCP 10s
@@ -141,7 +142,7 @@ mbcfopm6jw2apjlxjd3z5o4cn7cpyj2b4ftkljur5yr5mitiu7hd3wd5 ClusterIP 10.96.170.75 
 
 Finally, to test that it is all working, forward port 8080 from the new service, and you can hit localhost:8080 to see your wasmCloud actor in action!
 
-```shell
+```bash
 $ kubectl port-forward svc/mbcfopm6jw2apjlxjd3z5o4cn7cpyj2b4ftkljur5yr5mitiu7hd3wd5 8080
 Forwarding from 127.0.0.1:8080 -> 8080
 Forwarding from [::1]:8080 -> 8080

--- a/blog/bring-your-own-wasm-components/index.mdx
+++ b/blog/bring-your-own-wasm-components/index.mdx
@@ -29,7 +29,7 @@ You'll need to [install wasmCloud](https://wasmcloud.com/docs/installation), [Py
 
 Once `pip` is in place, you'll also need to install `componentize-py`:
 
-```shell
+```bash
 pip install componentize-py==0.9.2
 ```
 
@@ -105,7 +105,7 @@ If you're familiar with wasmCloud, this should all look perfectly standard: we'r
 
 Now let's build our Wasm artifact:
 
-```shell
+```bash
 wash build -o json
 ```
 
@@ -113,13 +113,13 @@ Replace the value of the `image` field for the `python-http` actor with the file
 
 If you haven't already, run `wash up` to start a wasmCloud host. Then, from `examples/http`, run:
 
-```shell
+```bash
 wash app deploy wadm.yaml
 ```
 
 When `wash app list` reports that the deployment is ready, you can `curl` the component for a response. Per the readme for this example, we'll send over a couple of stanzas of poetry:
 
-```shell
+```bash
 curl -i -H 'content-type: text/plain' --data-binary @- http://localhost:8080/echo <<EOF
 ’Twas brillig, and the slithy toves
       Did gyre and gimble in the wabe:
@@ -139,7 +139,7 @@ All mimsy were the borogoves,
 
 Success! We get our bit of **Alice in Wonderland** back, and now we're down the rabbit hole. When we're done, we'll clean up:
 
-```shell
+```bash
 wash app undeploy python
 wash app delete python --delete-all
 ```

--- a/blog/example_creating_webassembly_actor_in_go_with_tinygo.md
+++ b/blog/example_creating_webassembly_actor_in_go_with_tinygo.md
@@ -1,11 +1,11 @@
 ---
-title: "Building Portable, Scalable Components with TinyGo and wasmCloud"
-image: "/img/tinygo-logo.png"
+title: 'Building Portable, Scalable Components with TinyGo and wasmCloud'
+image: '/img/tinygo-logo.png'
 date: 2022-06-01T9:00:00-04:00
-author: "Kevin Hoffman"
-author_profile: "https://www.linkedin.com/in/%F0%9F%A6%80-kevin-hoffman-9252669/"
-description: "A walkthrough of creating a TinyGo wasmCloud actor"
-categories: ["tinygo", "webassembly", "wasmcloud", "go", "example"]
+author: 'Kevin Hoffman'
+author_profile: 'https://www.linkedin.com/in/%F0%9F%A6%80-kevin-hoffman-9252669/'
+description: 'A walkthrough of creating a TinyGo wasmCloud actor'
+categories: ['tinygo', 'webassembly', 'wasmcloud', 'go', 'example']
 draft: false
 ---
 
@@ -23,8 +23,8 @@ To get started, you'll need <u>[wash](https://github.com/wasmcloud/wash)</u> ver
 
 Let's create a new empty actor from a template as follows:
 
-```terminal
- $ wash new actor
+```bash
+$ wash new actor
 ? Select a project template: ›
   hello: a hello-world actor (in Rust) that responds over an http connection
 ❯ echo-tinygo: a hello-world actor (in TinyGo) that responds over an http connection
@@ -69,7 +69,7 @@ What we're going to do for this blog post is modify this web request handler so 
 
 First, let's add another provider interface to our imports by first running `go get`
 
-```terminal
+```bash
 go get github.com/wasmcloud/interfaces/keyvalue/tinygo
 ```
 
@@ -130,7 +130,7 @@ This is something that we have to watch out for in TinyGo. If we use the stock J
 
 To get the preceding output, I typically run the following command (though use could also use `wasm-objdump`, too):
 
-```terminal
+```bash
 wasm2wat build/kvcounter_s.wasm| grep import
 ```
 

--- a/blog/globally_distributed_webassembly_applications_with_wasmcloud_and_nats.md
+++ b/blog/globally_distributed_webassembly_applications_with_wasmcloud_and_nats.md
@@ -1,11 +1,11 @@
 ---
-title: "Globally Distributed WebAssembly Applications with wasmCloud and NATS"
-image: "/img/ngs-global.png"
+title: 'Globally Distributed WebAssembly Applications with wasmCloud and NATS'
+image: '/img/ngs-global.png'
 date: 2022-10-18T9:00:00-04:00
-author: "Brooks Townsend"
-author_profile: "https://linkedin.com/in/brooks-townsend"
-description: "Taking a wasmCloud lattice from local to globally distributed with NATS and NGS"
-categories: ["webassembly", "wasmcloud", "nats", "distributed", "lattice"]
+author: 'Brooks Townsend'
+author_profile: 'https://linkedin.com/in/brooks-townsend'
+description: 'Taking a wasmCloud lattice from local to globally distributed with NATS and NGS'
+categories: ['webassembly', 'wasmcloud', 'nats', 'distributed', 'lattice']
 draft: false
 ---
 
@@ -132,7 +132,7 @@ wash up --nats-remote-url tls://connect.ngs.global --nats-credsfile ~/.nkeys/cre
 
 You should see output like the following:
 
-```plain
+```
 🏃 Running in interactive mode, your host is running at http://localhost:4000
 🚪 Press `CTRL+c` at any time to exit
 11:37:41.559 [info] Wrote "./host_config.json"
@@ -175,6 +175,7 @@ wash link put MCUCZ7KMLQBRRWAREIBQKTJ64MMQ5YKEGTCRGPPV47N4R72W2SU3EYMU VCCVLH4XW
 wash start provider wasmcloud.azurecr.io/httpserver:0.17.0
 wash start provider wasmcloud.azurecr.io/httpclient:0.7.0
 ```
+
 :::info
 Previous guides used `wash ctl start`, which is now deprecated and will be removed in a future version.
 See [the wash command refactoring RFC](https://github.com/wasmCloud/wash/issues/538) for more information and to provide feedback
@@ -206,7 +207,7 @@ HOST_machine=second wash up --nats-remote-url tls://connect.ngs.global --nats-cr
 
 You should see a similar dump of logs, but notably you should see that you are connecting to a stream with one consumer (your local machine)
 
-```plain
+```
 16:06:22.896 [info] Lattice cache stream created or verified as existing (1 consumers).
 ```
 

--- a/blog/webassembly_components_and_wasmcloud_actors_a_glimpse_of_the_future.md
+++ b/blog/webassembly_components_and_wasmcloud_actors_a_glimpse_of_the_future.md
@@ -1,11 +1,11 @@
 ---
-title: "WebAssembly Components and wasmCloud Actors: A Glimpse of the Future"
-image: "/img/wasm.png"
+title: 'WebAssembly Components and wasmCloud Actors: A Glimpse of the Future'
+image: '/img/wasm.png'
 date: 2022-06-16T11:00:00-04:00
-author: "Taylor Thomas"
-author_profile: "https://twitter.com/_oftaylor"
-description: "Using the Component Model with wasmCloud Actors"
-categories: ["wasm", "webassembly", "components"]
+author: 'Taylor Thomas'
+author_profile: 'https://twitter.com/_oftaylor'
+description: 'Using the Component Model with wasmCloud Actors'
+categories: ['wasm', 'webassembly', 'components']
 draft: false
 ---
 
@@ -90,7 +90,7 @@ Here are what the interfaces look like:
 
 **wasmbus_receiver.wit**
 
-```plain
+```
 // These are importing some common types that you see in the receive function signature. See the
 // actual code on Github if you are curious what these types look like
 use * from error-type
@@ -104,7 +104,7 @@ receive a message. We'll see how this works in code below
 
 **httpserver.wit**
 
-```plain
+```
 use * from error-type
 
 type header-map = list<tuple<string, string>>
@@ -199,7 +199,7 @@ keyvalue:
 
 **keyvalue.wit**
 
-```plain
+```
 use * from error-type
 
 // Increment the value of the key by the given amount
@@ -268,7 +268,7 @@ keyvalue contract described above and also requires one other interface:
 
 **wasmbus-sender.wit**
 
-```plain
+```
 use * from error-type
 use * from wasmbus-common
 
@@ -371,7 +371,7 @@ to use, so hopefully we can enlighten you here. Before linking, we built all of 
 workspace by running `cargo build --release`. Once they were built, we ran the following command to
 link them together
 
-```terminal
+```bash
 wasmlink ./target/wasm32-wasi/release/httpserver.wasm \
    -m keyvalue=./target/wasm32-wasi/release/keyvalue.wasm \
    -m httpserver=./target/wasm32-wasi/release/kvcounter_actor.wasm \

--- a/content/english/blog/better-together-building-efficient-microservices-in-kubernetes-with-webassembly.md
+++ b/content/english/blog/better-together-building-efficient-microservices-in-kubernetes-with-webassembly.md
@@ -1,10 +1,10 @@
 ---
-title: "Better Together: Building Efficient Microservices in Kubernetes using WebAssembly"
-image: "images/blogs/adobe-kubernetes/header.png"
+title: 'Better Together: Building Efficient Microservices in Kubernetes using WebAssembly'
+image: 'images/blogs/adobe-kubernetes/header.png'
 date: 2022-11-17T11:00:00-05:00
-author: "Sean Isom and Colin Murphy, Adobe"
-description: "Bringing two major CNCF projects together – wasmCloud and Kubernetes – promises greater agility and major efficiencies"
-categories: ["webassembly", "wasmcloud", "kubernetes", "Cloud Native", "CNCF"]
+author: 'Sean Isom and Colin Murphy, Adobe'
+description: 'Bringing two major CNCF projects together – wasmCloud and Kubernetes – promises greater agility and major efficiencies'
+categories: ['webassembly', 'wasmcloud', 'kubernetes', 'Cloud Native', 'CNCF']
 draft: false
 ---
 
@@ -57,18 +57,18 @@ Normally, you can follow the single step in the documentation for installing was
 wasmcloud:
   enableApplierSupport: true
   customLabels:
-    wasmcloud.dev/route-to: "true"
+    wasmcloud.dev/route-to: 'true'
 ```
 
 Then you can deploy via helm (with your choice of RELEASE_NAME)
 
-```shell
+```bash
 helm install <RELEASE_NAME> wasmcloud/wasmcloud-host -f values.yaml
 ```
 
 Finally, to verify the install, you can grab the name of the deployment:
 
-```shell
+```bash
 $ kubectl get deployments
 NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
 wasmcloud-test-wasmcloud-host   1/1     1            1           4m32s
@@ -76,7 +76,7 @@ wasmcloud-test-wasmcloud-host   1/1     1            1           4m32s
 
 And then forward port 4000 to localhost:
 
-```shell
+```bash
 $ kubectl port-forward deployment/wasmcloud-test-wasmcloud-host 4000
 Forwarding from 127.0.0.1:4000 -> 4000
 Forwarding from [::1]:4000 -> 4000
@@ -93,13 +93,14 @@ We’re also using a handy wasmCloud Actor written by Taylor Thomas at Cosmonic,
 
 Let’s set up the example `echo` actor to get things running. We’ll need to create several providers and actors, then wire them up with link definitions. First start the actors and providers [with the current latest versions](https://github.com/wasmCloud/capability-providers#first-party-capability-providers):
 
-```shell
+```bash
 wash start provider wasmcloud.azurecr.io/applier:0.3.0
 wash start provider wasmcloud.azurecr.io/nats_messaging:0.17.0
 wash start provider wasmcloud.azurecr.io/httpserver:0.17.0
 wash start actor wasmcloud.azurecr.io/service_applier:0.3.0
 wash start actor wasmcloud.azurecr.io/echo:0.3.8
 ```
+
 :::info
 Previous guides used `wash ctl start`, which is now deprecated and will be removed in a future version.
 See [the wash command refactoring RFC](https://github.com/wasmCloud/wash/issues/538) for more information and to provide feedback
@@ -119,11 +120,12 @@ Finally, link the Echo actor to the httpserver actor, using the Contract ID (`wa
 
 Note that this (and the previous commands) could also be done via wash:
 
-```shell
+```bash
 $ wash link put MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver 'ADDRESS=0.0.0.0:8080'
 ⡃⠀ Defining link between MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5 and VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M ...
 Published link (MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5) <-> (VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M) successfully
 ```
+
 :::info
 Previous guides used `wash ctl link`, which is now deprecated and will be removed in a future version.
 See [the wash command refactoring RFC](https://github.com/wasmCloud/wash/issues/538) for more information and to provide feedback
@@ -131,7 +133,7 @@ See [the wash command refactoring RFC](https://github.com/wasmCloud/wash/issues/
 
 This link will create a Kubernetes service automatically on port 8080:
 
-```shell
+```bash
 $ kubectl get svc
 NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S) AGE
 mbcfopm6jw2apjlxjd3z5o4cn7cpyj2b4ftkljur5yr5mitiu7hd3wd5 ClusterIP 10.96.170.75 <none> 8080/TCP 10s
@@ -139,7 +141,7 @@ mbcfopm6jw2apjlxjd3z5o4cn7cpyj2b4ftkljur5yr5mitiu7hd3wd5 ClusterIP 10.96.170.75 
 
 Finally, to test that it is all working, forward port 8080 from the new service, and you can hit localhost:8080 to see your wasmCloud actor in action!
 
-```shell
+```bash
 $ kubectl port-forward svc/mbcfopm6jw2apjlxjd3z5o4cn7cpyj2b4ftkljur5yr5mitiu7hd3wd5 8080
 Forwarding from 127.0.0.1:8080 -> 8080
 Forwarding from [::1]:8080 -> 8080

--- a/docs/deployment/nats/cluster-config.mdx
+++ b/docs/deployment/nats/cluster-config.mdx
@@ -16,7 +16,7 @@ The following sections will cover running a single server and a three node clust
 
 Below is a minimal example of a server configuration file:
 
-```text
+```
 # Use an appropriate server name for your environment
 server_name: myserver
 
@@ -52,7 +52,7 @@ The following shows how to configure a cluster composed of three servers on thre
 
 The first server acts as the _seed_ for the cluster. The is nothing special about a seed server, other than the fact it starts the discovery process for other nodes.
 
-```text
+```
 server_name: wasmcloud-0
 host: 0.0.0.0
 cluster {
@@ -74,7 +74,7 @@ nats-server -c server-0.conf
 
 Next, bring up two additional servers on different machines:
 
-```text
+```
 server_name: wasmcloud-1
 host: 0.0.0.0
 cluster {
@@ -91,7 +91,7 @@ jetstream {
 }
 ```
 
-```text
+```
 server_name: wasmcloud-2
 host: 0.0.0.0
 cluster {

--- a/docs/deployment/security/env.mdx
+++ b/docs/deployment/security/env.mdx
@@ -8,7 +8,7 @@ The wasmCloud host can obtain configuration via environment variables. (For a li
 
 However, there are security pitfalls related to environment variables. For example, consider setting environment variables on the command line along with invoking the script, e.g.
 
-```shell
+```bash
 $ ENV_VAR_1=foo ENV_VAR_2=bar ./startapp
 ```
 

--- a/docs/developer/actors/generate.mdx
+++ b/docs/developer/actors/generate.mdx
@@ -15,7 +15,7 @@ We provide example templates for creating [actors](/docs/concepts/actors) in Rus
   <TabItem value="rust" label="Rust" default>
 Creating the scaffold for a new actor in Rust is easy. We will create an actor that accepts an HTTP request and responds with "Hello from Rust!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world --branch v0.81.0
 ```
 
@@ -67,7 +67,7 @@ Within the `handle` method, the actor receives the HTTP request, creates an `Out
   <TabItem value="tinygo" label="TinyGo">
 Creating the scaffold for a new actor in TinyGo is easy. We will create an actor that accepts an HTTP request and responds with "Hello from Go!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world --branch v0.81.0
 ```
 
@@ -128,7 +128,7 @@ Lastly, this Go directive will ensure that when we build our project with `tinyg
   <TabItem value="typescript" label="TypeScript">
 Creating the scaffold for a new actor in TypeScript is easy. We will create an actor that accepts an HTTP request and responds with "Hello from TypeScript!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/typescript/actors/http-hello-world --branch v0.81.0
 ```
 
@@ -184,7 +184,7 @@ Lastly, this export statement includes the `handle` function under the `incoming
   <TabItem value="python" label="Python">
 Creating the scaffold for a new actor in Python is easy. We will create an actor that accepts an HTTP request and responds with "Hello from Python!". To create your new actor project, change to the directory where you want the project to be created, and enter the command below. The first term on the command (`hello`) is the project name. If you choose a different project name, the name of the subdirectory and some symbols in the generated code will be different from the example code in this guide.
 
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/python/actors/http-hello-world --branch v0.81.0
 ```
 

--- a/docs/developer/actors/publish.mdx
+++ b/docs/developer/actors/publish.mdx
@@ -9,27 +9,27 @@ Once you're finished iterating on your actor component, you can publish it to an
 
 Once you have a registry available, you can use the [wash push](/docs/cli/push) and [wash pull](/docs/cli/pull) commands to push and pull actor components from OCI registries. For example, to pull a wasmCloud example locally:
 
-```shell
+```bash
 wash pull wasmcloud.azurecr.io/hello:0.1.7
 ```
 
 If you're working with an unauthenticated registry, you can directly push artifacts to it by specifying an image reference and the local file:
 
-```shell
+```bash
 wash push localhost:5000/v2/wasmcloud/hello:0.1.7 ./hello.wasm
 ```
 
 ## Authenticated Registries
 If you're working with an OCI registry that requires credentials, `wash` supports basic authentication via the `--username` and `--password` flags. Alternatively, you may opt to export your credentials as environment variables to avoid exposing them on the command line. This method of authentication works for both pushing and pulling.
 
-```shell
+```bash
 export WASH_REG_USER=wasmcloud
 export WASH_REG_PASSWORD=supersecret
 wash push wasmcloud.azurecr.io/hello:0.1.7 ./hello.wasm
 ```
 
 If your wasmCloud host is pulling from a registry that requires credentials, you can specify them when starting the host:
-```shell
+```bash
 export OCI_REGISTRY=ghcr.io
 export OCI_REGISTRY_USER=myusername
 export OCI_REGISTRY_PASSWORD=mys3cretper5onaltoken

--- a/docs/developer/actors/run.mdx
+++ b/docs/developer/actors/run.mdx
@@ -66,12 +66,12 @@ Once you've got the actor's public key, you can export a `HELLO_ACTOR_ID` enviro
 <Tabs groupId="os" queryString>
 <TabItem value="unix" label="Unix" default>
 
-```shell
+```bash
 # Paste your actor ID after the `=` below (with no space after the `=`)
 export HELLO_ACTOR_ID=
 ```
 
-```shell
+```bash
 wash link put ${HELLO_ACTOR_ID} VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M wasmcloud:httpserver address=0.0.0.0:8087
 ```
 
@@ -92,25 +92,25 @@ wash link put $env:HELLO_ACTOR_ID VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2
 
 At this point your HTTP server capability provider has been notified that a link definition was created, and it started the corresponding web server listening on port `8087`. You can now hit that endpoint and exercise the code you just wrote:
 
-```shell
+```bash
 curl localhost:8087
 ```
 
 and you should get the response:
 
-```text
+```
 Hello World
 ```
 
 The actor accepts an optional parameter `name`, and uses it to change the greeting. (Notice the quotes around the url below).
 
-```shell
+```bash
 curl "localhost:8087?name=Carol"
 ```
 
 The response should be
 
-```text
+```
 Hello Carol
 ```
 

--- a/docs/developer/actors/update.mdx
+++ b/docs/developer/actors/update.mdx
@@ -22,18 +22,18 @@ that away in the future.
 
 Before running `wash dev`, you'll need to enable experimental mode for wash:
 
-```shell
+```bash
 export WASH_EXPERIMENTAL=true
 ```
 
 Alternatively, you can run the command with the `--experimental` flag:
 
-```shell
+```bash
 wash dev --experimental
 ```
 
 The output should look like the following:
-```shell
+```bash
 ⚠️   No running wasmcloud host detected (PID file missing), starting a new host...
 🔧  Successfully started wasmCloud instance
 ⏳  Waiting for host to become reachable...

--- a/docs/developer/debugging/actors.mdx
+++ b/docs/developer/debugging/actors.mdx
@@ -17,7 +17,7 @@ When developing actors, there are a few common errors that can cause your actor 
 
 The following error can happen when attempting to start an actor from a local registry server over HTTP: 
 
-```console
+```
 2023-12-19T22:31:26.154791Z ERROR wasmcloud_host::wasmbus: failed to scale actor actor_ref=127.0.0.1:5000/v2/hello:0.1.0 err=failed to fetch actor
 
 Caused by:
@@ -105,7 +105,7 @@ You can pass the actual actor ID if you wish, but for ease of use, `wash` will a
 
 You can try out this command with the KV Counter example:
 
-```shell
+```bash
 $ wget https://raw.githubusercontent.com/wasmCloud/examples/main/actor/kvcounter/wadm.yaml
 $ wash app put wadm.yaml
 
@@ -182,7 +182,7 @@ This command will run until it detects a message that is past the time you start
 
 You can use the `wash capture replay` command to replay a `.washcapture` file. For example:
 
-```shell
+```bash
 $ wash capture replay 2023-06-14T11:11:03.476732-06:00.default.washcapture
 ```
 

--- a/docs/developer/debugging/host.mdx
+++ b/docs/developer/debugging/host.mdx
@@ -31,7 +31,7 @@ If you followed the [installation](/docs/installation) guide, then you likely st
 
 At the start of this logfile you'll see something like:
 
-```console
+```
 2023-12-19T21:36:49.708714Z  INFO async_nats::options: event: connected
 2023-12-19T21:36:49.708910Z  INFO async_nats::options: event: connected
 2023-12-19T21:36:49.711351Z  INFO wasmcloud_host::wasmbus: bucket already exists. Skipping creation. bucket=LATTICEDATA_default
@@ -46,20 +46,20 @@ Logs are appended to the end of this file as they are generated, so for the late
 
 If you ran the wasmCloud host inside a docker container, you can use the `docker logs` command to view the logs. To find the name of the wasmCloud host container, run:
 
-```console
+```bash
 docker ps -a --format "table {{.Image}}\t{{.Names}}"
 ```
 
 You should see output like:
 
-```console
+```
 IMAGE                               NAMES
 wasmcloud/wasmcloud:latest          docker-wasmcloud-1
 ```
 
 Then you can view the logs by running:
     
-```console
+```bash
 docker logs -f docker-wasmcloud-1
 ```
 
@@ -79,7 +79,7 @@ The wasmCloud host supports the following log levels:
 
 If you want to configure the log level for a specific library, you can set the `RUST_LOG` environment variable. For example, to change the log level of `async-nats` to `warn` while keeping the host at `debug`, you could run:
 
-```console
+```bash
 RUST_LOG=async_nats=warn,debug wasmcloud --log-level debug
 ```
 
@@ -95,7 +95,7 @@ By default, the wasmCloud host emits logs as unstructured text. However, structu
 
 Structured logs look like the following:
 
-```console
+```
 {"timestamp":"2023-12-19T22:16:06.389492Z","level":"INFO","fields":{"message":"event: connected"},"target":"async_nats::options"}
 {"timestamp":"2023-12-19T22:16:06.390689Z","level":"INFO","fields":{"message":"event: connected"},"target":"async_nats::options"}
 {"timestamp":"2023-12-19T22:16:06.401737Z","level":"INFO","fields":{"message":"bucket already exists. Skipping creation.","bucket":"LATTICEDATA_default"},"target":"wasmcloud_host::wasmbus"}

--- a/docs/developer/interfaces/creating-an-interface.md
+++ b/docs/developer/interfaces/creating-an-interface.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating an interface"
+title: 'Creating an interface'
 date: 2018-12-29T11:02:05+06:00
 sidebar_position: 6
 draft: false
@@ -15,7 +15,7 @@ When designing our interface for the payments capability, we need to clearly def
 
 - **AuthorizePayment** - Validates that a potential payment transaction can go through. If this succeeds then we should assume it is safe to complete a payment. Payments _cannot_ be completed without getting a validation code (in other words, all payments must be pre-authorized).
 - **CompletePayment** - Completes a previously authorized payment. This operation requires the "authorization code" from a successful authorization operation.
-- **GetPaymentMethods** - Retrieves an _opaque_ list of payment methods, which is a list of customer-facing method names and the [tokens](https://en.wikipedia.org/wiki/Tokenization_(data_security)) belonging to that payment method. You could think of this list as a previously saved list of payment methods stored in a "wallet". A payment method _token_ is required to authorize and subsequently complete a payment transaction. A customer may have stored multiple tokens in their wallet with familiar labels such as "family credit card", "business account", etc.
+- **GetPaymentMethods** - Retrieves an _opaque_ list of payment methods, which is a list of customer-facing method names and the [tokens](<https://en.wikipedia.org/wiki/Tokenization_(data_security)>) belonging to that payment method. You could think of this list as a previously saved list of payment methods stored in a "wallet". A payment method _token_ is required to authorize and subsequently complete a payment transaction. A customer may have stored multiple tokens in their wallet with familiar labels such as "family credit card", "business account", etc.
 
 Now let's take a look at the data payloads that might be used with these methods. Again, keep in mind that this is an example use case: a real implementation is likely to have far more detail.
 
@@ -74,7 +74,7 @@ In response to the empty query, a payments capability provider will return the f
 
 Now that we have logically defined the contract to be shared by the payments-consuming actors and the payments capability provider, let's use some of the available wasmCloud tools to generate the actor interface code.
 
-```shell
+```bash
 wash new interface payments
 ```
 
@@ -237,7 +237,7 @@ list PaymentMethods {
 
 If you modify this `.smithy` file, there are two useful `wash` commands to check it for errors:
 
-```text
+```
 wash lint
 wash validate
 ```

--- a/docs/developer/providers/create-par.md
+++ b/docs/developer/providers/create-par.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating a provider archive"
+title: 'Creating a provider archive'
 date: 2018-12-29T11:02:05+06:00
 sidebar_position: 8
 draft: false
@@ -13,7 +13,7 @@ Capability providers are always compiled in "release" mode. The `Makefile` creat
 
 If this is the first time you've run this command, some keys will be generated for you and you should see output that looks like the following:
 
-```sh
+```bash
 No keypair found in "/home/user/.wash/keys/fakepay_provider_service.nk".
 We will generate one for you and place it there.
 If you'd like to use alternative keys, you can supply them as a flag.
@@ -28,7 +28,7 @@ The `wash` command creates a private issuer _seed key_ if there isn't one alread
 
 We can use `wash` to inspect a provider archive as well (primary key has been truncated to fit documentation):
 
-```sh
+```bash
 wash par inspect build/fakepay_provider.par.gz
 ╔══════════════════════════════════════════════════════════════════════╗
 ║                        Fake Payments - Provider Archive              ║

--- a/docs/developer/providers/rust.md
+++ b/docs/developer/providers/rust.md
@@ -1,5 +1,5 @@
 ---
-title: "Creating a new provider"
+title: 'Creating a new provider'
 date: 2018-12-29T11:02:05+06:00
 sidebar_position: 7
 draft: false
@@ -18,7 +18,7 @@ Thankfully, our scaffolding and reusable Rust crates take care of the basic plum
 
 Let's create a new provider project
 
-```shell
+```bash
 wash new provider fakepay-provider
 ```
 
@@ -115,7 +115,7 @@ Change the path of the interface file to match your location.
 
 Also, we need to make one edit to the project Makefile: change the last part of CAPABILITY_ID to replace "fakepay_provider" with "payments", to match the capability contract we defined in the interface:
 
-```Makefile
+```makefile
 CAPABILITY_ID = "wasmcloud:examples:payments"
 ```
 

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -1,9 +1,9 @@
 ---
-title: "Developer Workflows"
+title: 'Developer Workflows'
 date: 2018-12-29T11:02:05+06:00
 sidebar_position: 1
 draft: false
-description: "Common development loops"
+description: 'Common development loops'
 ---
 
 As a developer using wasmCloud, there are a number of common day-to-day workflows that you will experience.

--- a/docs/ecosystem/wash/contexts.mdx
+++ b/docs/ecosystem/wash/contexts.mdx
@@ -20,7 +20,7 @@ Let's take a look at a context. If you haven't already, try going through the [i
 
 Next, run this command:
 
-```shell
+```bash
 wash ctx list
 ```
 
@@ -36,7 +36,7 @@ Let's take a look at that context. You can use the built-in `wash ctx edit` comm
 <Tabs groupId="os" queryString>
   <TabItem value="unix" label="Unix" default>
 
-```shell
+```bash
 cat $HOME/.wash/contexts/host_config.json | jq
 ```
 
@@ -81,19 +81,19 @@ This context contains our reasonable-defaults values of connecting to NATS local
 
 If you'd like to use contexts to manage connections to multiple local lattices, you can create your own context. You can do that in one of two ways:
 
-```shell
+```bash
 # Create a context with specified name and default values
 wash ctx new ctx_tutorial
 ```
 
-```shell
+```bash
 # Create a context interactively with terminal prompts
 wash ctx new --interactive
 ```
 
 Once created, you can use the `edit` subcommand to easily edit those contexts. `wash` attempts to use the terminal editor defined in your environment as `EDITOR`, but will also accept an argument for your favorite terminal editor.
 
-```shell
+```bash
 wash ctx edit --editor vim ctx_tutorial
 ```
 

--- a/docs/hosts/abis/wasmbus/interfaces/codegen-toml.md
+++ b/docs/hosts/abis/wasmbus/interfaces/codegen-toml.md
@@ -1,5 +1,5 @@
 ---
-title: "codegen.toml files"
+title: 'codegen.toml files'
 draft: false
 ---
 
@@ -26,32 +26,31 @@ Directories are scanned recursively for all model files ending in `.smithy` or `
 Examples:
 
 - single path
-   ```text
-   # Load a model from an absolute or relative path.
-   # Relative paths are relative to the location of codegen.toml.
-   [[models]]
-   path = "models/foo.smithy"
-   ```
-  
- - folder 
+  ```
+  # Load a model from an absolute or relative path.
+  # Relative paths are relative to the location of codegen.toml.
+  [[models]]
+  path = "models/foo.smithy"
+  ```
+- folder
 
-   ```text
-   # Search the my-models folder recursively, and load all model files found.
-   # Path is absolute or relative
-   [[models]]
-   path = "my-models"
-   ```
-   
+  ```
+  # Search the my-models folder recursively, and load all model files found.
+  # Path is absolute or relative
+  [[models]]
+  path = "my-models"
+  ```
+
 - path prefix with mix of folders and named files
 
-   ```text
-   # Load a list of files that share a common path prefix. This example
-   # loads all the files in any subdirectory of /etc/models/v1/,
-   # and the named files /etc/models/base/foo.smithy and /etc/models/base/bar.json
-   [[models]]
-   path = "/etc/models"
-   files = [ "v1", "base/foo.smithy", "base/bar.json" ]
-   ```
+  ```
+  # Load a list of files that share a common path prefix. This example
+  # loads all the files in any subdirectory of /etc/models/v1/,
+  # and the named files /etc/models/base/foo.smithy and /etc/models/base/bar.json
+  [[models]]
+  path = "/etc/models"
+  files = [ "v1", "base/foo.smithy", "base/bar.json" ]
+  ```
 
 ### From URLs
 
@@ -62,15 +61,15 @@ Examples:
 
 - single file url
 
-  ```text
+  ```
   # Load a single smithy file from a url
   [[models]]
   url = "https://example.com/models/foo.smithy"
   ```
 
 - multiple files with common prefix
-  
-  ```text
+
+  ```
   # Load multiple files from the same base url
   #   https://example.com/models/v1/foo.smithy and
   #   https://example.com/models/v1/bar.smithy"
@@ -79,7 +78,6 @@ Examples:
   files =  [ "foo.smithy", "bar.smithy" ]
   ```
 
-
 ### Caching
 
 All files loaded by url are cached locally, to speed up development time
@@ -87,11 +85,10 @@ and to enable offline builds (after the first time).
 
 Cached files are located in the following folders, depending on your platform.
 
-|Platform | Value                               | Example                      |
-| ------- | ----------------------------------- | ---------------------------- |
-| Linux   | `$XDG_CACHE_HOME`/weld or `$HOME`/.cache/weld | /home/alice/.cache/weld           |
-| macOS   | `$HOME`/Library/Caches/weld              | /Users/Alice/Library/Caches/weld  |
-| Windows | `{FOLDERID_LocalAppData}\weld`           | C:\Users\Alice\AppData\Local\weld |
-
+| Platform | Value                                         | Example                           |
+| -------- | --------------------------------------------- | --------------------------------- |
+| Linux    | `$XDG_CACHE_HOME`/weld or `$HOME`/.cache/weld | /home/alice/.cache/weld           |
+| macOS    | `$HOME`/Library/Caches/weld                   | /Users/Alice/Library/Caches/weld  |
+| Windows  | `{FOLDERID_LocalAppData}\weld`                | C:\Users\Alice\AppData\Local\weld |
 
 The command `wash drain smithy` can be used to discard all files in the local cache, so they will be downloaded again as-needed by the code generator.

--- a/docs/hosts/abis/wasmbus/interfaces/tips/avoid-single-member-structures.md
+++ b/docs/hosts/abis/wasmbus/interfaces/tips/avoid-single-member-structures.md
@@ -1,15 +1,15 @@
 ---
-title: "Single-member structures"
+title: 'Single-member structures'
 draft: false
 ---
 
-A function is modeled as an operation, with an optional `input` type 
+A function is modeled as an operation, with an optional `input` type
 for its parameters, and an optional `output` type for its return value.
 If either input or output type is a structure containing one member, it
 is often preferred to simplify the declaration and api to use the value directly,
-without the structure wrapper. For example, instead of 
+without the structure wrapper. For example, instead of
 
-```text
+```
 /// count the number of values matching a query string
 operation Count {
     input: String,
@@ -22,7 +22,8 @@ structure CountResponse {
 ```
 
 Use
-```text
+
+```
 /// count the number of values matching a query string
 operation Count {
     input: String,
@@ -35,8 +36,3 @@ One reason you might still prefer to use a structure is if you expect to add fie
 Another reason you may need a structure is if the value is optional (in Rust, `Option<T>`). Since operation input and output can't be declared optional, you'd have to make the optional value a field of a structure.
 
 If neither of those cases apply, structures with one member can be replaced with the member.
-
-
-
-
-

--- a/docs/hosts/abis/wasmbus/interfaces/traits.md
+++ b/docs/hosts/abis/wasmbus/interfaces/traits.md
@@ -1,5 +1,5 @@
 ---
-title: "Annotation traits"
+title: 'Annotation traits'
 draft: false
 ---
 
@@ -73,7 +73,7 @@ Uses the provided name for on-the-wire serialization
 
 **Example**
 
-```text
+```
 structure Data {
     name: String,
 

--- a/docs/hosts/abis/wasmbus/interfaces/wasmcloud-smithy.md
+++ b/docs/hosts/abis/wasmbus/interfaces/wasmcloud-smithy.md
@@ -1,5 +1,5 @@
 ---
-title: "wasmCloud Smithy"
+title: 'wasmCloud Smithy'
 draft: false
 ---
 
@@ -81,7 +81,7 @@ Due to the way we use msgpack, map key types are limited to String.
 
 Structures are just like the structures in your favorite programming languages.
 
-```text
+```
 /// Documentation for my structure
 structure Point {
     x: Integer,
@@ -104,6 +104,7 @@ The `@required` trait may be used on structure members to indicate that it must 
 A Service defines a set of operations. wasmCloud has defined a set of required and optional annotations for services and their operations.
 
 The `@wasmbus` annotation is required. `wasmbus` is the name wasmCloud uses for its messaging protocol.
+
 ```
 @wasmbus(
     contractId: "wasmcloud:httpclient",
@@ -124,7 +125,7 @@ These attributes control code generation, so if you can't find the generated met
 Operations represent functions, and are declared with 0 or 1 input types (parameters)
 and 0 or 1 output types (return values).
 
-```text
+```
 /// Increment the value of the counter, returning its new value
 operation Increment {
     input: I32,
@@ -137,7 +138,7 @@ other than optional types.
 An operation with no input declaration means the operation takes no parameters,
 for example,
 
-```text
+```
 operation GetTimeOfDay {
     output: Timestamp
 }
@@ -146,7 +147,7 @@ operation GetTimeOfDay {
 An operation without output means the operation has no return value
 (e.g., returns 'void'), for example,
 
-```text
+```
 operation SetCounter {
     input: U64,
 }
@@ -163,13 +164,13 @@ We would like to model functions that take multiple parameters. We can do that w
 
 For example, a key value store might have a "set" operation:
 
-```text
+```
 Set(key: string, value: string, expires: i32): SetResponse
 ```
 
 Since Smithy operations can only be declared with a single input type, the Smithy declaration might look like
 
-```text
+```
 operation Set {
   input: SetRequest,
   output: SetResponse,

--- a/docs/hosts/elixir/running.md
+++ b/docs/hosts/elixir/running.md
@@ -1,5 +1,5 @@
 ---
-title: "Running the Host"
+title: 'Running the Host'
 date: 2018-12-29T11:02:05+06:00
 sidebar_position: 11
 draft: false

--- a/docs/reference/wasi/support.md
+++ b/docs/reference/wasi/support.md
@@ -20,6 +20,7 @@ wash inspect --wit ./build/hello_world_s.wasm
 ```
 
 ```javascript
+
 package root:component;
 
 world root {

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -21,7 +21,7 @@ Component examples are experimental and likely to require recompilation with eac
 :::info[Rust & WebAssembly]
 To perform the steps in this guide, you'll need to have a [Rust toolchain](https://www.rust-lang.org/tools/install) installed locally and the wasm32 target installed:
 
-```shell
+```bash
 rustup target add wasm32-wasi
 ```
 
@@ -210,7 +210,7 @@ Component examples are experimental and likely to require recompilation with eac
 :::info[Python & WebAssembly]
 To perform the steps in this guide, you'll need you'll need to install [Python 3.10](https://www.python.org/) or later, [pip](https://pip.pypa.io/en/stable/installation/), and `componentize-py` to compile Python code to WebAssembly.
 
-```shell
+```bash
 pip install componentize-py==0.9.2
 ```
 ::: 
@@ -219,7 +219,7 @@ Let's extend this application to do more than just say "hello." Using the `path_
 
 :::info
 If you're using an IDE or would like to look at the imports, you can generate the bindings using `componentize-py` to get IDE suggestions and autofills.
-```shell
+```bash
 componentize-py bindings .
 ```
 :::

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -71,7 +71,7 @@ Pick your language of choice below to follow
   :::
 
 This command generates a new actor project in the `./hello` directory:
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/rust/actors/http-hello-world --branch v0.81.0
 ```
 
@@ -84,7 +84,7 @@ This actor is a simple Rust project with a few extra goodies included for wasmCl
 :::info[Rust dependencies]
 You don't need any Rust dependencies installed to run this example, but if you want to build it yourself you'll need to install the [Rust toolchain](https://www.rust-lang.org/tools/install) and the `wasm32-wasi` target.
 
-```shell
+```bash
 rustup target add wasm32-wasi
 ```
 :::
@@ -97,7 +97,7 @@ rustup target add wasm32-wasi
   :::
 
 This command generates a new actor project in the `./hello` directory:
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/golang/actors/http-hello-world  --branch v0.81.0
 ```
 
@@ -119,7 +119,7 @@ Component examples are experimental and likely to require recompilation with eac
 :::
 
 This command generates a new actor project in the `./hello` directory:
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/typescript/actors/http-hello-world  --branch v0.81.0
 ```
 
@@ -141,7 +141,7 @@ Component examples are experimental and likely to require recompilation with eac
 :::
 
 This command generates a new actor project in the `./hello` directory:
-```shell
+```bash
 wash new actor hello --git wasmcloud/wasmcloud --subfolder examples/python/actors/http-hello-world --branch v0.81.0
 ```
 
@@ -182,11 +182,11 @@ Feel free to take a look at the code and the project structure. We'll take a loo
 
 ## Building the Application
 We can use the open source HTTP Server capability provider to serve our application, so the only thing you'll need to build is the actor component. Change directory into the generated `hello` directory and run `wash build` to build your actor, taking note of the actor path after building:
-```shell
+```bash
 cd hello
 wash build
 ```
-```shell
+```bash
 Actor built and signed and can be found at "/Users/wasmcloud/hello/build/http_hello_world_s.wasm"
 ```
 
@@ -225,7 +225,7 @@ If you prefer not to build anything yet, you can use `wasmcloud.azurecr.io/hello
 
 We'll use `wash` and [wadm](/docs/category/declarative-application-deployment-wadm), the wasmCloud application deployment manager, to start this actor, the httpserver capability, and link them together to configure them.
 
-```shell
+```bash
 cd hello # enter the new project directory (if you haven't already)
 wash app deploy wadm.yaml
 ```
@@ -233,14 +233,14 @@ wash app deploy wadm.yaml
 ![wash app deploy diagram](../images/washappdeploy.png)
 
 `wadm` will take care of taking this manifest and scheduling the resources on the host that you launched earlier. You should see output in the host logs when your actor and capability start up, which should happen after just a few seconds. After you see that the HTTP server set up the listener in the host logs, or once the application is `Deployed` when you check `wash app list`, you can query it yourself:
-```shell
+```bash
 ➜ wash app list
 
 Name             Latest Version   Deployed Version   Deploy Status   Description
 http-hello-world v0.0.1           v0.0.1                  Deployed   HTTP Hello World
 ```
 
-```shell
+```bash
 $ curl localhost:8080
 Hello, World!
 ```
@@ -478,7 +478,7 @@ Now your hello application is ready to deploy v0.0.2 with 50 replicas, meaning i
 
 To view the wasmCloud dashboard, you'll have to launch `wash` with the option `--nats-websocket-port 4001`. Go ahead and `CTRL+c` or `wash down` to stop your previous host, and then relaunch it with the new option:
 
-```shell
+```bash
 wash up --nats-websocket-port 4001
 ```
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,7 +179,28 @@ const config: Config = {
       appId: '2IM4TMH501',
     },
     prism: {
-      additionalLanguages: ['rust', 'powershell', 'toml', 'elixir'],
+      additionalLanguages: [
+        // this is all the currently supported and enabled languages. To add more, see https://prismjs.com/#supported-languages
+        'bash',
+        'cpp',
+        'css',
+        'elixir',
+        'go',
+        'javascript',
+        'json',
+        'makefile',
+        'powershell',
+        'python',
+        'rust',
+        'toml',
+        'typescript',
+        'yaml',
+        // unsupported languages
+        // TODO: switch to http://shiki.style/
+        // 'grpc',
+        // 'smithy',
+        // 'wit',
+      ],
       theme: themes.dracula,
       darkTheme: themes.dracula,
     },


### PR DESCRIPTION
- Enable a few more languages that we use in the docs
- Align usage of markdown codeblocks to correct name for languages (some have aliases, but decided to just align to the package name from prism)