### PR TITLE
fix(docs): fix policy example link

### DIFF
--- a/docs/deployment/security/policy-service.mdx
+++ b/docs/deployment/security/policy-service.mdx
@@ -149,4 +149,4 @@ Past policy decisions can be revoked/overridden by the policy service by publish
 
 Since the policy service API is over NATS, it can be implemented by anything that can subscribe and publish responses to the configured policy topic (including a wasmCloud component!).
 
-An example policy service implementing Open Policy Agent is [available in the wasmCloud GitHub repository](https://github.com/wasmCloud/wasmCloud/examples/security).
+An example policy service implementing Open Policy Agent is [available in the wasmCloud GitHub repository](https://github.com/wasmCloud/wasmCloud/tree/main/examples/security).


### PR DESCRIPTION
Noticed this link needed the `tree/main` while reviewing the policy docs.

I searched the repo for more cases of `wasmCloud/wasmCloud/examples` and the only hits were in go imports 👍