### PR TITLE
feat(mdx): change to shiki for syntax highlighting

### DIFF
--- a/blog/wasmcloud-0.82-wasi-p2-is-here/index.mdx
+++ b/blog/wasmcloud-0.82-wasi-p2-is-here/index.mdx
@@ -53,9 +53,7 @@ Previously, you'd have to know or find the absolute path to your signed build ar
 - name: hello
   type: actor
   properties:
-      // highlight-start
-    image: file://./build/hello_s.wasm
-      // highlight-end
+    image: file://./build/hello_s.wasm // [!code highlight]
 ```
 
 # OpenTelemetry logging

--- a/docs/concepts/interface-driven-development.mdx
+++ b/docs/concepts/interface-driven-development.mdx
@@ -63,7 +63,7 @@ How to *use* WIT in your WebAssembly components is beyond the scope of this docu
 
 For those familiar with [gRPC][grpc], the above WIT interface would look something like the following:
 
-```grpc
+```proto
 syntax = "proto3";
 
 package greeter;

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -43,31 +43,28 @@ use wasi::http::types::*;
 struct HttpServer;
 
 impl Guest for HttpServer {
-// highlight-start
-    // Make sure to remove the _ prefix from the `request` variable
-    fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
-// highlight-end
+    fn handle(_request: IncomingRequest, response_out: ResponseOutparam) { // [!code --]
+    fn handle(request: IncomingRequest, response_out: ResponseOutparam) { // [!code ++]
         let response = OutgoingResponse::new(Fields::new());
         response.set_status_code(200).unwrap();
         let response_body = response.body().unwrap();
-// highlight-start
-        let name = match request
-            .path_with_query()
-            .unwrap()
-            .split("=")
-            .collect::<Vec<&str>>()[..]
-        {
-            // query string is "/?name=<name>" e.g. localhost:8080?name=Bob
-            ["/?name", name] => name.to_string(),
-            // query string is anything else or empty e.g. localhost:8080
-            _ => "World".to_string(),
-        };
+        let name = match request // [!code ++]
+            .path_with_query() // [!code ++]
+            .unwrap() // [!code ++]
+            .split("=") // [!code ++]
+            .collect::<Vec<&str>>()[..] // [!code ++]
+        { // [!code ++]
+            // query string is "/?name=<name>" e.g. localhost:8080?name=Bob // [!code ++]
+            ["/?name", name] => name.to_string(), // [!code ++]
+            // query string is anything else or empty e.g. localhost:8080 // [!code ++]
+            _ => "World".to_string(), // [!code ++]
+        }; // [!code ++]
         response_body
             .write()
             .unwrap()
-            .blocking_write_and_flush(format!("Hello, {}!\n", name).as_bytes())
+            .blocking_write_and_flush(b"Hello from Rust!\n") // [!code --]
+            .blocking_write_and_flush(format!("Hello, {}!\n", name).as_bytes()) // [!code ++]
             .unwrap();
-// highlight-end
         OutgoingBody::finish(response_body, None).expect("failed to finish response body");
         ResponseOutparam::set(response_out, Ok(response));
     }
@@ -86,9 +83,9 @@ Let's extend this application to do more than just say "Hello from Go!" Using th
 package main
 
 import (
-	"fmt"
-	"strings"
-	http "github.com/wasmcloud/wasmcloud/examples/golang/actors/http-hello-world/gen"
+  "fmt"
+  "strings"
+  http "github.com/wasmcloud/wasmcloud/examples/golang/actors/http-hello-world/gen"
 )
 
 // Helper type aliases to make code more readable
@@ -100,36 +97,33 @@ type HttpError = http.WasiHttp0_2_0_TypesErrorCode
 type HttpServer struct{}
 
 func init() {
-	httpserver := HttpServer{}
-	// Set the incoming handler struct to HttpServer
-	http.SetExportsWasiHttp0_2_0_IncomingHandler(httpserver)
+  httpserver := HttpServer{}
+  // Set the incoming handler struct to HttpServer
+  http.SetExportsWasiHttp0_2_0_IncomingHandler(httpserver)
 }
 
 func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWriter) {
-	// Construct HttpResponse to send back
-	headers := http.NewFields()
-	httpResponse := http.NewOutgoingResponse(headers)
-	httpResponse.SetStatusCode(200)
+  // Construct HttpResponse to send back
+  headers := http.NewFields()
+  httpResponse := http.NewOutgoingResponse(headers)
+  httpResponse.SetStatusCode(200)
 
-// highlight-start
-	name := getNameFromPath(request.PathWithQuery().Unwrap())
-	httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8(fmt.Sprintf("Hello %s!\n", name))).Unwrap()
-// highlight-end
+  httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8("Hello from Go!\n")).Unwrap() // [!code --]
+  name := getNameFromPath(request.PathWithQuery().Unwrap()) // [!code ++]
+  httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8(fmt.Sprintf("Hello %s!\n", name))).Unwrap() // [!code ++]
 
-	// Send HTTP response
-	okResponse := http.Ok[HttpOutgoingResponse, HttpError](httpResponse)
-	http.StaticResponseOutparamSet(responseWriter, okResponse)
+  // Send HTTP response
+  okResponse := http.Ok[HttpOutgoingResponse, HttpError](httpResponse)
+  http.StaticResponseOutparamSet(responseWriter, okResponse)
 }
 
-// highlight-start
-func getNameFromPath(path string) string {
-	parts := strings.Split(path, "=")
-	if len(parts) == 2 {
-		return parts[1]
-	}
-	return "World"
-}
-// highlight-end
+func getNameFromPath(path string) string { // [!code ++]
+  parts := strings.Split(path, "=") // [!code ++]
+  if len(parts) == 2 { // [!code ++]
+    return parts[1] // [!code ++]
+  } // [!code ++]
+  return "World" // [!code ++]
+} // [!code ++]
 
 //go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt
 func main() {}
@@ -150,7 +144,7 @@ import {
   ResponseOutparam,
   OutgoingResponse,
   Fields,
-} from "wasi:http/types@0.2.0-rc-2023-12-05";
+} from "wasi:http/types@0.2.0";
 
 // Implementation of wasi-http incoming-handler
 //
@@ -163,13 +157,12 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   let outgoingBody = outgoingResponse.body();
   // Create a stream for the response body
   let outputStream = outgoingBody.write();
-  //highlight-start
-  // Write "hello [name]" to the response stream
-  const name = getNameFromPath(req.pathWithQuery() || "")
+  // Write "hello [name]" to the response stream // [!code ++]
+  const name = getNameFromPath(req.pathWithQuery() || "") // [!code ++]
   outputStream.blockingWriteAndFlush(
-    new Uint8Array(new TextEncoder().encode(`Hello ${name}!\n`))
+    new Uint8Array(new TextEncoder().encode("hello from Typescript")) // [!code --]
+    new Uint8Array(new TextEncoder().encode(`hello ${name}!`)) // [!code ++]
   );
-  //highlight-end
 
   // Set the status code for the response
   outgoingResponse.setStatusCode(200);
@@ -178,15 +171,13 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   ResponseOutparam.set(resp, { tag: "ok", val: outgoingResponse });
 }
 
-//highlight-start
-function getNameFromPath(path: string): string {
-  const parts = path.split("=");
-  if (parts.length == 2) {
-    return parts[1];
-  }
-  return "world";
-}
-//highlight-end
+function getNameFromPath(path: string): string { // [!code ++]
+  const parts = path.split("="); // [!code ++]
+  if (parts.length == 2) { // [!code ++]
+    return parts[1]; // [!code ++]
+  } // [!code ++]
+  return "world"; // [!code ++]
+} // [!code ++]
 
 export const incomingHandler = {
   handle,
@@ -216,10 +207,8 @@ componentize-py bindings .
 
 ```python
 class IncomingHandler(exports.IncomingHandler):
-#highlight-start
-    # Make sure to change the variable name for the request from _ to request in the handle function.
-    def handle(self, request: IncomingRequest, response_out: ResponseOutparam):
-#highlight-end
+    def handle(self, _: IncomingRequest, response_out: ResponseOutparam): # [!code --]
+    def handle(self, request: IncomingRequest, response_out: ResponseOutparam): # [!code ++]
         # Construct the HTTP response to send back 
         outgoingResponse = OutgoingResponse(Fields.from_list([]))
         # Set the status code to OK
@@ -227,22 +216,19 @@ class IncomingHandler(exports.IncomingHandler):
         outgoingBody = outgoingResponse.body()
 
         # Write our Hello message to the response body
-#highlight-start
-        name = get_name_from_path(request.path_with_query())
-        outgoingBody.write().blocking_write_and_flush(bytes("Hello {}!\n".format(name), "utf-8"))
-#highlight-end
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello from Python!\n", "utf-8")) # [!code --]
+        name = get_name_from_path(request.path_with_query()) # [!code ++]
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello {}!\n".format(name), "utf-8")) # [!code ++]
         OutgoingBody.finish(outgoingBody, None)
         # Set and send the HTTP response
         ResponseOutparam.set(response_out, Ok(outgoingResponse))
 
