### PR TITLE
doc: Add neovim syntax highlighting

### DIFF
--- a/docs/ecosystem/useful-webassembly-tools/index.mdx
+++ b/docs/ecosystem/useful-webassembly-tools/index.mdx
@@ -9,24 +9,35 @@ sidebar_position: 4
 
 Beyond the wasmCloud toolchain, the WebAssembly community maintains many open source projects that are invaluable for Wasm users. This is a non-comprehensive list of tools we've found particularly useful.
 
-## WIT syntax highlighting (VSCode)
+## WIT Syntax Highlighting
 
-Syntax highlighting can make WIT definitions easier to read. The [VSCode extension](https://github.com/bytecodealliance/vscode-wit/) maintained by the Bytecode Alliance brings a more legible WIT experience to your IDE. 
+Syntax highlighting can make WIT definitions easier to read and bring a more legible WIT experience to your IDE. Here are a few options for syntax highlighting in popular editors:
+
+### VS Code WIT Syntax Highlighting
+
+The [VSCode extension](https://github.com/bytecodealliance/vscode-wit/) maintained by the Bytecode Alliance can be installed either via the [extensions marketplace](https://marketplace.visualstudio.com/items?itemName=BytecodeAlliance.wit-idl) or manually.
 
 ![WIT syntax highlighting](../../images/wit-syntax.png)
 
-You can install via the extensions marketplace or manually. For a manual install, you will need [`npm`](https://www.npmjs.com/). Run:
+#### VS Code Extension Manual installation
+
+For a manual install, you will need [`npm`](https://www.npmjs.com/). Run:
 
 ```shell
 git clone https://github.com/bytecodealliance/vscode-wit.git && cd vscode-wit
 ```
+
 ```shell
 npm ci && npm run install-plugin
 ```
 
+### Neovim WIT Syntax Highlighting
+
+The [tree-sitter-wit](https://github.com/liamwh/tree-sitter-wit/) Tree-sitter parser maintained by [liamwh](https://github.com/liamwh) can be installed with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter). Installation instructions can be found on either of the two linked repositories.
+
 ## WIT dependency management with `wit-deps`
 
-It's important to ensure consistency between the WIT dependencies defined in your `deps.toml` manifest and the actual files in your project. [`wit-deps`](https://github.com/bytecodealliance/wit-deps) is a simple dependency management CLI tool maintained by the Bytecode Alliance that ensures your dependencies are consistently and correctly populated. 
+It's important to ensure consistency between the WIT dependencies defined in your `deps.toml` manifest and the actual files in your project. [`wit-deps`](https://github.com/bytecodealliance/wit-deps) is a simple dependency management CLI tool maintained by the Bytecode Alliance that ensures your dependencies are consistently and correctly populated.
 
 You will need [Rust and `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html). Install `wit-deps` by running:
 
@@ -44,7 +55,7 @@ For more detail on `wit-deps`, see the [documentation in the project README](htt
 
 ## WebAssembly artifact manipulation with `wasm-tools`
 
-Sometimes you might want to observe or manipulate a component independently of wasmCloud&mdash;perhaps to view the component's WIT interface, compose Wasm components into one, or even for more niche jobs like converting a WebAssembly module to a component. The [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools) CLI tool is a utility belt with a long list of options. 
+Sometimes you might want to observe or manipulate a component independently of wasmCloud&mdash;perhaps to view the component's WIT interface, compose Wasm components into one, or even for more niche jobs like converting a WebAssembly module to a component. The [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools) CLI tool is a utility belt with a long list of options.
 
 You will need [Rust and `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html). Install `wasm-tools` by running:
 
@@ -77,3 +88,4 @@ Install the `wasi-virt` command line tool with `cargo`:
 ```bash
 cargo +nightly install --git https://github.com/bytecodealliance/wasi-virt
 ```
+


### PR DESCRIPTION
## Feature or Problem
Add install instructions for WIT syntax highlighting for Neovim.

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
N/A

## Testing
N/A

### Unit Test(s)
N/A

### Acceptance or Integration
N/A

### Manual Verification
Used a markdown preview tool to preview the .mdx file. Also used Markdownlint to lint the file. Didn't build the docs locally or anything though.
