### PR TITLE
fix: remove mentions of `--capid` and claim signing

### DIFF
--- a/docs/cli/claims.md
+++ b/docs/cli/claims.md
@@ -5,7 +5,11 @@ sidebar_position: 5
 description: "wash claims command reference"
 ---
 
-Every component in a wasmCloud environment claims its capabilities or the features it can interact with to supplement its current behavior. These capabilities are claimed in the form of JSON Web Tokens (JWTs). `wash claims` will assist you to generate, manage and view these JWTs for wasmCloud components. Following are the subcommands available under `wash claims`.
+Every component in a wasmCloud environment contains metadata which are called claims, in the form of JSON Web Tokens (JWTs).
+
+`wash claims` helps generate, manage and view these JWTs for wasmCloud components.
+
+The following are the subcommands available under `wash claims`.
 
 - `inspect`
 - `sign`
@@ -17,7 +21,7 @@ Every component in a wasmCloud environment claims its capabilities or the featur
 This subcommand will be deprecated in future versions. Please use `wash inspect` instead.
 :::
 
-Inspect helps you to examine the capabilities of a wasmCloud component. It accepts the path to the wasmCloud component or provider and prints out the properties of that component.
+`wash inspect` helps you to examine the stored metadata of a wasmCloud component. `wash inspect` accepts the path to the wasmCloud component or provider and prints out the properties of that component.
 
 #### Usage
 
@@ -32,9 +36,6 @@ Inspect helps you to examine the capabilities of a wasmCloud component. It accep
   Can Be Used                                                immediately
   Version                                                      0.3.7 (4)
   Call Alias                                                   (Not set)
-                               Capabilities
-  HTTP Server
-  Logging
                                    Tags
   None
 
@@ -81,12 +82,12 @@ Inspect helps you to examine the capabilities of a wasmCloud component. It accep
 
 ## `sign`
 
-`wash claims sign` assists you in signing a WebAssembly component by specifying some standard capabilities available in the wasmCloud environment. A user may also specify custom capabilities and other metadata such as expiration, tags, etc.
+`wash claims sign` assists you in signing a WebAssembly component with metadata about the component. Users may specify metadata such as expiration, tags, etc.
 
 #### Usage
 
 ```
-wash claims sign /path/to/wasm-module --name=component-name -q -k
+wash claims sign /path/to/wasm-module --name=component-name
 ```
 
 #### Options
@@ -97,25 +98,9 @@ wash claims sign /path/to/wasm-module --name=component-name -q -k
 
 `--experimental` Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
 
-`--keyvalue` (Alias `-k`) Enable the Key/Value Store standard capability
-
 `--msg` (Alias `-g`) Enable the Message broker standard capability
 
-`--http_server` (Alias `-q`) Enable the HTTP server standard capability
-
-`--http_client` Enable the HTTP client standard capability
-
-`--blob_store` (Alias `-f`) Enable access to the blob store capability
-
-`--extras` (Alias `-z`) Enable access to the extras functionality (random nos, guids, etc)
-
-`--logging` (Alias `-l`) Enable access to logging capability
-
-`--events` (Alias `-e`) Enable access to an append-only event stream provider
-
 `--name` (Alias `-n`) A human-readable, descriptive name for the token
-
-`--cap` (Alias `-c`) Add custom capabilities
 
 `--tag` (Alias `-t`) A list of arbitrary tags to be embedded in the token
 
@@ -160,29 +145,13 @@ wash claims token component --name=example -k
 
 #### Options
 
-`--keyvalue` (Alias `-k`) Enable the Key/Value Store standard capability
-
 `--output` (Alias `-o`) Specify output format (text or json) [default: text]
 
 `--experimental` Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
 
 `--msg` (Alias `-g`) Enable the Message broker standard capability
 
-`--http_server` (Alias `-q`) Enable the HTTP server standard capability
-
-`--http_client` Enable the HTTP client standard capability
-
-`--blob_store` (Alias `-f`) Enable access to the blob store capability
-
-`--extras` (Alias `-z`) Enable access to the extras functionality (random nos, guids, etc)
-
-`--logging` (Alias `-l`) Enable access to logging capability
-
-`--events` (Alias `-e`) Enable access to an append-only event stream provider
-
 `--name` (Alias `-n`) A human-readable, descriptive name for the token
-
-`--cap` (Alias `-c`) Add custom capabilities
 
 `--tag` (Alias `-t`) A list of arbitrary tags to be embedded in the token
 