-#highlight-start
-def get_name_from_path(path: str) -> str:
-    parts = path.split("=")
-    if len(parts) == 2:
-        return parts[-1]
-    else:
-        return "World"
-#highlight-end
+def get_name_from_path(path: str) -> str: # [!code ++]
+    parts = path.split("=") # [!code ++]
+    if len(parts) == 2: # [!code ++]
+        return parts[-1] # [!code ++]
+    else: # [!code ++]
+        return "World" # [!code ++]
 ```
 
   </TabItem>
@@ -275,16 +261,14 @@ Hello, Bob!
 
 To further enhance our application, let's add persistent storage to keep a record of each person that this application greeted. We'll use the key-value store capability for this, and just like HTTP server, you won't need to pick a library or a specific vendor implementation yet. You'll just need to add the capability to your actor, and then you can pick a capability provider at runtime.
 
-  In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/world.wit` file:
+In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
 ```wit
 package wasmcloud:hello;
 
 world hello {
-  // highlight-start
-  import wasi:keyvalue/atomic@0.1.0;
-  import wasi:keyvalue/eventual@0.1.0;
-  import wasi:logging/logging;
-  // highlight-end
+  import wasi:keyvalue/atomic@0.1.0; // [!code ++]
+  import wasi:keyvalue/eventual@0.1.0; // [!code ++]
+  import wasi:logging/logging; // [!code ++]
 
   export wasi:http/incoming-handler@0.2.0;
 }
@@ -294,7 +278,7 @@ world hello {
   <TabItem value="rust" label="Rust">
 
 Let's use the atomic increment function to keep track of how many times we've greeted each person. 
-  ```rust
+```rust
     let name = match request
         .path_with_query()
         .unwrap()
@@ -307,23 +291,21 @@ Let's use the atomic increment function to keep track of how many times we've gr
         _ => "World".to_string(),
     };
 
-// highlight-start
-    wasi::logging::logging::log(
-        wasi::logging::logging::Level::Info,
-        "",
-        &format!("Greeting {name}"),
-    );
-
-    let bucket =
-        wasi::keyvalue::types::Bucket::open_bucket("").expect("failed to open empty bucket");
-    let count = wasi::keyvalue::atomic::increment(&bucket, &name, 1)
-        .expect("failed to increment count");
-
+    wasi::logging::logging::log( // [!code ++]
+        wasi::logging::logging::Level::Info, // [!code ++]
+        "", // [!code ++]
+        &format!("Greeting {name}"), // [!code ++]
+    ); // [!code ++]
+// [!code ++]
+    let bucket = // [!code ++]
+        wasi::keyvalue::types::Bucket::open_bucket("").expect("failed to open empty bucket"); // [!code ++]
+    let count = wasi::keyvalue::atomic::increment(&bucket, &name, 1) // [!code ++]
+        .expect("failed to increment count"); // [!code ++]
+// [!code ++]
     response_body
         .write()
         .unwrap()
         .blocking_write_and_flush(format!("Hello x{count}, {name}!\n").as_bytes())
-// highlight-end
         .unwrap();
   ```
 
@@ -334,24 +316,23 @@ Let's use the atomic increment function to keep track of how many times we've gr
 
 ```go
 func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWriter) {
-	// Construct HttpResponse to send back
-	headers := http.NewFields()
-	httpResponse := http.NewOutgoingResponse(headers)
-	httpResponse.SetStatusCode(200)
+  // Construct HttpResponse to send back
+  headers := http.NewFields()
+  httpResponse := http.NewOutgoingResponse(headers)
+  httpResponse.SetStatusCode(200)
+// [!code ++]
+  name := getNameFromPath(request.PathWithQuery().Unwrap()) // [!code ++]
+// [!code ++]
+  http.WasiLoggingLoggingLog(http.WasiLoggingLoggingLevelInfo(), "", fmt.Sprintf("Greeting %s", name)) // [!code ++]
+  bucket := http.StaticBucketOpenBucket("").Unwrap() // [!code ++]
+  count := http.WasiKeyvalue0_1_0_AtomicIncrement(bucket, name, 1).Unwrap() // [!code ++]
 
-	name := getNameFromPath(request.PathWithQuery().Unwrap())
+  httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8("Hello from Go!\n")).Unwrap() // [!code --]
+  httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8(fmt.Sprintf("Hello x%d, %s!\n", count, name))).Unwrap() // [!code ++]
 
-//highlight-start
-	http.WasiLoggingLoggingLog(http.WasiLoggingLoggingLevelInfo(), "", fmt.Sprintf("Greeting %s", name))
-	bucket := http.StaticBucketOpenBucket("").Unwrap()
-	count := http.WasiKeyvalue0_1_0_AtomicIncrement(bucket, name, 1).Unwrap()
-
-	httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8(fmt.Sprintf("Hello x%d, %s!\n", count, name))).Unwrap()
-//highlight-end
-
-	// Send HTTP response
-	okResponse := http.Ok[HttpOutgoingResponse, HttpError](httpResponse)
-	http.StaticResponseOutparamSet(responseWriter, okResponse)
+  // Send HTTP response
+  okResponse := http.Ok[HttpOutgoingResponse, HttpError](httpResponse)
+  http.StaticResponseOutparamSet(responseWriter, okResponse)
 }
 ```
 
@@ -360,22 +341,29 @@ func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWrite
 
 Let's use the atomic increment function to keep track of how many times we've greeted each person.
 
