### PR TITLE
docs(plugins): Adds docs for wash plugins

### DIFF
--- a/docs/cli/plugin.md
+++ b/docs/cli/plugin.md
@@ -1,0 +1,41 @@
+---
+title: "wash plugin"
+draft: false
+sidebar_position: 28
+description: "wash plugin command reference"
+---
+
+Wash plugin helps you update, install, and retrieve information about wash plugins. Following are the subcommands available under `wash plugin`:
+
+- `install`
+- `uninstall`
+- `list`
+
+### `install`
+
+This subcommand will install a plugin for wash. These plugins can be used to add additional subcommands to wash. These plugins are Wasm Components and are sandboxed, but care should be taken to ensure that the plugin's code is trusted as it will be granted access to some resources via wash. Plugins can be installed from local files, from a URL, or from an OCI registry.
+
+#### Usage
+```
+wash install <file|http|https|oci>://<plugin-name>
+```
+
+### `uninstall`
+
+This subcommand uninstalls a plugin.
+
+#### Usage
+
+```
+wash plugin uninstall <plugin-id>
+```
+
+### `list`
+
+This subcommand lists all the installed plugins with some additional metadata
+
+#### Usage
+
+```
+wash plugin list
+```

--- a/docs/ecosystem/wash/plugin_developer.md
+++ b/docs/ecosystem/wash/plugin_developer.md
@@ -1,0 +1,17 @@
+---
+title: "Wash Plugin Developer Guide"
+date: 2024-04-26T11:02:05+06:00
+draft: false
+sidebar_position: 4
+description: "How to create your own plugins"
+---
+
+:::tip
+
+Wash plugins are available starting with version 0.28
+
+:::
+
+## Creating a plugin
+
+## Future development

--- a/docs/ecosystem/wash/plugin_developer.md
+++ b/docs/ecosystem/wash/plugin_developer.md
@@ -8,10 +8,124 @@ description: "How to create your own plugins"
 
 :::tip
 
-Wash plugins are available starting with version 0.28
+Wash plugins are available starting with version 0.28.
 
 :::
 
+This guide assumes some familiarity with building Wasm components. If you're not familiar with Wasm
+components and WIT, please read our existing [developer documentation](../../developer/components) first.
+
 ## Creating a plugin
 
