### PR TITLE
Fix broken links to first party provider repo

### DIFF
--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -50,7 +50,7 @@ In addition to on-lattice providers, some capability contracts have implementati
 
 The list of capability providers continues to grow. Please refer to these links for more information:
 
-- [first-party providers](https://github.com/wasmCloud/wasmCloud/tree/main/crates/providers) - a list of supported capability providers
+- [first-party providers](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) - a list of supported capability providers (v0.82 versions)
 - [interfaces](https://github.com/wasmcloud/interfaces) - definitions of several api specifications, many of which are capability contracts
 - [example providers](https://github.com/wasmCloud/examples/tree/main/provider) - additional sample code
 

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -50,7 +50,7 @@ In addition to on-lattice providers, some capability contracts have implementati
 
 The list of capability providers continues to grow. Please refer to these links for more information:
 
-- [first-party providers](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) - a list of supported capability providers (v0.82 versions)
+- [first-party providers](https://github.com/wasmCloud/wasmCloud/tree/main/crates) - supported capability providers are available in the wasmCloud repository (available in `crates/provider-*` directories)
 - [interfaces](https://github.com/wasmcloud/interfaces) - definitions of several api specifications, many of which are capability contracts
 - [example providers](https://github.com/wasmCloud/examples/tree/main/provider) - additional sample code
 

--- a/docs/reference/official-oci/index.md
+++ b/docs/reference/official-oci/index.md
@@ -9,4 +9,4 @@ draft: false
 🚧 This page is under heavy renovation for wasmCloud 1.0. Check back soon! 🚧
 :::
 
-We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our Github repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) (this refers to version 0.82) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.
+We maintain all officially supported, continually updated, first-party images managed by the wasmCloud team in our GitHub repositories. Refer to the [providers](https://github.com/wasmCloud/wasmCloud/tree/main/crates) (available in `crates/provider-*` directories) for the latest updated versions of our first-party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example components and providers.

--- a/docs/reference/official-oci/index.md
+++ b/docs/reference/official-oci/index.md
@@ -5,4 +5,8 @@ sidebar_position: 2
 draft: false
 ---
 
-We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our Github repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/main/crates/providers) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.
+:::warning[Under Construction]
+🚧 This page is under heavy renovation for wasmCloud 1.0. Check back soon! 🚧
+:::
+
+We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our Github repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) (this refers to version 0.82) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.

--- a/versioned_docs/version-0.82/concepts/capabilities.mdx
+++ b/versioned_docs/version-0.82/concepts/capabilities.mdx
@@ -50,7 +50,7 @@ In addition to on-lattice providers, some capability contracts have implementati
 
 The list of capability providers continues to grow. Please refer to these links for more information:
 
-- [first-party providers](https://github.com/wasmCloud/wasmCloud/tree/main/crates/providers) - a list of supported capability providers
+- [first-party providers](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) - a list of supported capability providers
 - [interfaces](https://github.com/wasmcloud/interfaces) - definitions of several api specifications, many of which are capability contracts
 - [example providers](https://github.com/wasmCloud/examples/tree/main/provider) - additional sample code
 

--- a/versioned_docs/version-0.82/reference/official-oci/index.md
+++ b/versioned_docs/version-0.82/reference/official-oci/index.md
@@ -5,4 +5,4 @@ sidebar_position: 2
 draft: false
 ---
 
-We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our Github repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/main/crates/providers) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.
+We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our Github repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.


### PR DESCRIPTION
I ran a broken link checker and these are the stragglers, pointing to the old location for first-party providers. Updated the links to point to the 0.82 branch. 