+:::info[Missing Imports]
+
+At the time of writing, JCO does not generate types for `wasi:logging` or `wasi:keyvalue`. This is
+a known issue and will be resolved in a future release. For now, you can tell the TypeScript
+compiler to ignore the missing types by adding `//@ts-expect-error` before each import statement.
+Simply including the import statement will allow the host to provider the functionality at runtime.
+
+:::
+
 ```typescript
 import {
   IncomingRequest,
   ResponseOutparam,
   OutgoingResponse,
   Fields,
-} from 'wasi:http/types@0.2.0';
+} from "wasi:http/types@0.2.0";
 
-//highlight-start
-//@ts-expect-error -- these types aren't currently known by JCO
-import { log } from "wasi:logging/logging";
-//@ts-expect-error -- these types aren't currently known by JCO
-import { increment } from "wasi:keyvalue/atomic@0.1.0";
-//@ts-expect-error -- these types aren't currently known by JCO
-import { Bucket } from "wasi:keyvalue/types@0.1.0";
-//highlight-end
+//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++]
+import { log } from "wasi:logging/logging"; // [!code ++]
+//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++]
+import { increment } from "wasi:keyvalue/atomic@0.1.0"; // [!code ++]
+//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++]
+import { Bucket } from "wasi:keyvalue/types@0.1.0"; // [!code ++]
 
 // Implementation of wasi-http incoming-handler
 //
@@ -388,20 +376,18 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   let outgoingBody = outgoingResponse.body();
   // Create a stream for the response body
   let outputStream = outgoingBody.write();
-  //highlight-start
-  // Write to the response stream
-  const name = getNameFromPath(req.pathWithQuery() || "")
-
-  log("info", "", `Greeting ${name}`);
-
-  // Increment the bucket's count
-  const bucket = Bucket.openBucket("");
-  const count = increment(bucket, name, 1);
-
-  outputStream.blockingWriteAndFlush(
-    new Uint8Array(new TextEncoder().encode(`Hello x${count}, ${name}!\n`))
-  );
-  //highlight-end
+  // Write to the response stream // [!code ++]
+  const name = getNameFromPath(req.pathWithQuery() || "") // [!code ++]
+// [!code ++]
+  log("info", "", `Greeting ${name}`); // [!code ++]
+// [!code ++]
+  // Increment the bucket's count // [!code ++]
+  const bucket = Bucket.openBucket(""); // [!code ++]
+  const count = increment(bucket, name, 1); // [!code ++]
+// [!code ++]
+  outputStream.blockingWriteAndFlush( // [!code ++]
+    new Uint8Array(new TextEncoder().encode(`Hello x${count}, ${name}!\n`)) // [!code ++]
+  ); // [!code ++]
 
   // Set the status code for the response
   outgoingResponse.setStatusCode(200);
@@ -422,12 +408,11 @@ from hello import exports
 from hello.types import Ok
 from hello.imports.types import (
     IncomingRequest, ResponseOutparam,
-#highlight-start
-    OutgoingResponse, Fields, OutgoingBody, Bucket
+    OutgoingResponse, Fields, OutgoingBody # [!code --]
+    OutgoingResponse, Fields, OutgoingBody, Bucket # [!code ++]
 )
-from hello.imports.atomic import increment
-from hello.imports.logging import (log, Level)
-#highlight-end
+from hello.imports.atomic import increment # [!code ++]
+from hello.imports.logging import (log, Level) # [!code ++]
 
 class IncomingHandler(exports.IncomingHandler):
     def handle(self, request: IncomingRequest, response_out: ResponseOutparam):
@@ -439,13 +424,11 @@ class IncomingHandler(exports.IncomingHandler):
 
         # Write our Hello message to the response body
         name = get_name_from_path(request.path_with_query())
-#highlight-start
-        log(Level.INFO, "", "Greeting {}".format(name))
-        bucket = Bucket.open_bucket("")
-        count = increment(bucket, name, 1)
-
-        outgoingBody.write().blocking_write_and_flush(bytes("Hello x{}, {}!\n".format(count, name), "utf-8"))
-#highlight-end
+        log(Level.INFO, "", "Greeting {}".format(name)) # [!code ++]
+        bucket = Bucket.open_bucket("") # [!code ++]
+        count = increment(bucket, name, 1) # [!code ++]
+# [!code ++]
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello x{}, {}!\n".format(count, name), "utf-8")) # [!code ++]
         OutgoingBody.finish(outgoingBody, None)
         # Set and send the HTTP response
         ResponseOutparam.set(response_out, Ok(outgoingResponse))
@@ -488,9 +471,7 @@ kind: Application
 metadata:
   name: http-hello-world
   annotations:
-//highlight-start
-    version: v0.0.3
-//highlight-end
+    version: v0.0.3 # Increment the version number # [!code ++]
     description: "HTTP hello world demo, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
     experimental: true
 spec:
@@ -508,26 +489,24 @@ spec:
             target: httpserver
             values:
               address: 0.0.0.0:8080
-//highlight-start
-        # The new key-value link configuration
-        - type: linkdef
-          properties:
-            target: keyvalue
-            values:
-              address: redis://127.0.0.1:6379
+        # The new key-value link configuration # [!code ++]
+        - type: linkdef # [!code ++]
+          properties: # [!code ++]
+            target: keyvalue # [!code ++]
+            values: # [!code ++]
+              address: redis://127.0.0.1:6379 # [!code ++]
 
     - name: httpserver
       type: capability
       properties:
         image: wasmcloud.azurecr.io/httpserver:0.19.1
         contract: wasmcloud:httpserver
-    # The new capability provider
-    - name: keyvalue
-      type: capability
-      properties:
-        image: wasmcloud.azurecr.io/kvredis:0.22.0
-        contract: wasmcloud:keyvalue
-//highlight-end
+    # The new capability provider # [!code ++]
+    - name: keyvalue # [!code ++]
+      type: capability # [!code ++]
+      properties: # [!code ++]
+        image: wasmcloud.azurecr.io/kvredis:0.22.0 # [!code ++]
+        contract: wasmcloud:keyvalue # [!code ++]
 ```
 
 For the last step, we can deploy the `v0.0.3` version of our application. Then, again, we can test our new functionality.

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -48,17 +48,17 @@ impl Guest for HttpServer {
         let response = OutgoingResponse::new(Fields::new());
         response.set_status_code(200).unwrap();
         let response_body = response.body().unwrap();
-        let name = match request // [!code ++]
-            .path_with_query() // [!code ++]
-            .unwrap() // [!code ++]
-            .split("=") // [!code ++]
-            .collect::<Vec<&str>>()[..] // [!code ++]
-        { // [!code ++]
-            // query string is "/?name=<name>" e.g. localhost:8080?name=Bob // [!code ++]
-            ["/?name", name] => name.to_string(), // [!code ++]
-            // query string is anything else or empty e.g. localhost:8080 // [!code ++]
-            _ => "World".to_string(), // [!code ++]
-        }; // [!code ++]
+        let name = match request // [!code ++:11]
+            .path_with_query()
+            .unwrap()
+            .split("=")
+            .collect::<Vec<&str>>()[..]
+        {
+            // query string is "/?name=<name>" e.g. localhost:8080?name=Bob
+            ["/?name", name] => name.to_string(),
+            // query string is anything else or empty e.g. localhost:8080
+            _ => "World".to_string(),
+        };
         response_body
             .write()
             .unwrap()
@@ -117,13 +117,13 @@ func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWrite
   http.StaticResponseOutparamSet(responseWriter, okResponse)
 }
 
-func getNameFromPath(path string) string { // [!code ++]
-  parts := strings.Split(path, "=") // [!code ++]
-  if len(parts) == 2 { // [!code ++]
-    return parts[1] // [!code ++]
-  } // [!code ++]
-  return "World" // [!code ++]
-} // [!code ++]
+func getNameFromPath(path string) string { // [!code ++:8]
+  parts := strings.Split(path, "=")
+  if len(parts) == 2 {
+    return parts[1]
+  }
+  return "World"
+}
 
 //go:generate wit-bindgen tiny-go wit --out-dir=gen --gofmt
 func main() {}
@@ -171,13 +171,13 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   ResponseOutparam.set(resp, { tag: "ok", val: outgoingResponse });
 }
 
-function getNameFromPath(path: string): string { // [!code ++]
-  const parts = path.split("="); // [!code ++]
-  if (parts.length == 2) { // [!code ++]
-    return parts[1]; // [!code ++]
-  } // [!code ++]
-  return "world"; // [!code ++]
-} // [!code ++]
+function getNameFromPath(path: string): string { // [!code ++:8]
+  const parts = path.split("=");
+  if (parts.length == 2) {
+    return parts[1];
+  }
+  return "world";
+}
 
 export const incomingHandler = {
   handle,
@@ -194,22 +194,25 @@ To perform the steps in this guide, you'll need you'll need to install [Python 3
 ```bash
 pip install componentize-py
 ```
-::: 
+
+:::
 
 Let's extend this application to do more than just say "hello." Using the `path_with_query` method on the incoming request, we can check the request for a name provided in a query string, and then return a greeting with that name. If there isn't one or the path isn't in the format we expect, we'll default to saying "hello world!". We'll also add a helper function to keep our code readable.
 
 :::info
 If you're using an IDE or would like to look at the imports, you can generate the bindings using `componentize-py` to get IDE suggestions and autofills.
+
 ```bash
 componentize-py bindings .
 ```
+
 :::
 
 ```python
 class IncomingHandler(exports.IncomingHandler):
     def handle(self, _: IncomingRequest, response_out: ResponseOutparam): # [!code --]
     def handle(self, request: IncomingRequest, response_out: ResponseOutparam): # [!code ++]
-        # Construct the HTTP response to send back 
+        # Construct the HTTP response to send back
         outgoingResponse = OutgoingResponse(Fields.from_list([]))
         # Set the status code to OK
         outgoingResponse.set_status_code(200)
@@ -223,25 +226,27 @@ class IncomingHandler(exports.IncomingHandler):
         # Set and send the HTTP response
         ResponseOutparam.set(response_out, Ok(outgoingResponse))
 
-def get_name_from_path(path: str) -> str: # [!code ++]
-    parts = path.split("=") # [!code ++]
-    if len(parts) == 2: # [!code ++]
-        return parts[-1] # [!code ++]
-    else: # [!code ++]
-        return "World" # [!code ++]
+def get_name_from_path(path: str) -> str: # [!code ++:6]
+    parts = path.split("=")
+    if len(parts) == 2:
+        return parts[-1]
+    else:
+        return "World"
 ```
 
   </TabItem>
 </Tabs>
 
 After changing the code, you can use `wash` to build the local actor:
+
 ```bash
 wash build
 ```
 
 ## Deploying your Actor
 
-Now that you've made an update to your actor, you can use wash to stop the previous version. You can supply either the name of the actor or the full 56 character signing key to the `wash stop actor` command. **wadm** will take care of starting the new local copy from the updated file. 
+Now that you've made an update to your actor, you can use wash to stop the previous version. You can supply either the name of the actor or the full 56 character signing key to the `wash stop actor` command. **wadm** will take care of starting the new local copy from the updated file.
+
 ```bash
 wash stop actor http-hello-world
 ```
@@ -262,6 +267,7 @@ Hello, Bob!
 To further enhance our application, let's add persistent storage to keep a record of each person that this application greeted. We'll use the key-value store capability for this, and just like HTTP server, you won't need to pick a library or a specific vendor implementation yet. You'll just need to add the capability to your actor, and then you can pick a capability provider at runtime.
 
 In your template, we already included the `wasi:keyvalue` interface for interacting with a key value store. We can also use the `wasi:logging` interface to log the name of each person we greet. Before you can use the functionality of those interfaces, you'll need to add a few imports to your `wit/hello.wit` file:
+
 ```wit
 package wasmcloud:hello;
 
@@ -277,7 +283,8 @@ world hello {
 <Tabs groupId="lang" queryString>
   <TabItem value="rust" label="Rust">
 
-Let's use the atomic increment function to keep track of how many times we've greeted each person. 
+Let's use the atomic increment function to keep track of how many times we've greeted each person.
+
 ```rust
     let name = match request
         .path_with_query()
@@ -291,23 +298,23 @@ Let's use the atomic increment function to keep track of how many times we've gr
         _ => "World".to_string(),
     };
 
-    wasi::logging::logging::log( // [!code ++]
-        wasi::logging::logging::Level::Info, // [!code ++]
-        "", // [!code ++]
-        &format!("Greeting {name}"), // [!code ++]
-    ); // [!code ++]
-// [!code ++]
-    let bucket = // [!code ++]
-        wasi::keyvalue::types::Bucket::open_bucket("").expect("failed to open empty bucket"); // [!code ++]
-    let count = wasi::keyvalue::atomic::increment(&bucket, &name, 1) // [!code ++]
-        .expect("failed to increment count"); // [!code ++]
-// [!code ++]
+    wasi::logging::logging::log( // [!code ++:11]
+        wasi::logging::logging::Level::Info,
+        "",
+        &format!("Greeting {name}"),
+    );
+
+    let bucket =
+        wasi::keyvalue::types::Bucket::open_bucket("").expect("failed to open empty bucket");
+    let count = wasi::keyvalue::atomic::increment(&bucket, &name, 1)
+        .expect("failed to increment count");
+
     response_body
         .write()
         .unwrap()
         .blocking_write_and_flush(format!("Hello x{count}, {name}!\n").as_bytes())
         .unwrap();
-  ```
+```
 
   </TabItem>
   <TabItem value="tinygo" label="TinyGo">
@@ -320,15 +327,15 @@ func (h HttpServer) Handle(request HttpRequest, responseWriter HttpResponseWrite
   headers := http.NewFields()
   httpResponse := http.NewOutgoingResponse(headers)
   httpResponse.SetStatusCode(200)
-// [!code ++]
-  name := getNameFromPath(request.PathWithQuery().Unwrap()) // [!code ++]
-// [!code ++]
-  http.WasiLoggingLoggingLog(http.WasiLoggingLoggingLevelInfo(), "", fmt.Sprintf("Greeting %s", name)) // [!code ++]
-  bucket := http.StaticBucketOpenBucket("").Unwrap() // [!code ++]
-  count := http.WasiKeyvalue0_1_0_AtomicIncrement(bucket, name, 1).Unwrap() // [!code ++]
 
+  name := getNameFromPath(request.PathWithQuery().Unwrap()) // [!code ++:7]
+
+  http.WasiLoggingLoggingLog(http.WasiLoggingLoggingLevelInfo(), "", fmt.Sprintf("Greeting %s", name))
+  bucket := http.StaticBucketOpenBucket("").Unwrap()
+  count := http.WasiKeyvalue0_1_0_AtomicIncrement(bucket, name, 1).Unwrap()
+
+  httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8(fmt.Sprintf("Hello x%d, %s!\n", count, name))).Unwrap()
   httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8("Hello from Go!\n")).Unwrap() // [!code --]
