### PR TITLE
fix: broken 1.0 docs links

### DIFF
--- a/community/2024-04-17-community-meeting.mdx
+++ b/community/2024-04-17-community-meeting.mdx
@@ -21,7 +21,7 @@ import ReactPlayer from 'react-player/youtube';
 
 * Bugs and minor issues are all tackled. So live on the call, Brooks bumped wash and wasmCloud to 1.0. :fireworks:
 
-* After celebrating the 1.0 release, Brooks showed [liamwh](https://github.com/liamwh)'s recent contribution to the wasmCloud docs, adding his neovim extension for WIT syntax highlighting to the [Useful WebAssembly Tools](https://wasmcloud.com/docs/1.0/ecosystem/useful-webassembly-tools/) page. 
+* After celebrating the 1.0 release, Brooks showed [liamwh](https://github.com/liamwh)'s recent contribution to the wasmCloud docs, adding his neovim extension for WIT syntax highlighting to the [Useful WebAssembly Tools](https://wasmcloud.com/docs/ecosystem/useful-webassembly-tools/) page. 
 
 * Brooks also pointed out Bailey's [RFC for implementing a Postgres interface](https://github.com/wasmCloud/wasmCloud/issues/1914). Bailey explained the thinking behind the proposal, including taking a declarative approach (rather than using sockets in a POSIX-style approach) and allowing developers to use the implementation-specific syntax required in the world of SQL databases.
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -167,7 +167,7 @@ const config: Config = {
     },
     announcementBar: {
       id: '1.0',
-      content: `🎉️ <b>wasmCloud v1.0</b> is available! Read the <a href="/docs/1.0/intro">1.0 documentation</a> and try it out now.`,
+      content: `🎉️ <b>wasmCloud v1.0</b> is available! Read the <a href="/docs/intro">1.0 documentation</a> and try it out now.`,
       backgroundColor: '#20232a',
       textColor: '#fff',
     },


### PR DESCRIPTION
Fixing a few links that still used the `/docs/1.0` format, now that 1.0 is the default.