### PR TITLE
Add woke for checking our language use

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,23 @@
+name: 'woke'
+on:
+  pull_request:
+
+jobs:
+  woke:
+    name: Run woke
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.18 
+
+      - name: Install woke
+        run: |
+          go install github.com/get-woke/woke@v0.19.0
+
+      - name: Run woke
+        run: |
+          woke -c .woke.yaml --exit-1-on-failure

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,3 @@
+ignore_files:
+  - /**/*.dic
+  - /**/*.excalidraw

--- a/blog/wasm-day-summary-blog/index.mdx
+++ b/blog/wasm-day-summary-blog/index.mdx
@@ -59,7 +59,7 @@ WebAssembly has particular potential in far-edge locations; in devices and on se
 
 The team works with a wide range of manufacturers, all with highly specialized services and bespoke equipment. WebAssembly allows the team to more closely monitor the performance, and state of individual pieces of equipment which results in better longevity, and maintenance savings. More importantly, though, it's wasmCloud's security posture that Tyler and Jochen appreciate.
 
-As Tyler explains: "wasmCloud's sandbox environment is really helpful for us as a great security model across a bunch of our different types of customers. These can be customers with full IT teams focused on security, where getting them to whitelist a URL takes a month of conversation and multiple people's time, all the way down to accommodating customers who have absolutely no security. This sandbox model is really great, and crucial because our customer data is often very sensitive.”
+As Tyler explains: "wasmCloud's sandbox environment is really helpful for us as a great security model across a bunch of our different types of customers. These can be customers with full IT teams focused on security, where getting them to [allow] a URL takes a month of conversation and multiple people's time, all the way down to accommodating customers who have absolutely no security. This sandbox model is really great, and crucial because our customer data is often very sensitive.”
 
 ## [CRI-O's WASM Adventure: Challenges, Strategies, and What Lies Ahead](https://www.youtube.com/watch?v=opX7PGwVO1c&list=PLj6h78yzYM2MQteKoXxICTWiUdZYEw6RI&index=7)—Sohan Kunkerkar & Peter Hunt, Red Hat
 

--- a/community/2023-02-01-community-meeting.mdx
+++ b/community/2023-02-01-community-meeting.mdx
@@ -37,7 +37,7 @@ import ReactPlayer from 'react-player/youtube';
   - Dagger allows you to take your CI/CD pipelines and run them identically, locally as you would in Github action or anywhere else.
   - This is pretty cool as one of the biggest pain points occurs when testing code at work, then trying to test later at home or in github - these are completely different test structures which causes confusion.
   - Demo shows wash new echo actor - build, sign, inspect, name and then call.
-  - What’s really cool is a call test on the actor which allows me to do some sanity checking. I.e. that it’s functioning.
+  - What’s really cool is a call test on the actor which allows me to do some coherence checking. I.e. that it’s functioning.
   - As a bonus, we tested starting and stopping inside Cosmonic using appropriate wash context. Not only do we test in a function, we also test whether it deploys and stops properly.
   - Unit tests are a little hard as we can’t mock wasmCloud yet, so this is a different angle - testing end-to-end integration
   - Next up - start actor, start provider, link then curl through provider.

--- a/docs/ecosystem/wash/plugin_developer.md
+++ b/docs/ecosystem/wash/plugin_developer.md
@@ -62,7 +62,7 @@ second element is the documentation for the flag or argument. For `arguments`, t
 they are positional arguments. This data is used to hook in to the CLI parsing library, meaning that
 when the plugin is run, the CLI will automatically parse the flags and arguments to make sure they
 are valid. There is not currently any way to inform the CLI parsing library which arguments are
-required and which are optional, so it only provides a basic sanity check (such as if an unknown
+required and which are optional, so it only provides a basic coherence check (such as if an unknown
 flag is passed) and to hook in help text to `wash`.
 
 Because a plugin just uses `wasi:cli/run`, any component that already implements that interface can

--- a/versioned_docs/version-0.82/concepts/actors.mdx
+++ b/versioned_docs/version-0.82/concepts/actors.mdx
@@ -13,7 +13,7 @@ The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this ent
 
 ## Overview
 
-The [actor model](https://en.wikipedia.org/wiki/Actor_model) is a model of concurrent computation that informs the way to build applications on wasmCloud. In this model, the **actor** is the primitive building block of concurrent computation. Actors are "black-box" computational entities that can only communicate with other actors by passing messages.
+The [actor model](https://en.wikipedia.org/wiki/Actor_model) is a model of concurrent computation that informs the way to build applications on wasmCloud. In this model, the **actor** is the primitive building block of concurrent computation. Actors are "closed-box" computational entities that can only communicate with other actors by passing messages.
 
 The academic definition of actors calls for them to be able to perform the following tasks _concurrently_:
 

--- a/versioned_docs/version-0.82/developer/providers/create-par.md
+++ b/versioned_docs/version-0.82/developer/providers/create-par.md
@@ -51,6 +51,6 @@ wash par inspect build/fakepay_provider.par.gz
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
 
-At this point we've decided on a logical contract for actors and capability providers to use for the Payments service. We created a (mostly) code-generated interface crate that can be declared as a dependency by both provider and actor, and we created a dummy implementation of the payments provider.
+At this point we've decided on a logical contract for actors and capability providers to use for the Payments service. We created a (mostly) code-generated interface crate that can be declared as a dependency by both provider and actor, and we created a placeholder implementation of the payments provider.
 
 Next we'll write an actor that communicates with any payment provider, regardless of whether it's our fake implementation or not.


### PR DESCRIPTION
## Feature or Problem

In setting up #406, I got to wondering if there was a way to better automate this, and came across [Microsoft's Inclusive Linting guidance](https://microsoft.github.io/code-with-engineering-playbook/continuous-integration/inclusive-linting/), which recommends adopting [`woke`](https://github.com/get-woke/woke).

This seems like a reasonable first step towards more inclusive language use, so I put together a PR to install `woke` from source (as opposed to using the [`woke-action`](https://github.com/get-woke/woke-action) which is pretty out of date at this point) and run it as part of the pipeline, failing if it reports any `error` levels.

## Example failure
<img width="1218" alt="Screenshot 2024-05-06 at 9 29 47 AM" src="https://github.com/wasmCloud/wasmcloud.com/assets/1687902/725356d0-9d52-42a0-a4fa-ff7dfc5b4f71">