-  httpResponse.Body().Unwrap().Write().Unwrap().BlockingWriteAndFlush([]uint8(fmt.Sprintf("Hello x%d, %s!\n", count, name))).Unwrap() // [!code ++]
 
   // Send HTTP response
   okResponse := http.Ok[HttpOutgoingResponse, HttpError](httpResponse)
@@ -351,19 +358,14 @@ Simply including the import statement will allow the host to provider the functi
 :::
 
 ```typescript
-import {
-  IncomingRequest,
-  ResponseOutparam,
-  OutgoingResponse,
-  Fields,
-} from "wasi:http/types@0.2.0";
+import { IncomingRequest, ResponseOutparam, OutgoingResponse, Fields } from 'wasi:http/types@0.2.0';
 
-//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++]
-import { log } from "wasi:logging/logging"; // [!code ++]
-//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++]
-import { increment } from "wasi:keyvalue/atomic@0.1.0"; // [!code ++]
-//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++]
-import { Bucket } from "wasi:keyvalue/types@0.1.0"; // [!code ++]
+//@ts-expect-error -- these types aren't currently generated by JCO // [!code ++:6]
+import { log } from 'wasi:logging/logging';
+//@ts-expect-error -- these types aren't currently generated by JCO
+import { increment } from 'wasi:keyvalue/atomic@0.1.0';
+//@ts-expect-error -- these types aren't currently generated by JCO
+import { Bucket } from 'wasi:keyvalue/types@0.1.0';
 
 // Implementation of wasi-http incoming-handler
 //
@@ -376,24 +378,24 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
   let outgoingBody = outgoingResponse.body();
   // Create a stream for the response body
   let outputStream = outgoingBody.write();
-  // Write to the response stream // [!code ++]
-  const name = getNameFromPath(req.pathWithQuery() || "") // [!code ++]
-// [!code ++]
-  log("info", "", `Greeting ${name}`); // [!code ++]
-// [!code ++]
-  // Increment the bucket's count // [!code ++]
-  const bucket = Bucket.openBucket(""); // [!code ++]
-  const count = increment(bucket, name, 1); // [!code ++]
-// [!code ++]
-  outputStream.blockingWriteAndFlush( // [!code ++]
-    new Uint8Array(new TextEncoder().encode(`Hello x${count}, ${name}!\n`)) // [!code ++]
-  ); // [!code ++]
+  // Write to the response stream // [!code ++:12]
+  const name = getNameFromPath(req.pathWithQuery() || '');
+ 
+  log('info', '', `Greeting ${name}`);
+ 
+  // Increment the bucket's count
+  const bucket = Bucket.openBucket('');
+  const count = increment(bucket, name, 1);
+ 
+  outputStream.blockingWriteAndFlush(
+    new Uint8Array(new TextEncoder().encode(`Hello x${count}, ${name}!\n`)),
+  );
 
   // Set the status code for the response
   outgoingResponse.setStatusCode(200);
 
   // Set the created response
-  ResponseOutparam.set(resp, { tag: "ok", val: outgoingResponse });
+  ResponseOutparam.set(resp, { tag: 'ok', val: outgoingResponse });
 }
 ```
 
@@ -416,7 +418,7 @@ from hello.imports.logging import (log, Level) # [!code ++]
 
 class IncomingHandler(exports.IncomingHandler):
     def handle(self, request: IncomingRequest, response_out: ResponseOutparam):
-        # Construct the HTTP response to send back 
+        # Construct the HTTP response to send back
         outgoingResponse = OutgoingResponse(Fields.from_list([]))
         # Set the status code to OK
         outgoingResponse.set_status_code(200)
@@ -424,11 +426,11 @@ class IncomingHandler(exports.IncomingHandler):
 
         # Write our Hello message to the response body
         name = get_name_from_path(request.path_with_query())
-        log(Level.INFO, "", "Greeting {}".format(name)) # [!code ++]
-        bucket = Bucket.open_bucket("") # [!code ++]
-        count = increment(bucket, name, 1) # [!code ++]
-# [!code ++]
-        outgoingBody.write().blocking_write_and_flush(bytes("Hello x{}, {}!\n".format(count, name), "utf-8")) # [!code ++]
+        log(Level.INFO, "", "Greeting {}".format(name)) # [!code ++:5]
+        bucket = Bucket.open_bucket("")
+        count = increment(bucket, name, 1)
+
+        outgoingBody.write().blocking_write_and_flush(bytes("Hello x{}, {}!\n".format(count, name), "utf-8"))
         OutgoingBody.finish(outgoingBody, None)
         # Set and send the HTTP response
         ResponseOutparam.set(response_out, Ok(outgoingResponse))
@@ -436,7 +438,6 @@ class IncomingHandler(exports.IncomingHandler):
 
   </TabItem>
 </Tabs>
-
 
 ### Deploying a Key-Value Store Provider
 
@@ -472,7 +473,7 @@ metadata:
   name: http-hello-world
   annotations:
     version: v0.0.3 # Increment the version number # [!code ++]
-    description: "HTTP hello world demo, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
+    description: 'HTTP hello world demo, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
     experimental: true
 spec:
   components:
@@ -489,24 +490,24 @@ spec:
             target: httpserver
             values:
               address: 0.0.0.0:8080
-        # The new key-value link configuration # [!code ++]
-        - type: linkdef # [!code ++]
-          properties: # [!code ++]
-            target: keyvalue # [!code ++]
-            values: # [!code ++]
-              address: redis://127.0.0.1:6379 # [!code ++]
+        # The new key-value link configuration # [!code ++:6]
+        - type: linkdef
+          properties:
+            target: keyvalue
+            values:
+              address: redis://127.0.0.1:6379
 
     - name: httpserver
       type: capability
       properties:
         image: wasmcloud.azurecr.io/httpserver:0.19.1
         contract: wasmcloud:httpserver
-    # The new capability provider # [!code ++]
-    - name: keyvalue # [!code ++]
-      type: capability # [!code ++]
-      properties: # [!code ++]
-        image: wasmcloud.azurecr.io/kvredis:0.22.0 # [!code ++]
-        contract: wasmcloud:keyvalue # [!code ++]
+    # The new capability provider # [!code ++:6]
+    - name: keyvalue
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/kvredis:0.22.0
+        contract: wasmcloud:keyvalue
 ```
 
 For the last step, we can deploy the `v0.0.3` version of our application. Then, again, we can test our new functionality.

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -421,7 +421,7 @@ spec:
 
 WebAssembly can be easily scaled due to its small size, portability, and [wasmtime](https://wasmtime.dev/)'s ability to efficiently instantiate multiple instances of a single WebAssembly component. We leverage these aspects to make it simple to scale your applications with wasmCloud. Components only use resources when they're actively processing requests, so you can specify the number of replicas you want to run and wasmCloud will automatically scale up and down to meet demand. Let's scale up our hello world application to 50 replicas by editing `wadm.yaml`:
 
-```yaml
+```yaml {17-19}
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
@@ -438,11 +438,9 @@ spec:
         image: wasmcloud.azurecr.io/hello:0.1.7
       traits:
         - type: spreadscaler
-        // highlight-start
           properties:
             # Update the scale to 50
             replicas: 50
-        // highlight-end
 ```
 
 Now your hello application is ready to deploy v0.0.2 with 50 replicas, meaning it can handle up to 50 concurrent incoming HTTP requests. Just run `wash app deploy wadm.yaml` again, wasmCloud will be configured to automatically scale your actor component based on incoming load. It's a little easier to visualize this in the wasmCloud dashboard, so let's take a look at that next.