@@ -275,7 +244,7 @@ Generate a signed JWT for a capability provider
 #### Usage
 
 ```
-wash claims token provider --name=example --capid=your-capid --vendor=vendor-name
+wash claims token provider --name=example --vendor=vendor-name
 ```
 
 #### Options
@@ -285,8 +254,6 @@ wash claims token provider --name=example --capid=your-capid --vendor=vendor-nam
 `--output` (Alias `-o`) Specify output format (text or json) [default: text]
 
 `--experimental` Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
-
-`--capid` (Alias `-c`) Capability contract ID that this provider supports
 
 `--vendor` (Alias `-v`) A human-readable string identifying the vendor of this provider (e.g. Redis or Cassandra or NATS etc)
 

--- a/docs/cli/get.md
+++ b/docs/cli/get.md
@@ -44,7 +44,7 @@ wash get inventory <your-host-ID>
 
 ### `claims`
 
-This subcommand queries the lattice for its claims cache. It retrieves the issuer, subject, associated capabilities, version and revision for all the claims.
+This subcommand queries the lattice for its claims cache. It retrieves the issuer, subject, version and revision for all the claims.
 
 #### Usage
 

--- a/docs/cli/inspect.md
+++ b/docs/cli/inspect.md
@@ -5,7 +5,9 @@ sidebar_position: 12
 description: "wash inspect command reference"
 ---
 
-Inspect helps you to examine the capabilities of a wasmCloud component. It accepts the path to the wasmCloud component or provider and prints out the properties of that component.
+`wash inspect` helps you to examine the metadata of a wasmCloud component. 
+
+`wash inspect` accepts the path to the wasmCloud component or provider and prints out the properties of that component.
 
 #### Usage
 
@@ -20,9 +22,6 @@ Inspect helps you to examine the capabilities of a wasmCloud component. It accep
   Can Be Used                                                immediately
   Version                                                      0.3.7 (4)
   Call Alias                                                   (Not set)
-                               Capabilities
-  HTTP Server
-  Logging
                                    Tags
   None
 

--- a/docs/cli/par.md
+++ b/docs/cli/par.md
@@ -18,12 +18,10 @@ This subcommand creates a provider archive using an architecture target, provide
 #### Usage
 
 ```
-wash par create --capid <CAPID> --vendor <VENDOR> --name <NAME> --arch <ARCH> --binary /path/to/binary
+wash par create --vendor <VENDOR> --name <NAME> --arch <ARCH> --binary /path/to/binary
 ```
 
 #### Options
-
-`--capid` (Alias `-c`) Capability contract ID (e.g. wasmcloud:messaging or wasmcloud:keyvalue)
 
 `--output` (Alias `-o`) Specify output format (text or json) [default: text]
 

--- a/docs/developer/components/run.mdx
+++ b/docs/developer/components/run.mdx
@@ -55,8 +55,6 @@ wash inspect ./build/hello_s.wasm
   Can Be Used                                                immediately
   Version                                                      0.1.0 (0)
   Call Alias                                                   (Not set)
-                               Capabilities
-  HTTP Server
                                    Tags
   None
 ```

--- a/docs/hosts/security.md
+++ b/docs/hosts/security.md
@@ -45,15 +45,10 @@ In addition to the standard claims required by all [JSON Web Token (JWT)](https:
     "name": "Key Value Counter",
     "hash": "4B4BCE3588955E068DC9D32382C8727CBF46819C907AB3A1630ED7B97C530D13",
     "tags": [],
-    "caps": ["wasmcloud:keyvalue", "wasmcloud:httpserver"],
     "prov": false
   }
 }
 ```
-
-Here one of the most important fields in the `wascap` object is the `caps` field, which contains an array of _capability contract IDs_. Each capability provider must conform to a single, globally unique contract identifier. This ID is typically prefixed with a namespace or vendor prefix, but is not a requirement.
-
-The preceding token indicates that the _Key Value Counter_ component has been granted access to the Key-Value and HTTP Server capabilities, _without regard_ for which specific provider is used to satisfy those capabilities. In other words, this component can use _any_ key-value provider, be it Redis or Cassandra or Consul. If you want to further limit which capabilities can be used by actors at runtime, you can define and utlize an [OPA](https://www.openpolicyagent.org/) policy.
 
 ### Managing Keys
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Now that capability claim signing has been removed, the documentation that recommends specifying `--capid` needs to be changed/updated going forward.

See: https://github.com/wasmCloud/wasmCloud/issues/1219

This commit removes mentions of `--capid` and other instances of claim signing.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
