### PR TITLE
fix(python): remove pinned componentize-py version

### DIFF
--- a/blog/bring-your-own-wasm-components/index.mdx
+++ b/blog/bring-your-own-wasm-components/index.mdx
@@ -30,7 +30,7 @@ You'll need to [install wasmCloud](https://wasmcloud.com/docs/installation), [Py
 Once `pip` is in place, you'll also need to install `componentize-py`:
 
 ```bash
-pip install componentize-py==0.9.2
+pip install componentize-py
 ```
 
 Next, we'll download the **`componentize-py`** repo from GitHub. For now, this demo is easiest if you [download the repo ZIP from this pre-WASI 0.2.0 commit](https://github.com/bytecodealliance/componentize-py/tree/6535546d2bbe7f9857fbe50bd6a79fad97c6188a). The GitHub repo gives us a directory of Python examples, including an app that makes and receives HTTP requests. If we open `examples/http/app.py`, we find a nifty demo that returns an echo or hash depending on your request. 

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -201,7 +201,7 @@ export const incomingHandler = {
 To perform the steps in this guide, you'll need you'll need to install [Python 3.10](https://www.python.org/) or later, [pip](https://pip.pypa.io/en/stable/installation/), and `componentize-py` to compile Python code to WebAssembly.
 
 ```bash
-pip install componentize-py==0.9.2
+pip install componentize-py
 ```
 ::: 
 

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -154,7 +154,7 @@ This actor is a simple Python project with a few extra goodies included for wasm
 :::info[Dependencies]
 You don't need any Python dependencies installed to run this example, but if you want to build it yourself you'll need to install [Python 3.10 or later](https://www.python.org/) and [pip](https://pypi.org/project/pip/). After you have those, you'll need to install [componentize-py](https://github.com/bytecodealliance/componentize-py/tree/main?tab=readme-ov-file#getting-started):
 ```
-pip install componentize-py==0.9.2
+pip install componentize-py
 ```
 :::
 


### PR DESCRIPTION
## Feature or Problem
This PR removes the unneeded componentize-py version attestation.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
