### PR TITLE
docs: replace runtime with app platform

### DIFF
--- a/blog/all-the-clouds-a-stage.md
+++ b/blog/all-the-clouds-a-stage.md
@@ -34,7 +34,7 @@ Specifically, when it comes to wasmCloud, all of our actors are stateless, at le
 
 ## Actor Supervision
 
-The general approach, thus far, has been that actor supervision is something the wasmCloud runtime takes care of by default. So, when you run an actor, we're responsible for making sure that it comes back from the dead after it dies and that, if you want to scale out 10 copies of it, you can.
+The general approach, thus far, has been that actor supervision is something the wasmCloud application platform takes care of by default. So, when you run an actor, we're responsible for making sure that it comes back from the dead after it dies and that, if you want to scale out 10 copies of it, you can.
 
 If you want to communicate between actors, we make that happen without you needing to have a supervisory relationship. One of the ways we can manage workflows that typically require people to be able to create their own actors comes from our declarative application deployment manager, or wadm. So, if you want to declare that you need to maintain 10 instances of this actor across a spread of five hosts, all of which have a certain set of characteristics, Wadm will do that for you. More importantly, the actors don't know that's how things are being done.
 

--- a/docs/tour/why-wasmcloud.mdx
+++ b/docs/tour/why-wasmcloud.mdx
@@ -24,7 +24,7 @@ wasmCloud applications compile to [WebAssembly](https://webassembly.org/), which
 
 ### Cloud Support
 
-wasmCloud applications can be deployed to any cloud, edge, bare-metal, or on-prem machine that can run the wasmCloud runtime. This means that you can deploy your application to any cloud provider, or even to your own datacenter, without having to worry about the underlying infrastructure.
+wasmCloud applications can be deployed to many cloud, edge, bare-metal, or on-prem machines due to the portability of Wasm and broad support of operating systems and architectures by [Wasmtime](https://github.com/bytecodealliance/wasmtime), our WebAssembly runtime of choice. This means that you can deploy your application to any cloud provider, or even to your own datacenter, without having to worry about the underlying infrastructure.
 
 ### Scaling
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -48,7 +48,7 @@ const config: Config = {
   title: 'wasmCloud',
   tagline: 'Build applications in any language. Deploy them anywhere.',
   customFields: {
-    description: 'The secure, distributed, WebAssembly Actor runtime',
+    description: 'The secure, distributed, WebAssembly application platform',
     tagline_1: 'Build applications in any language.',
     tagline_2: 'Deploy them anywhere.',
   },


### PR DESCRIPTION
 wasmCloud is an application platform

Signed-off-by: Bailey Hayes <behayes2@gmail.com>