### PR TITLE
Update official OCI image list

### DIFF
--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -41,6 +41,8 @@ First-party providers include:
 - [messaging-kafka](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-messaging-kafka)
 - [messaging-nats](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-messaging-nats)
 
+In [Wadm manifests](/docs/1.0/ecosystem/wadm/), you can refer to the [wasmCloud GitHub Packages registry](https://github.com/orgs/wasmCloud/packages?repo_name=wasmCloud) for OCI images of providers&mdash;for example: `ghcr.io/wasmcloud/keyvalue-redis:0.23.0`
+
 ## Keep reading
 
 [Continue to learn more about interfaces](/docs/1.0/concepts/interfaces) that providers use to communicate with components (or one another), or...

--- a/docs/reference/official-oci/index.md
+++ b/docs/reference/official-oci/index.md
@@ -5,8 +5,17 @@ sidebar_position: 2
 draft: false
 ---
 
-:::warning[Under Construction]
-🚧 This page is under heavy renovation for wasmCloud 1.0. Check back soon! 🚧
-:::
+We maintain all officially supported, continually updated, first-party images managed by the wasmCloud team on GitHub repositories. 
 
-We maintain all officially supported, continually updated, first-party images managed by the wasmCloud team in our GitHub repositories. Refer to the [providers](https://github.com/wasmCloud/wasmCloud/tree/main/crates) (available in `crates/provider-*` directories) for the latest updated versions of our first-party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example components and providers.
+You can find a complete list of the most up-to-date versions and OCI images for all first-party wasmCloud providers on [GitHub Packages](https://github.com/orgs/wasmCloud/packages?repo_name=wasmCloud). The list includes:
+
+* `blobstore-fs`
+* `blobstore-s3`
+* `http-server`
+* `http-client`
+* `keyvalue-redis`
+* `keyvalue-vault`
+* `messaging-nats`
+* `messaging-kafka`
+
+The code for providers is maintained [in the wasmCloud repository](https://github.com/wasmCloud/wasmCloud/tree/main/crates/). Refer to the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example components and providers.


### PR DESCRIPTION
Point to GitHub Packages registry for first-party providers in 1.0 version of Reference -> Official OCI Image List. 