### PR TITLE
fix(blog): Typo and minor styling fixes

### DIFF
--- a/blog/wasmcloud-1.0-webassembly-apps-production-any-cloud-any-edge/index.mdx
+++ b/blog/wasmcloud-1.0-webassembly-apps-production-any-cloud-any-edge/index.mdx
@@ -14,7 +14,7 @@ We're thrilled to announce the 1.0 release of wasmCloud, the universal applicati
 
 {/* truncate */}
 
-You can try it right now&mdash;[download the wasmCloud Shell (wash)](/docs/installation) and dive in to our [**quickstart**](https://wasmcloud.com/docs/tour/hello-world).
+You can try it right now&mdash;[**download the wasmCloud Shell (wash)**](/docs/installation) and dive in to our [**quickstart**](https://wasmcloud.com/docs/tour/hello-world).
 
 The 1.0 release is a grand culmination of effort from the [2024 Q1 roadmap](/docs/roadmap/) which focused primarily on standardization of host control interface and RPC protocols, events, and WebAssembly component support.
 
@@ -39,7 +39,7 @@ To leverage the composability and flexibility of components and distribute them 
 
 That's what we've done with the [**wasmCloud Application Deployment Manager (Wadm)**](https://github.com/wasmcloud/wadm). Wadm delivers the declarative application management experience that cloud engineers expect and automatic, out-of-the-box load balancing, service discovery, and failover for distributed applications. All of this uses the community standard [Open Application Model (OAM)](https://oam.dev/): if you know how to use a YAML manifest with Kubernetes, you're 99% of the way to using one with Wadm.
 
-Better yet, wasmCloud and Kubernetes integrate seamlessly through the open source [`wasmCloud-operator`](https://github.com/wasmCloud/wasmcloud-operator), which uses a Kubernetes controller and custom resource definitions (CRDs) to run wasmCloud hosts on Kubernetes. The operator enables you to deploy wasmCloud applications from within your cluster using the Kubernetes tooling you're already using. This way, Kubernetes focuses on what it's good at&mdash;infrastructure management&mdash;while wasmCloud handles the orchestration of distributed components, throwing the WebAssembly toolbox wide open for developers.
+Better yet, wasmCloud and Kubernetes integrate seamlessly through the open source [**`wasmCloud-operator`**](https://github.com/wasmCloud/wasmcloud-operator), which uses a Kubernetes controller and custom resource definitions (CRDs) to run wasmCloud hosts on Kubernetes. The operator enables you to deploy wasmCloud applications from within your cluster using the Kubernetes tooling you're already using. This way, Kubernetes focuses on what it's good at&mdash;infrastructure management&mdash;while wasmCloud handles the orchestration of distributed components, throwing the WebAssembly toolbox wide open for developers.
 
 - [**Check out our wasmCloud with Kubernetes page**](/docs/kubernetes) to learn more about the wasmCloud-operator project and how to get started running wasmCloud with Kubernetes.
 
@@ -49,9 +49,9 @@ Better yet, wasmCloud and Kubernetes integrate seamlessly through the open sourc
 
 wasmCloud hosts can be clustered together with the CNCF project [NATS](https://nats.io/) to form a distributed mesh network called a [lattice](https://wasmcloud.com/docs/concepts/lattice), allowing you to seamlessly distribute applications on any architecture, operating system, virtual or physical machine and communicate like it was running on a single computer.
 
-Whether a component is a serverless function or a microservice, it communicates over common WebAssembly Interface Type (WIT) definitions. Components speak a common language, so combining (or "composing") them is easy. With the 1.0 release, wasmCloud implements a new RPC protocol called [wRPC](https://github.com/wrpc/wrpc) to take this flexibility a step further, delivering the composability of the Component Model&mdash;dynamically and at runtime&mdash;across the lattice. This will be especially powerful for use-cases like apps comprised of many different services, or apps requiring explicit control over data location.
+Whether a component is a serverless function or a microservice, it communicates over common WebAssembly Interface Type (WIT) definitions. Components speak a common language, so combining (or "composing") them is easy. With the 1.0 release, wasmCloud implements a new RPC protocol called [**wRPC**](https://github.com/wrpc/wrpc) to take this flexibility a step further, delivering the composability of the Component Model&mdash;dynamically and at runtime&mdash;across the lattice. This will be especially powerful for use-cases like apps comprised of many different services, or apps requiring explicit control over data location.
 
-- [Read our primer on the four ways components are linked in wasmCloud](/docs/concepts/linking-components), including an in-depth breakdown of runtime linking between distributed components over the network.
+- [**Read our primer on the four ways components are linked in wasmCloud**](/docs/concepts/linking-components), including an in-depth breakdown of runtime linking between distributed components over the network.
 
 ## Vendorless application components
 
@@ -63,9 +63,9 @@ Since wasmCloud supports custom interfaces written with the community-standard i
 
 - For more on WASI 0.2 and our approach to vendor-neutrality, check out our blog, [**Vendor-neutral apps with wasmCloud 1.0 and WASI 0.2**](/blog/wasmcloud-1.0-vendor-neutral-apps).
 
-- You might also want to see our [blog on why WASI 0.2 is such a big deal](/blog/wasi-preview-2-officially-launches).
+- You might also want to see our [**blog on why WASI 0.2 is such a big deal**](/blog/wasi-preview-2-officially-launches).
 
-- If you're new to components, WASI, and the wider WebAssembly ecosystem, check out our [Concepts documention](/docs/category/concepts) to get up to speed&mdash;the [Components](/docs/concepts/components) page is a great place to start.
+- If you're new to components, WASI, and the wider WebAssembly ecosystem, check out our [**Concepts documention**](/docs/category/concepts) to get up to speed&mdash;the [**Components**](/docs/concepts/components) page is a great place to start.
 
 ## Completely OTEL observable
 
@@ -75,7 +75,7 @@ Our approach to observability aims to be simple, flexible, and compatible with y
 
 - Find out more about observability and wasmCloud in our blog, [**Complete OpenTelemetry Observability with wasmCloud**](https://wasmcloud.com/blog/otel-observable).
 
-- See the [**Observability with OpenTelementry**](/docs/deployment/observability/observability-with-opentelemetry) page in the wasmCloud docs for more information on metrics, logs, and traces, along with an example observability ecosystem that you can launch with just a few commands.
+- See the [**Observability with OpenTelemetry**](/docs/deployment/observability/observability-with-opentelemetry) page in the wasmCloud docs for more information on metrics, logs, and traces, along with an example observability ecosystem that you can launch with just a few commands.
 
 ## Defense-in-depth security by default
 
@@ -95,7 +95,7 @@ For users, 1.0 represents a stable foundation to build on with confidence&mdash;
 
 Smithy-generated actors and providers were deprecated in v0.82, and support is officially removed in v1.0.0. If you need help migrating from Smithy interfaces, just reach out on the [wasmCloud Slack](https://slack.wasmcloud.com/) or on [GitHub](https://github.com/wasmCloud/wasmCloud/issues). We've also dropped the term "actor" itself in favor of "component"&mdash;we're building WebAssembly components here, after all, and we want it to be absolutely clear that these are standard WebAssembly components you could pick up and run with any other system that runs components.
 
-The v1.0.0 release of wasmCloud is **not** compatible over the lattice with previous versions of wasmCloud, `wash`, or Wadm, owing to the shift to components, WIT interfaces, and a new RPC protocol. For these reasons, it’s recommended to update all wasmCloud hosts that you run to v1.0.0 at the same time. Associated tooling like **wadm** should update to at least version **v0.11.0** as well in order to match the protocol versions.
+The v1.0.0 release of wasmCloud is **not** compatible over the lattice with previous versions of wasmCloud, `wash`, or Wadm, owing to the shift to components, WIT interfaces, and a new RPC protocol. For these reasons, it’s recommended to update all wasmCloud hosts that you run to v1.0.0 at the same time. Associated tooling like **Wadm** should update to at least version **v0.11.0** as well in order to match the protocol versions.
 
 Finally, the model for Wadm manifests has changed slightly&mdash;see the guide to [Migrating from v0.82](/docs/ecosystem/wadm/migrating) for complete instructions.
 


### PR DESCRIPTION
Corrects "OpenTelementry," styles "Wadm" consistently, and adds bold styling to key links.