+The easiest way to get started creating a plugin is to use `wash new component` and select one of
+the plugin examples from the list. This will get you started with a fully functional example plugin
+that demonstrates how to use all of the available functionality.
+
+### Plugin API
+
+The Plugin API is defined via WIT and is a small wrapper around the standard `wasi:cli/run`
+interface. The WIT is defined in the `wash-lib` crate and can be found
+[here](https://github.com/puppetlabs/wash/blob/main/crates/wash-lib/wit).
+
+A plugin can be any component that exports `wasi:cli/run` and the wasmCloud-defined interface called
+`wasmcloud:wash/subcommand`. This is a very small interface that expects a single function called
+`register` that returns metadata about the plugin. The definition for this data can be found in the
+WIT, but is defined below for convenience:
+
+```wit
+record metadata {
+    /// The friendly name of the plugin
+    name: string,
+    /// The ID of the plugin. This must be unique across all plugins and is used as the name of
+    /// the subcommand added to wash. This ID should contain no whitespace
+    id: string,
+    /// The version of the plugin
+    version: string,
+    /// The author of the plugin
+    author: string,
+    /// The description of the plugin. This will be used as the top level help text for the plugin
+    description: string,
+    /// The list of flags and their documentation that can be used with this plugin. The key is
+    /// the name of the flag and the value is the documentation for the flag.
+    %flags: list<tuple<string, string>>,
+    /// The list of positional arguments that can be used with this plugin. The key is the name
+    /// of the argument and the value is the documentation for the argument.
+    arguments: list<tuple<string, string>>,
+}
+```
+
+Most of these fields are fairly straightforward, but the `%flags` and `arguments` fields are a bit
+more complicated. These fields are used to define the flags and positional arguments that can be
+used with the plugin. These fields are defined as a list of tuples (as WIT doesn't have support for
+a `map` type yet) where the first element of the tuple is the name of the flag or argument and the
+second element is the documentation for the flag or argument. For `arguments`, the order matters as
+they are positional arguments. This data is used to hook in to the CLI parsing library, meaning that
+when the plugin is run, the CLI will automatically parse the flags and arguments to make sure they
+are valid. There is not currently any way to inform the CLI parsing library which arguments are
+required and which are optional, so it only provides a basic sanity check (such as if an unknown
+flag is passed) and to hook in help text to `wash`.
+
+Because a plugin just uses `wasi:cli/run`, any component that already implements that interface can
+be used by composing it with another component that exports the `wasmcloud:wash/subcommand`
+interface. In the future we plan on adding an example of doing this.
+
+#### Availability of other resources during registration
+
+When `wash` first loads a plugin to call the `register` function, it will be loaded with a "deny
+all" policy for all system resources. This means that the plugin can't access any of the resources
+that are normally available to a plugin. This is specifically for purposes of security as it ensures
+that a plugin is only returning the necessary information for registering the plugin. Once a plugin
+is loaded and is called directly, it is given access to system resources as described below.
+
+### `run` function implementation details
+
+When a plugin is run, the `wash` will call the `run` function exported by your plugin. The plugin
+will be passed all arguments that were passed after `wash`, including the plugin name. So if you had
+a plugin called `foo` and the user ran `wash foo --bar baz`, the `run` function would be called with
+the arguments `["foo", "--bar", "baz"]`. The `run` function is responsible for parsing the arguments
+in whatever way you see fit. The `run` function doesn't support returning a specific return code,
+but `wash` will ensure that the return code is 0 if the `run` function returns normally and a
+non-zero return code if the `run` function returns with an error. A plugin is also allowed to use
+`wasi:cli/exit` to exit early as well, but this may cause some `wash` cleanup to not run.
+
+A plugin has access to the following resourses while it is running:
+
+- Stdin
+- Stdout
+- Stderr
+- A single directory with full write privileges at `$WASH_DIR/plugins/scratch/<plugin_id>`
+- The ability to do outbound HTTP requests to any address
+- Environment variable passthrough for all environment variables that start with
+  `WASH_PLUGIN_<plugin_id_uppercase>_` (e.g. `WASH_PLUGIN_FOO_` for a plugin with the id of "foo")
+
+Just like a normal CLI, the plugin can read the incoming stdin and should write any
+messages/logs/etc to stdout/stderr.
+
+### Configuring your plugin
+
+All plugins are expected to document their configuration options (whether it be a file, environment
+variables, or command line flags) in a README or other well-known location. As noted in previous
+sections, all command line options will be added to the autogenerated help text for `wash`.
+
+Outside of command line flags, there are generally two ways to configure a CLI: environment
+variables or configuration files (or both). Every plugin is given a list of environment varibles
+that are prefixed with `WASH_PLUGIN_<plugin_id_uppercase>_`. So if you have a plugin with the id of
+"foo", any variable with the prefix `WASH_PLUGIN_FOO_` will be available for the plugin to consume.
+This means that any configuration via environment variables must be done via this naming scheme.
+
+For configuration files, every plugin is given a directory at
+`$WASH_DIR/plugins/scratch/<plugin_id>`. A plugin can use this directory to store any configuration
+files it needs (in addition to any specific application data it needs to persist). The configuration
+file format and parsing is left to the maintainer of a plugin, but it should also be documented. So
+if you had a `config.toml` file for your plugin, you should let users know that if they need to
+create or edit that file, it should be at `$WASH_DIR/plugins/scratch/<plugin_id>/config.toml`.
+
 ## Future development
+
+Currently we only support subcommand-style plugins for `wash`. In the future, we plan to add support
+for auth plugins, registry plugins, and resource plugins (plugins used to access custom enterprise
+resources that hook into wasmCloud such as ingress points, queues, DBs, etc.). Each of these will
+likely have a separate interface that is part of the `wasmcloud:wash` WIT package.
+
+The `subcommands` world will also have support for the CTL interface added to it in the near future.
+This will allow plugins access to interact with wasmCloud lattices.

--- a/docs/ecosystem/wash/plugins.md
+++ b/docs/ecosystem/wash/plugins.md
@@ -1,5 +1,5 @@
 ---
-title: "Wash plugins"
+title: "Wash Plugins"
 date: 2024-04-26T11:02:05+06:00
 draft: false
 sidebar_position: 3
@@ -8,23 +8,22 @@ description: "Using wash plugins"
 
 :::tip
 
-Wash plugins are available starting with version 0.28
+Wash plugins are available starting with version 0.28.
 
 :::
 
-Wash plugins are a way to extend the functionality of wash. They are Wasm components that can be
-used to add new subcommands to wash. This functionality is experimental, but enabled by default.
-What this means is that we may change the plugin API based on feedback of those using it. However,
-due to the power of the component model, it is very easy to adapt an older version of a plugin to a
-newer version of the API, likely with no changes to the plugin's code and transparent to users.
+Plugins are Wasm components that can extend the functionality of wash with new subcommands. This
+functionality is experimental but enabled by default, meaning we may change the plugin API based on
+feedback from those using it. The component model will make it very easy to adapt an older version
+of a plugin to a newer version of the API, with full transparency to users and few if any changes to
+the plugin code.
 
 ## Managing and consuming plugins
 
 ### Installing a plugin
 
-Installation of a plugin is a relatively straightforward process. A plugin can be installed from a
-local file, a URL, or from an OCI registry. This is done by specifying it in URI format. Some
-examples of this follow:
+A plugin can be installed from a local file, a URL, or from an OCI registry. This is done by
+specifying it in URI format. Some examples of this follow:
 
 - `file:///path/to/plugin.wasm`
 - `https://github.com/myuser/plugins/releases/download/v0.1.0/wash-plugin.wasm`

--- a/docs/ecosystem/wash/plugins.md
+++ b/docs/ecosystem/wash/plugins.md
@@ -1,0 +1,139 @@
+---
+title: "Wash plugins"
+date: 2024-04-26T11:02:05+06:00
+draft: false
+sidebar_position: 3
+description: "Using wash plugins"
+---
+
+:::tip
+
+Wash plugins are available starting with version 0.28
+
+:::
+
+Wash plugins are a way to extend the functionality of wash. They are Wasm components that can be
+used to add new subcommands to wash. This functionality is experimental, but enabled by default.
+What this means is that we may change the plugin API based on feedback of those using it. However,
+due to the power of the component model, it is very easy to adapt an older version of a plugin to a
+newer version of the API, likely with no changes to the plugin's code and transparent to users.
+
+## Managing and consuming plugins
+
+### Installing a plugin
+
+Installation of a plugin is a relatively straightforward process. A plugin can be installed from a
+local file, a URL, or from an OCI registry. This is done by specifying it in URI format. Some
+examples of this follow:
+
+- `file:///path/to/plugin.wasm`
+- `https://github.com/myuser/plugins/releases/download/v0.1.0/wash-plugin.wasm`
+- `oci://ghcr.io/myuser/plugins/wash-plugin:v0.1.0`
+
+To install a plugin, run the following command:
+
+```shell
+wash plugin install https://github.com/myuser/plugins/releases/download/v0.1.0/wash-plugin.wasm
+
+Plugin Hello (version 0.1.0) installed
+```
+
+The command will download the plugin, validate it, and then install it – erroring if there are any
+issues with the process
+
+There are also additional options for authenticating with an OCI registry and validating the
+checksum of the downloaded plugin. To see these options, run `wash plugin install --help`.
+
+### Updating a plugin
+
+By default, if you try to install a plugin that already exists or is registered with the same name,
+wash will refuse to install it. This is to prevent you from accidentally overwriting a plugin that
+you may have previously installed. If you want to update an existing plugin, just pass the
+`--update` flag to `wash plugin install`. This will overwrite the existing plugin with the new one,
+so be careful!
+
+### Listing installed plugins
+
+To list all installed plugins, run `wash plugin list`. This will show you a list of plugins and
+their versions, along with other useful metadata.
+
+```shell
+wash plugin list
+
+Name           ID      Version   Author      Description
+Hello Plugin   hello   0.1.0     WasmCloud   A simple plugin that says hello and logs a bunch of things
+```
+
+Please note that the ID is used for calling the plugin from the CLI and for uninstalling it.
+
+### Uninstalling a plugin
+
+To uninstall a plugin, run `wash plugin uninstall <plugin-id>`. This will remove the plugin from the
+list of installed plugins.
+
+### Running a plugin
+
+Once a plugin is installed, You can run it by calling `wash <plugin-id>`. This will run the plugin
+and pass any arguments to it. To see what flags and arguments are supported, pass the `--help` flag
+to the plugin.
+
+```shell
+wash hello --help
+
+A simple plugin that says hello and logs a bunch of things
+
+Usage: wash hello [OPTIONS] [name]
+
+Arguments:
+  [name]  A random name
+
+Options:
+      --foo <foo>        A foo variable
+  -o, --output <OUTPUT>  Specify output format (text or json) [default: text]
+      --experimental     Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
+  -h, --help             Print help
+  -V, --version          Print version
+```
+
+#### Configuring a plugin
+
+Each plugin will have its own set of configuration that it will need to document. However, there are
+a few key concepts that apply to all plugins. All plugins are only sent environment variables with
+the prefix `WASH_PLUGIN_<plugin_id_uppercase>_`. This means that if you have a plugin named `foo`,
+it will receive `WASH_PLUGIN_FOO_` as its environment variable prefix. So all environment variables
+used to configure that plugin will be prefixed with `WASH_PLUGIN_FOO_`.
+
+All plugins also get access to a directory for storing data. This directory is located at
+`$WASH_DIR/plugins/scratch/<plugin_id>`. This directory is used to store any data that the plugin
+needs to persist between runs. This means that any plugin with a configuration file will have it
+stored somewhere in that directory.
+
+#### Plugin access and security
+
+Plugins are only granted access to specific resources in the Wasm sandbox. The following list
+enumerates exactly which resources are granted to each plugin:
+
+- Stdin
+- Stdout
+- Stderr
+- A single directory with full write privileges at `$WASH_DIR/plugins/scratch/<plugin_id>`
+- The ability to do outbound HTTP requests to any address
+- Environment variable passthrough for all environment variables that start with
+  `WASH_PLUGIN_<plugin_id_uppercase>_` (e.g. `WASH_PLUGIN_FOO_` for a plugin with the id of "foo")
+
+We will also be adding the ability in the future for plugins to get access to a control interface
+client (the ability to access and interact with a lattice).
+
+To summarize, wash plugins are much more locked down than standard plugin models thanks to Wasm.
+However, they still have access to some more privileged resources so they can actually do some
+useful things. So, still be careful that your plugin is coming from a trusted source before
+installing. As the plugin ecosystem continues to evolve we will add more ways to fine tune what a
+plugin is allowed access to at any given time.
+
+### Disabling plugins
+
+Because plugins hook into the command line, they are loaded every time you run `wash` and before any
+arguments are parsed. If you wish to turn off plugins, you can set the environment variable
+`WASH_PLUGINS_DISABLED` to `true` (or any other value as it only checks if it is set). This will
+prevent all plugins from being loaded. Please note that this doesn't disable the `wash plugin`
+subcommand, but rather just prevents plugins from being loaded.


### PR DESCRIPTION
This adds a usage guide for the CLI as well as an overview of how plugins work. There is also a guide for plugin developers showing how they can develop plugins (or adapt existing components to be plugins)