--- a/languages/smithy.tmLanguage.json
+++ b/languages/smithy.tmLanguage.json
@@ -1,0 +1,565 @@
+{
+  "name": "Smithy",
+  "id": "smithy",
+  "aliases": ["smithy"],
+  "fileTypes": ["smithy"],
+  "scopeName": "source.smithy",
+  "uuid": "9c3e617f-4d4a-4370-9194-2e82173c1610",
+  "foldingStartMarker": "(\\{|\\[)\\s*",
+  "foldingStopMarker": "\\s*(\\}|\\])",
+  "patterns": [
+    {
+      "include": "#comment"
+    },
+    {
+      "name": "meta.keyword.statement.control.smithy",
+      "begin": "^(\\$)([A-Z-a-z_][A-Z-a-z0-9_]*)(:)\\s*",
+      "end": "\\n",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.control.smithy"
+        },
+        "2": {
+          "name": "support.type.property-name.smithy"
+        },
+        "3": {
+          "name": "punctuation.separator.dictionary.pair.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value"
+        },
+        {
+          "match": "[^\\n]",
+          "name": "invalid.illegal.control.smithy"
+        }
+      ]
+    },
+    {
+      "name": "meta.keyword.statement.metadata.smithy",
+      "begin": "^(metadata)\\s+(.+)\\s*(=)\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        },
+        "2": {
+          "name": "variable.other.smithy"
+        },
+        "3": {
+          "name": "keyword.operator.smithy"
+        }
+      },
+      "end": "\\n",
+      "patterns": [
+        {
+          "include": "#value"
+        }
+      ]
+    },
+    {
+      "name": "meta.keyword.statement.namespace.smithy",
+      "begin": "^(namespace)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        }
+      },
+      "end": "\\n",
+      "patterns": [
+        {
+          "match": "[A-Z-a-z_][A-Z-a-z0-9_]*(\\.[A-Z-a-z_][A-Z-a-z0-9_]*)*",
+          "name": "entity.name.type.smithy"
+        },
+        {
+          "match": "[^\\n]",
+          "name": "invalid.illegal.namespace.smithy"
+        }
+      ]
+    },
+    {
+      "name": "meta.keyword.statement.use.smithy",
+      "begin": "^(use)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        }
+      },
+      "end": "\\n",
+      "patterns": [
+        {
+          "match": "[A-Z-a-z_][A-Z-a-z0-9_]*(\\.[A-Z-a-z_][A-Z-a-z0-9_]*)*#[A-Z-a-z_][A-Z-a-z0-9_]*(\\.[A-Z-a-z_][A-Z-a-z0-9_]*)*",
+          "name": "entity.name.type.smithy"
+        },
+        {
+          "match": "[^\\n]",
+          "name": "invalid.illegal.use.smithy"
+        }
+      ]
+    },
+    {
+      "include": "#trait"
+    },
+    {
+      "name": "meta.keyword.statement.shape.smithy",
+      "begin": "^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|union|service|operation|resource|enum|intEnum)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)\\s+(with)\\s+(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        },
+        "2": {
+          "name": "entity.name.type.smithy"
+        },
+        "3": {
+          "name": "keyword.statement.with.smithy"
+        },
+        "4": {
+          "name": "punctuation.definition.array.begin.smithy"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#identifier",
+          "name": "entity.name.type.smithy"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.array.smithy"
+        }
+      ]
+    },
+    {
+      "name": "meta.keyword.statement.shape.smithy",
+      "match": "^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|union|service|operation|resource|enum|intEnum)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)",
+      "captures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        },
+        "2": {
+          "name": "entity.name.type.smithy"
+        }
+      }
+    },
+    {
+      "name": "meta.keyword.statement.shape.smithy",
+      "begin": "^(structure)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)(?:\\s+(for)\\s+([0-9a-zA-Z\\.#-]+))?\\s+(with)\\s+(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        },
+        "2": {
+          "name": "entity.name.type.smithy"
+        },
+        "3": {
+          "name": "keyword.statement.for-resource.smithy"
+        },
+        "4": {
+          "name": "entity.name.type.smithy"
+        },
+        "5": {
+          "name": "keyword.statement.with.smithy"
+        },
+        "6": {
+          "name": "punctuation.definition.array.begin.smithy"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#identifier",
+          "name": "entity.name.type.smithy"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.array.smithy"
+        }
+      ]
+    },
+    {
+      "name": "meta.keyword.statement.shape.smithy",
+      "match": "^(structure)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)(?:\\s+(for)\\s+([0-9a-zA-Z\\.#-]+))?",
+      "captures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        },
+        "2": {
+          "name": "entity.name.type.smithy"
+        },
+        "3": {
+          "name": "keyword.statement.for-resource.smithy"
+        },
+        "4": {
+          "name": "entity.name.type.smithy"
+        }
+      }
+    },
+    {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.begin.smithy"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.end.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#shape_inner"
+        }
+      ]
+    },
+    {
+      "name": "meta.keyword.statement.apply.smithy",
+      "begin": "^(apply)\\s+",
+      "end": "\\n",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#trait"
+        },
+        {
+          "include": "#shapeid"
+        },
+        {
+          "match": "[^\\n]",
+          "name": "invalid.illegal.apply.smithy"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "with_statement": {
+      "begin": "(with)\\s+(\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.statement.with.smithy"
+        },
+        "2": {
+          "name": "punctuation.definition.array.begin.smithy"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "match": ",",
+          "name": "punctuation.separator.array.smithy"
+        },
+        {
+          "include": "#identifier"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "comment": {
+      "patterns": [
+        {
+          "include": "#doc_comment"
+        },
+        {
+          "include": "#line_comment"
+        }
+      ]
+    },
+    "doc_comment": {
+      "match": "(///.*)",
+      "name": "comment.block.documentation.smithy"
+    },
+    "line_comment": {
+      "match": "(//.*)",
+      "name": "comment.line.double-slash.smithy"
+    },
+    "trait": {
+      "patterns": [
+        {
+          "name": "meta.keyword.statement.trait.smithy",
+          "begin": "(@)([0-9a-zA-Z\\.#-]+)(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.annotation.smithy"
+            },
+            "2": {
+              "name": "storage.type.annotation.smithy"
+            },
+            "3": {
+              "name": "punctuation.definition.dictionary.begin.smithy"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.dictionary.end.smithy"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#object_inner"
+            },
+            {
+              "include": "#value"
+            }
+          ]
+        },
+        {
+          "name": "meta.keyword.statement.trait.smithy",
+          "match": "(@)([0-9a-zA-Z\\.#-]+)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.annotation.smithy"
+            },
+            "2": {
+              "name": "storage.type.annotation.smithy"
+            }
+          }
+        }
+      ]
+    },
+    "value": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#object"
+        }
+      ]
+    },
+    "array": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.begin.smithy"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.smithy"
+        }
+      },
+      "name": "meta.structure.array.smithy",
+      "patterns": [
+        {
+          "include": "#value"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.array.smithy"
+        },
+        {
+          "match": "[^\\s\\]]",
+          "name": "invalid.illegal.array.smithy"
+        }
+      ]
+    },
+    "keywords": {
+      "match": "\\b(?:true|false|null)\\b",
+      "name": "constant.language.smithy"
+    },
+    "number": {
+      "match": "(?x:            # turn on extended mode\n                         -?         # an optional minus\n                         (?:\n                           0        # a zero\n                           |        # ...or...\n                           [1-9]    # a 1-9 character\n                           \\d*      # followed by zero or more digits\n                         )\n                         (?:\n                           (?:\n                             \\.     # a period\n                             \\d+    # followed by one or more digits\n                           )?\n                           (?:\n                             [eE]   # an e character\n                             [+-]?  # followed by an option +/-\n                             \\d+    # followed by one or more digits\n                           )?       # make exponent optional\n                         )?         # make decimal portion optional\n                       )",
+      "name": "constant.numeric.smithy"
+    },
+    "object": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.begin.smithy"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.end.smithy"
+        }
+      },
+      "name": "meta.structure.dictionary.smithy",
+      "patterns": [
+        {
+          "include": "#object_inner"
+        }
+      ]
+    },
+    "object_inner": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#string_key"
+        },
+        {
+          "match": ":",
+          "name": "punctuation.separator.dictionary.key-value.smithy"
+        },
+        {
+          "match": "=",
+          "name": "keyword.operator.smithy"
+        },
+        {
+          "name": "meta.structure.dictionary.value.smithy",
+          "include": "#value"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.dictionary.pair.smithy"
+        }
+      ]
+    },
+    "shape_inner": {
+      "patterns": [
+        {
+          "include": "#trait"
+        },
+        {
+          "match": ":=",
+          "name": "punctuation.separator.dictionary.inline-struct.smithy"
+        },
+        {
+          "include": "#with_statement"
+        },
+        {
+          "include": "#elided_target"
+        },
+        {
+          "include": "#object_inner"
+        }
+      ]
+    },
+    "string_key": {
+      "patterns": [
+        {
+          "include": "#identifier_key"
+        },
+        {
+          "include": "#dquote_key"
+        }
+      ]
+    },
+    "identifier_key": {
+      "name": "support.type.property-name.smithy",
+      "match": "[A-Z-a-z0-9_\\.#$]+(?=\\s*:)"
+    },
+    "dquote_key": {
+      "name": "support.type.property-name.smithy",
+      "match": "\".*\"(?=\\s*:)"
+    },
+    "string": {
+      "patterns": [
+        {
+          "include": "#textblock"
+        },
+        {
+          "include": "#dquote"
+        },
+        {
+          "include": "#shapeid"
+        }
+      ]
+    },
+    "textblock": {
+      "name": "string.quoted.double.smithy",
+      "begin": "\"\"\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.smithy"
+        }
+      },
+      "end": "\"\"\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.smithy"
+        }
+      ]
+    },
+    "dquote": {
+      "name": "string.quoted.double.smithy",
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.smithy"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.smithy"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.smithy"
+        }
+      ]
+    },
+    "identifier": {
+      "name": "entity.name.type.smithy",
+      "match": "[A-Z-a-z_][A-Z-a-z0-9_]*"
+    },
+    "shapeid": {
+      "name": "entity.name.type.smithy",
+      "match": "[A-Z-a-z_][A-Z-a-z0-9_\\.#$]*"
+    },
+    "elided_target": {
+      "match": "(\\$)([A-Z-a-z0-9_\\.#$]+)",
+      "captures": {
+        "1": {
+          "name": "keyword.statement.elision.smithy"
+        },
+        "2": {
+          "name": "support.type.property-name.smithy"
+        }
+      }
+    }
+  }
+}

--- a/languages/wit.tmLanguage.json
+++ b/languages/wit.tmLanguage.json
@@ -1,0 +1,793 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "WebAssembly Interface Types",
+  "id": "wit",
+  "aliases": ["wit"],
+  "patterns": [
+    {
+      "include": "#declaration"
+    },
+    {
+      "include": "#comment"
+    }
+  ],
+  "repository": {
+    "declaration": {
+      "patterns": [
+        {
+          "include": "#package-declaration"
+        },
+        {
+          "include": "#use-declaration"
+        },
+        {
+          "include": "#include-declaration"
+        },
+        {
+          "include": "#type-alias-declaration"
+        },
+        {
+          "include": "#world-interface-resource-record-declaration"
+        },
+        {
+          "include": "#variant-enum-flags-declaration"
+        },
+        {
+          "include": "#union-declaration"
+        },
+        {
+          "include": "#constructor-declaration"
+        },
+        {
+          "include": "#function-declaration"
+        },
+        {
+          "include": "#value-declaration"
+        },
+        {
+          "include": "#importexport-interface-id-declaration"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "package-declaration": {
+      "comment": "Example: `package wasi:clocks@1.2.0`",
+      "begin": "\\b(package)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.package.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#global-id"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "use-declaration": {
+      "comment": "Example: `use wasi:http/types@1.0.0 as http-types1`",
+      "begin": "\\b(use)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.use.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#as-id"
+        },
+        {
+          "include": "#global-id"
+        },
+        {
+          "include": "#unpack"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "include-declaration": {
+      "comment": "Example: `include my-using-a with { a as b }`",
+      "begin": "\\b(include)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.include.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "match": "with",
+          "name": "keyword.other.with.wit"
+        },
+        {
+          "include": "#global-id"
+        },
+        {
+          "include": "#unpack"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "type-alias-declaration": {
+      "comment": "Example: `type t2 = tuple<u32, u64>`",
+      "begin": "\\b(type)\\s+([a-zA-Z_%][a-zA-Z0-9\\-_]*)\\s*(=)\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.type.wit"
+        },
+        "2": {
+          "name": "entity.name.type.wit"
+        },
+        "3": {
+          "name": "punctuation.separator.equals"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#type"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "world-interface-resource-record-declaration": {
+      "begin": "\\b(world|interface|resource|record)\\s+([a-zA-Z_%][a-zA-Z0-9\\-_]*)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.wit"
+        },
+        "2": {
+          "name": "entity.name.type.wit"
+        }
+      },
+      "end": "(?<=[\\}])|(?=[;,\\]\\)}>])|(?=^\\s*(export|import|include|package|type|use|enum|flags|interface|record|resource|union|variant|world))",
+      "patterns": [
+        {
+          "include": "#block-content"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "variant-enum-flags-declaration": {
+      "begin": "\\b(variant|enum|flags)\\s+([a-zA-Z_%][a-zA-Z0-9\\-_]*)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.wit"
+        },
+        "2": {
+          "name": "entity.name.type.wit"
+        }
+      },
+      "end": "(?<=[\\}])|(?=[;,\\]\\)}>])|(?=^\\s*(export|import|include|package|type|use|enum|flags|interface|record|resource|union|variant|world))",
+      "patterns": [
+        {
+          "begin": "\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.curlybrace.open.wit"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.curlybrace.close.wit"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "Example: http-types1",
+              "match": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)",
+              "captures": {
+                "1": {
+                  "name": "variable.other.constant.wit"
+                }
+              }
+            },
+            {
+              "include": "#tuple"
+            },
+            {
+              "match": ",|;",
+              "name": "punctuation.separator.comma.wit"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "union-declaration": {
+      "begin": "\\b(union)\\s+([a-zA-Z_%][a-zA-Z0-9\\-_]*)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.wit"
+        },
+        "2": {
+          "name": "entity.name.type.wit"
+        }
+      },
+      "end": "(?<=[\\}])|(?=[;,\\]\\)}>])|(?=^\\s*(export|import|include|package|type|use|enum|flags|interface|record|resource|union|variant|world))",
+      "patterns": [
+        {
+          "begin": "\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.curlybrace.open.wit"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.curlybrace.close.wit"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#type"
+            },
+            {
+              "match": ",|;",
+              "name": "punctuation.separator.comma.wit"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "constructor-declaration": {
+      "comment": "Example: `constructor(a1: bool)`",
+      "begin": "\\b(constructor)\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.constructor.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#tuple"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "function-declaration": {
+      "comment": "Example: `export run: func(a1: bool)`",
+      "begin": "\\b((import|export)\\s+)?([a-zA-Z_%][a-zA-Z0-9\\-_]*)(?=\\s*:\\s*(static\\s+)?func)",
+      "beginCaptures": {
+        "2": {
+          "name": "keyword.other.importexport.wit"
+        },
+        "3": {
+          "name": "entity.name.function.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#type-annotation"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "value-declaration": {
+      "comment": "Example: `export message: string`",
+      "begin": "\\b((import|export)\\s+)?([a-zA-Z_%][a-zA-Z0-9\\-_]*)(?=\\s*:\\s+)",
+      "beginCaptures": {
+        "2": {
+          "name": "keyword.other.importexport.wit"
+        },
+        "3": {
+          "name": "variable.other.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#type-annotation"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "importexport-interface-id-declaration": {
+      "comment": "Example: `export wasi:http/types`",
+      "begin": "\\b((import|export)\\s+)",
+      "beginCaptures": {
+        "2": {
+          "name": "keyword.other.importexport.wit"
+        },
+        "3": {
+          "name": "variable.other.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#global-id"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+
+    "type": {
+      "patterns": [
+        {
+          "include": "#discard-type"
+        },
+        {
+          "include": "#function-type"
+        },
+        {
+          "include": "#interface-type"
+        },
+        {
+          "include": "#named-type"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "discard-type": {
+      "match": "_(?=[^a-zA-Z0-9_])",
+      "name": "keyword.other.discard.wit"
+    },
+    "function-type": {
+      "comment": "Example: `static func(a1: bool) -> u32`",
+      "begin": "(\\bstatic\\s+)?\\b(func)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.static.wit"
+        },
+        "2": {
+          "name": "keyword.other.func.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#return-type-annotation"
+        },
+        {
+          "include": "#tuple"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "interface-type": {
+      "comment": "Example: `interface { a: u8 }`",
+      "begin": "\\b(interface)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.interface.wit"
+        }
+      },
+      "end": "(?<=[\\}])|(?=[;,\\]\\)}>])|(?=^\\s*(export|import|include|package|type|use|enum|flags|interface|record|resource|union|variant|world))",
+      "patterns": [
+        {
+          "include": "#block-content"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "named-type": {
+      "comment": "Example: `list<u8>`",
+      "begin": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#type-parameter-list"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+
+    "block-content": {
+      "comment": "Example: `{ msg: string }`",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.open.wit"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.close.wit"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#declaration"
+        },
+        {
+          "match": ",|;",
+          "name": "punctuation.separator.comma.wit"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "type-parameter-list": {
+      "comment": "Example: `<u8, string>`",
+      "begin": "\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.anglebracket.open.wit"
+        }
+      },
+      "end": "\\>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.anglebracket.close.wit"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#named-parameter"
+        },
+        {
+          "include": "#type"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.comma.wit"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "tuple": {
+      "comment": "Example: `(a1: bool, a2: u32, u32)`",
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.parenthesis.open.wit"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.parenthesis.close.wit"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#named-parameter"
+        },
+        {
+          "include": "#type"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.comma.wit"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "named-parameter": {
+      "comment": "Example: `a1: bool`",
+      "begin": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)(?=\\s*:)",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.parameter.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#type-annotation"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+
+    "type-annotation": {
+      "comment": "Example: `: list<u8>`",
+      "begin": "(:)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.separator.colon.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#type"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "return-type-annotation": {
+      "comment": "Example: `-> u32`",
+      "begin": "->",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.arrow.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#tuple"
+        },
+        {
+          "include": "#type"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+
+    "unpack": {
+      "comment": "Example: `{ long-name as ln, abc }`",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.open.wit"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.curlybrace.close.wit"
+        }
+      },
+      "patterns": [
+        {
+          "match": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)(\\s+(as)\\s+([a-zA-Z_%][a-zA-Z0-9\\-_]*))?",
+          "captures": {
+            "1": {
+              "name": "variable.other.id.wit"
+            },
+            "3": {
+              "name": "keyword.other.as.wit"
+            },
+            "4": {
+              "name": "variable.other.id.wit"
+            }
+          }
+        },
+        {
+          "match": ",|;",
+          "name": "punctuation.separator.comma.wit"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "as-id": {
+      "comment": "Example: as http-types1",
+      "begin": "\\b(as)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.as.wit"
+        }
+      },
+      "end": "(?=[\n\r;,\\]\\)}>])",
+      "patterns": [
+        {
+          "include": "#local-id"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "local-id": {
+      "comment": "Example: http-types1",
+      "match": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)",
+      "captures": {
+        "1": {
+          "name": "variable.other.id.wit"
+        }
+      }
+    },
+    "global-id": {
+      "comment": "Example: wasi:http/types@1.0.0",
+      "patterns": [
+        {
+          "match": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)(\\:)([a-zA-Z_%][a-zA-Z0-9\\-_]*)((/)([a-zA-Z_%][a-zA-Z0-9\\-_]*))?((@)([a-zA-Z0-9\\-_\\.\\+]*[a-zA-Z0-9_]))?",
+          "captures": {
+            "1": {
+              "name": "string.unquoted.package-namespace.wit"
+            },
+            "2": {
+              "name": "string.unquoted.colon.wit"
+            },
+            "3": {
+              "name": "string.unquoted.package-name.wit"
+            },
+            "5": {
+              "name": "string.unquoted.slash.wit"
+            },
+            "6": {
+              "name": "string.unquoted.interface-name.wit"
+            },
+            "8": {
+              "name": "string.unquoted.at.wit"
+            },
+            "9": {
+              "name": "string.unquoted.package-version.wit"
+            }
+          }
+        },
+        {
+          "match": "([a-zA-Z_%][a-zA-Z0-9\\-_]*)",
+          "captures": {
+            "1": {
+              "name": "variable.other.id.wit"
+            }
+          }
+        }
+      ]
+    },
+
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.block.wit",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "include": "#markdown"
+            }
+          ]
+        },
+        {
+          "name": "comment.block.documentation.wit",
+          "begin": "///",
+          "end": "$",
+          "patterns": [
+            {
+              "include": "#markdown"
+            }
+          ]
+        },
+        {
+          "name": "comment.line.double-slash.wit",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "include": "#markdown"
+            }
+          ]
+        }
+      ]
+    },
+    "markdown": {
+      "patterns": [
+        {
+          "match": "\\G\\s*(#+.*)$",
+          "captures": {
+            "1": {
+              "name": "markup.heading.markdown"
+            }
+          }
+        },
+        {
+          "match": "\\G\\s*((\\>)\\s+)+",
+          "captures": {
+            "2": {
+              "name": "punctuation.definition.quote.begin.markdown"
+            }
+          }
+        },
+        {
+          "match": "\\G\\s*(\\-)\\s+",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown"
+            }
+          }
+        },
+        {
+          "match": "\\G\\s*(([0-9]+\\.)\\s+)",
+          "captures": {
+            "1": {
+              "name": "markup.list.numbered.markdown"
+            },
+            "2": {
+              "name": "punctuation.definition.list.begin.markdown"
+            }
+          }
+        },
+        {
+          "match": "(`.*?`)",
+          "captures": {
+            "1": {
+              "name": "markup.italic.markdown"
+            }
+          }
+        },
+        {
+          "match": "\\b(__.*?__)",
+          "captures": {
+            "1": {
+              "name": "markup.bold.markdown"
+            }
+          }
+        },
+        {
+          "match": "\\b(_.*?_)",
+          "captures": {
+            "1": {
+              "name": "markup.italic.markdown"
+            }
+          }
+        },
+        {
+          "match": "(\\*\\*.*?\\*\\*)",
+          "captures": {
+            "1": {
+              "name": "markup.bold.markdown"
+            }
+          }
+        },
+        {
+          "match": "(\\*.*?\\*)",
+          "captures": {
+            "1": {
+              "name": "markup.italic.markdown"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scopeName": "source.wit"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,26 @@
 {
-  "name": "wasmcloud-website",
+  "name": "wasmcloud.com",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wasmcloud-website",
+      "name": "wasmcloud.com",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@docusaurus/core": "^3.1.1",
         "@docusaurus/plugin-google-analytics": "^3.1.1",
         "@docusaurus/preset-classic": "^3.1.1",
         "@mdx-js/react": "^3.0.0",
+        "@shikijs/rehype": "^1.1.2",
+        "@shikijs/transformers": "^1.1.2",
         "clsx": "^2.0.0",
-        "prism-react-renderer": "^2.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hubspot-form": "^1.3.7",
-        "react-player": "^2.13.0"
+        "react-player": "^2.13.0",
+        "shiki": "^1.1.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.1.1",
@@ -3867,6 +3870,32 @@
       "version": "1.0.0-next.23",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
       "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg=="
+    },
+    "node_modules/@shikijs/core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.1.2.tgz",
+      "integrity": "sha512-ERVzNQz88ZkDqUpWeC57Kp+Kmx5RjqeDBR1M8AGWGom4yrkITiTfXCGmjchlDSw12MhDTuPYR4HVFW8uT61RaQ=="
+    },
+    "node_modules/@shikijs/rehype": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-1.1.2.tgz",
+      "integrity": "sha512-h90ycM3VFkI6bLD/WgUuxMR9yqc0ejWWiA//T4f4mqoIPW3bVW3uSB/0eJRM6WbP8fEaOAnA7mbKGsoTDGf4Ng==",
+      "dependencies": {
+        "@shikijs/transformers": "1.1.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.0",
+        "shiki": "1.1.2",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.1.2.tgz",
+      "integrity": "sha512-tldkUMW7RBkU2F6eXbiRMw3ja+hQer1EjwhD2NGOv6K0pgZdVp3JKjU8uisRtg65tyBqrVHq7zlLHVk7EKmUZA==",
+      "dependencies": {
+        "shiki": "1.1.2"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -8052,6 +8081,18 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.0.tgz",
+      "integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14645,6 +14686,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/shiki": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.1.2.tgz",
+      "integrity": "sha512-qNzFwTv5uhEDNUIwp7wHjsrffVeLbmOgWnM5mZZhoiz7G2qAUvqVfUzuWfieD45/YAKipzCtdV9SndacKtABow==",
+      "dependencies": {
+        "@shikijs/core": "1.1.2"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -15382,9 +15431,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -16404,6 +16453,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/docusaurus-plugin-shiki-rehype": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "dependencies": {
+        "@shikijs/rehype": "^1.1.2",
+        "shiki": "^1.1.2"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.2",
+        "typescript": "^5.3.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "wasmcloud-website",
+  "name": "wasmcloud.com",
   "version": "0.1.0",
-  "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start --config docusaurus.config.ts",
@@ -18,12 +18,14 @@
     "@docusaurus/plugin-google-analytics": "^3.1.1",
     "@docusaurus/preset-classic": "^3.1.1",
     "@mdx-js/react": "^3.0.0",
+    "@shikijs/rehype": "^1.1.2",
+    "@shikijs/transformers": "^1.1.2",
     "clsx": "^2.0.0",
-    "prism-react-renderer": "^2.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hubspot-form": "^1.3.7",
-    "react-player": "^2.13.0"
+    "react-player": "^2.13.0",
+    "shiki": "^1.1.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.1.1",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,6 +12,9 @@
   --ifm-spacing-md: 1rem;
   --ifm-spacing-lg: 2rem;
   --ifm-spacing-xl: 5rem;
+  --wasmcloud-code-highlight-hue: 180;
+  --wasmcloud-code-diff-add-hue: 145;
+  --wasmcloud-code-diff-remove-hue: 5;
 }
 
 /* You can override the default Infima variables here. */
@@ -27,6 +30,11 @@ html[data-theme='light'] {
   --ifm-menu-color-active: #155642;
   --ifm-font-color-base-inverse: #fff;
   --ifm-background-color: #ffffff;
+  --wasmcloud-code-highlight: hsl(var(--wasmcloud-code-highlight-hue), 100%, 95%);
+  --wasmcloud-code-diff-add: hsl(var(--wasmcloud-code-diff-add-hue), 50%, 55%);
+  --wasmcloud-code-diff-add-bg: hsl(var(--wasmcloud-code-diff-add-hue), 100%, 95%);
+  --wasmcloud-code-diff-remove: hsl(var(--wasmcloud-code-diff-remove-hue), 50%, 55%);
+  --wasmcloud-code-diff-remove-bg: hsl(var(--wasmcloud-code-diff-remove-hue), 100%, 95%);
   --header-hero-background: linear-gradient(
     180deg,
     #768692 1.02%,
@@ -48,6 +56,11 @@ html[data-theme='dark'] {
   --ifm-color-primary-lighter: #00c389;
   --ifm-color-primary-lightest: #0c2027;
   --docusaurus-highlighted-code-line-bg: rgba(0, 195, 137, 0.2);
+  --wasmcloud-code-highlight: hsl(var(--wasmcloud-code-highlight-hue), 100%, 13%);
+  --wasmcloud-code-diff-add: hsl(var(--wasmcloud-code-diff-add-hue), 100%, 75%);
+  --wasmcloud-code-diff-add-bg: hsl(var(--wasmcloud-code-diff-add-hue), 100%, 12%);
+  --wasmcloud-code-diff-remove: hsl(var(--wasmcloud-code-diff-remove-hue), 100%, 75%);
+  --wasmcloud-code-diff-remove-bg: hsl(var(--wasmcloud-code-diff-remove-hue), 100%, 12%);
   --ifm-menu-color-active: #00c389;
   --ifm-background-color: #000000;
   --ifm-footer-background-color: #0c2027;
@@ -57,6 +70,101 @@ html[data-theme='dark'] {
   --ifm-navbar-shadow: 0px 1px 0px 0px rgba(255, 255, 255, 0.5), 0px 3px 3px 0px rgba(0, 0, 0, 0.5);
   --docsearch-modal-background: #000;
 }
+
+/* Shiki Styles */
+*,
+*::before,
+*::after {
+  --shiki-dark: var(--ifm-pre-color);
+  --shiki-dark-bg: var(--ifm-color-emphasis-100);
+}
+
+[data-theme='dark'] .shiki {
+  background-color: var(--shiki-dark-bg) !important;
+}
+
+[data-theme='dark'] .shiki,
+[data-theme='dark'] .shiki span {
+  color: var(--shiki-dark) !important;
+}
+
+.shiki code {
+  /* display as flex-column to remove gap from line-breaks */
+  display: flex;
+  flex-direction: column;
+  width: min-content;
+  min-width: 100%;
+}
+
+.shiki .line:not(:last-child):empty::after {
+  /* display additional space so that empty lines don't collapse */
+  /* note that this is only visual and content does not get copied */
+  content: ' ';
+}
+
+/* highlighted */
+.shiki .line.highlighted {
+  position: relative;
+  display: inline-block;
+  margin: 0 calc(var(--ifm-pre-padding) * -1);
+  padding: 0 var(--ifm-pre-padding);
+  width: calc(100% + calc(var(--ifm-pre-padding) * 2));
+}
+
+.shiki .line.highlighted {
+  background-color: var(--wasmcloud-code-highlight);
+}
+
+/* diff */
+.shiki .line.diff {
+  position: relative;
+  display: inline-block;
+  margin: 0 calc(var(--ifm-pre-padding) * -1);
+  padding: 0 var(--ifm-pre-padding);
+  width: calc(100% + calc(var(--ifm-pre-padding) * 2));
+}
+
+.shiki .line.diff::before {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  padding: 0 0.5em 0 0.2em;
+}
+
+.shiki .line.diff.add {
+  background-color: var(--wasmcloud-code-diff-add-bg);
+}
+.shiki .line.diff.add::before {
+  color: var(--wasmcloud-code-diff-add);
+  content: '+';
+}
+
+.shiki .line.diff.remove {
+  background-color: var(--wasmcloud-code-diff-remove-bg);
+  user-select: none;
+}
+.shiki .line.diff.remove::before {
+  color: var(--wasmcloud-code-diff-remove);
+  content: '-';
+}
+
+/* focus */
+.shiki:has(.focused) .line:not(.focused) {
+  filter: blur(0.095rem);
+  opacity: 0.4;
+  transition: filter 0.35s, opacity 0.35s;
+}
+.shiki:has(.focused):hover .line:not(.focused) {
+  filter: blur(0);
+  opacity: 1;
+}
+
+.shiki .line.focused {
+  opacity: 1;
+}
+
+/* End Shiki Styles */
 
 .footer--dark {
   background-color: #081317; /* the theme sucks for this */

--- a/src/theme/MDXComponents/Code/CodeBlock.module.css
+++ b/src/theme/MDXComponents/Code/CodeBlock.module.css
@@ -1,0 +1,51 @@
+.CodeBlock {
+  position: relative;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--ifm-color-emphasis-700);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  background-color: var(--ifm-color-emphasis-100);
+  font-size: calc(var(--ifm-code-font-size) * 0.8);
+  font-weight: 500;
+  padding: 0.5em var(--ifm-pre-padding);
+  border-top-left-radius: var(--ifm-pre-border-radius);
+  border-top-right-radius: var(--ifm-pre-border-radius);
+}
+
+.button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--ifm-color-emphasis-700);
+  border: 1.4px solid var(--ifm-color-emphasis-700);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.CodeBlock:hover .button {
+  opacity: 0.4;
+}
+
+.CodeBlock:hover .button:focus-visible,
+.CodeBlock:hover .button:hover {
+  opacity: 1;
+}
+
+.content {
+  position: relative;
+}
+
+.header + .content .pre {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/src/theme/MDXComponents/Code/index.tsx
+++ b/src/theme/MDXComponents/Code/index.tsx
@@ -1,0 +1,67 @@
+import type { ComponentProps } from 'react';
+import React from 'react';
+import CopyButton from '@theme/CodeBlock/CopyButton';
+import type { Props } from '@theme/MDXComponents/Code';
+import codeBlockStyles from './CodeBlock.module.css';
+import clsx from 'clsx';
+
+function shouldBeInline(props: Props): boolean {
+  return (
+    // empty code blocks have no props.children,
+    // see https://github.com/facebook/docusaurus/pull/9704
+    typeof props.children !== 'undefined' &&
+    React.Children.toArray(props.children).every(
+      (el) => typeof el === 'string' && !el.includes('\n'),
+    )
+  );
+}
+
+function getTextForCopy(node: React.ReactNode): string {
+  if (node === null) return '';
+
+  switch (typeof node) {
+    case 'string':
+    case 'number':
+      return node.toString();
+    case 'boolean':
+      return '';
+    case 'object':
+      if (node instanceof Array) return node.map(getTextForCopy).join('');
+      if ('props' in node) {
+        // skip lines that are "removed" in a diff by adding some recognizable whitespace
+        if (node.props.className?.includes('diff remove')) return '\n \n';
+        return getTextForCopy(node.props.children);
+      }
+    default:
+      return '';
+  }
+}
+
+function stripDiffSpacer(str: string): string {
+  // remove the extra space added to removed lines in diffs
+  return str.replace(/\n \n\n/g, '');
+}
+
+function CodeBlock(props: ComponentProps<'code'>): JSX.Element {
+  const codeRef = React.useRef<HTMLElement>(null);
+  const language = props.className?.replace(/language-/, '');
+  const code = stripDiffSpacer(getTextForCopy(props.children));
+
+  return (
+    <div className={codeBlockStyles.CodeBlock}>
+      <div className={codeBlockStyles.header}>
+        <div>{language}</div>
+      </div>
+      <div className={codeBlockStyles.content}>
+        <pre className={clsx(codeBlockStyles.pre, 'shiki')}>
+          <code {...props} ref={codeRef} />
+        </pre>
+        <CopyButton className={codeBlockStyles.button} code={code} />
+      </div>
+    </div>
+  );
+}
+
+export default function MDXCode(props): JSX.Element {
+  return shouldBeInline(props) ? <code {...props} /> : <CodeBlock {...props} />;
+}


### PR DESCRIPTION
## Feature or Problem
Adds syntax highlighting for `wit` and `smithy` through [`shiki`](http://shiki.style/) as a rehype markdown plugin.

Example of `wit` and `smithy` in use: [/docs/concepts/interface-driven-development](https://deploy-preview-297--dreamy-golick-5f201e.netlify.app/docs/concepts/interface-driven-development)