### PR TITLE
Add WASI Virt and composition example

### DIFF
--- a/docs/concepts/interfaces.mdx
+++ b/docs/concepts/interfaces.mdx
@@ -92,7 +92,7 @@ wasmCloud supports interfaces belonging to [WebAssembly System Interface (WASI)]
 | https://github.com/WebAssembly/wasi-http        | 0.2.0    |
 
 :::warning[Sensitive interfaces]
-As a security-first platform, wasmCloud provides stubbed implementations of `wasi-filesystem` and `wasi-sockets` that don’t truly interact with the host system. For functionality that depends on these interfaces, we recommend using [wasi-virt](https://github.com/bytecodealliance/wasi-virt) to virtualize your component.
+As a security-first platform, wasmCloud provides stubbed implementations of `wasi-filesystem` and `wasi-sockets` that don’t truly interact with the host system. For functionality that depends on these interfaces, we recommend using [wasi-virt](https://github.com/bytecodealliance/wasi-virt) to virtualize your component. **Learn more about using WASI Virt with wasmCloud** on the [**Virtualize**](/docs/developer/components/virtualize) developer page.
 :::
 
 Additionally, wasmCloud supports proposed WASI APIs that are in the process of implementation and standardization:

--- a/docs/concepts/linking-components/linking-at-build.mdx
+++ b/docs/concepts/linking-components/linking-at-build.mdx
@@ -8,7 +8,7 @@ type: 'docs'
 
 ## Overview
 
-At build-time, WebAssembly components may be **composed**, meaning they will be packaged together as a single component and linked internally. The composability of components is a core tenet of components' design. Open source CLI tools like [`wac`](https://github.com/bytecodealliance/wac) and [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools) (using the `compose` subcommand) enable you to compose components before deployment.
+At build-time, WebAssembly components may be **composed**, meaning they will be packaged together as a single component and linked internally. The composability of components is a core tenet of components' design. Open source CLI tools like [`wac`](https://github.com/bytecodealliance/wac) and [WASI Virt](https://github.com/bytecodealliance/wasi-virt) enable you to compose components before deployment.
 
 It's important to note that build-time composition is a matter of link *declaration*. These links will be resolved upon component instantiation by the WebAssembly runtime&mdash;in our case, [Wasmtime](https://github.com/bytecodealliance/wasmtime), the underlying runtime used by the wasmCloud host. 
 
@@ -23,48 +23,88 @@ Linking at build makes sense when...
 
 ## Example: Composition
 
-This example uses a Wasm component written in TypeScript that composes with the Rust component [wit2wadm](https://github.com/brooksmtownsend/wit2wadm). The wit2wadm tool is a small Rust library that is useful for generating deployment manifests, and can be compiled to a component. Here we are using its componentized form as an arbitrary example of a component that can be composed at build-time in order to reuse functionality from different languages. 
-
-The instructions below show how to build an arbitrary TypeScript component and compose it with the Rust-based wit2wadm component as if it was a native TypeScript library.
+In this example, we'll perform multiple compositions, using tools like **WAC** and **WASI Virt** to compose Wasm binaries that run in wasmCloud and Wasmtime, and ultimately arriving at a single composed component. 
 
 ### Prerequisites
 
-- [wasm-tools](https://github.com/bytecodealliance/wasm-tools/tree/main)
-- [jco](https://github.com/bytecodealliance/jco)
-- [wash](https://wasmcloud.com/docs/installation)
-- [node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
-- [rust](https://www.rust-lang.org/tools/install)
+This demo is designed to demonstrate multiple ecosystem tools, including:
 
-Clone the example TypeScript component repository:
+- [wasmCloud Shell (wash)](https://wasmcloud.com/docs/installation)
+- [Wasmtime](https://github.com/bytecodealliance/wasmtime)
+- [WebAssembly Compositions (WAC)](https://github.com/bytecodealliance/wac)
+- [WASI Virt](https://github.com/bytecodealliance/wasi-virt)
+
+Note that multiple tools require Cargo, and WASI Virt requires the [nightly release channel for Rust](https://github.com/bytecodealliance/WASI-Virt/blob/main/rust-toolchain.toml), so you may wish to install that up front:
 
 ```bash
-git clone https://github.com/brooksmtownsend/wit2wadm-ts.git
+rustup toolchain install nightly
 ```
 
-Install Node dependencies and build the component:
+#### wasmCloud Shell (`wash`)
+
+Follow the instructions for your OS on the [Installation page](https://wasmcloud.com/docs/installation). Since several of the following tools use [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html), you may wish to use `wash` through Cargo as well. 
+
+```shell
+cargo install wash-cli
+```
+
+#### Wasmtime 
+
+On Linux or macOS, you can install Wasmtime locally with an install script:
+
+```shell
+curl https://wasmtime.dev/install.sh -sSf | bash
+```
+
+#### WebAssembly Compositions (WAC)
+
+WAC requires [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html). Once you've installed Cargo:
+
+```shell
+cargo install wac-cli
+```
+
+#### WASI Virt
+
+WASI Virt requires the nightly release channel for [Rust](https://www.rust-lang.org/tools/install):
 
 ```bash
-# Install NPM dependencies
-npm install
-# Build the TypeScript component
+rustup toolchain install nightly
+```
+
+Install the `wasi-virt` command line tool with Rust's `cargo` package manager:
+
+```bash
+cargo +nightly install --git https://github.com/bytecodealliance/wasi-virt
+```
+
+#### Example files
+
+The example files are included in the wasmCloud [monorepo](https://en.wikipedia.org/wiki/Monorepo) at [github.com/wasmcloud/wasmcloud](https://github.com/wasmcloud/wasmcloud). You can perform a "sparse" checkout to download only the relevant example directory (and associated documentation and metadata):
+
+```bash
+git clone --depth 1 --no-checkout https://github.com/wasmCloud/wasmCloud.git
+cd wasmcloud
+git sparse-checkout set ./examples/rust/composition
+git checkout
+cd examples/rust/composition
+```
+
+For this example, we will use the `pong` and `http-hello2` directories as well as the `compose.wac` file at the root of the `composition` project directory.
+
+### Virtualizing a component
+
+Navigate to the `pong` directory. Here we have a Rust-based component with a custom interface called `pong` that will return a string "ping" on its exported `pingpong` interface. Build the component:
+
+```shell
+cd pong
 wash build
 ```
-Inside the `wit2wadm-ts` project directory, we'll clone the `wit2wadm` Rust library as well:
 
-```bash
-git clone https://github.com/brooksmtownsend/wit2wadm.git
-```
+We can use `wash inspect` to take a look at the WIT for this component:
 
-Now (from the root of `wit2wadm-ts`) we can build the other component:
-
-```bash
-wash build -p ./wit2wadm
-```
-
-Let's take a look at the two component's WIT interfaces:
-
-```bash
-wash inspect --wit ./wit2wadm/build/wit2wadm_component_s.wasm
+```shell
+wash inspect --wit ./build/pong_s.wasm
 ```
 ```wit
 package root:component;
@@ -82,63 +122,110 @@ world root {
   import wasi:filesystem/preopens@0.2.0;
   import wasi:random/random@0.2.0;
 
-  export wasmcloud:tools/convert;
+  export example:pong/pingpong;
 }
 ```
+You can see the `pingpong` interface listed as an export and `wasi:cli/environment` as one of many imports. 
 
-```bash
-wash inspect --wit ./build/wit2wadm_ts_s.wasm
+Now it's time to perform our first composition in the form of a virtualization with WASI Virt. Using WASI Virt, we're going to compose `pong_s.wasm` into an encapsulating component with an environment variable `PONG` set to `demo`. The resulting component will be named `virt.wasm`.
+
+```shell
+wasi-virt build/pong_s.wasm --allow-random -e PONG=demo -o virt.wasm
+```
+Now let's view the WIT for our virtualized component:
+
+```shell
+wash inspect --wit virt.wasm 
 ```
 ```wit
 package root:component;
 
 world root {
-  import wasmcloud:tools/convert;
+  import wasi:random/random@0.2.0;
 
-  export wasmcloud:tools/convert;
+  export example:pong/pingpong;
 }
 ```
+The virtualized component still exports `pingpong` but no longer requires `wasi:cli/environment`&mdash;that import (and all of the others except the new `wasi:random/random`, which we added via a WASI Virt argument) is satisfied by the encapsulating component. If we run this component on wasmCloud or with Wasmtime, the host will be able to satisfy the `random` import. But we still need another component to invoke this one via the exposed `pingpong` interface. 
 
-What we're going to be doing by composing these components together is connecting the `export wasmcloud:tools/convert` in the Rust component to the `import wasmcloud:tools/component` in the TypeScript component, and the final product is a single WebAssembly component.
+### Composing a component
 
-![wit2wasm architecture](../../images/wit2wadm-ts.png)
+In the `http-hello2` directory, we have a modified `http-hello-world` component that imports the `pingpong` interface and calls for a string from `pong` to append to the hello world message. Navigate to that directory and build the component.
 
-### Compose
-
-Compose the component with the wit2wadm Rust component in the `wit2wadm` directory, satisfying the `wasmcloud:tools/convert` import in our WIT:
-
-```bash
-# Copy into current directory for simplicity
-cp ./wit2wadm/build/wit2wadm_component_s.wasm ./wit2wadm.wasm
-# Compose the components, the wit2wadm component export will satisfy the import of the TypeScript component
-wasm-tools compose ./build/wit2wadm_ts_s.wasm --definitions ./wit2wadm.wasm > composed.wasm
+```shell
+cd ../http-hello2
+wash build
 ```
+For context, let's try running `wasmtime serve` *without* composing `pong` and `http-hello-world` together. 
 
-Taking a look at our composed component, we can see that we've ended up with a combination of both components:
+```shell
+wasmtime serve -S cli=y build/http_hello_world.wasm
+Error: component imports instance `example:pong/pingpong`, but a matching implementation was not found in the linker
+
+Caused by:
+    0: instance export `ping` has the wrong type
+    1: function implementation is missing
+```
+As we might expect, it doesn't work&mdash;the hello world component doesn't have anything linked to fulfill the `pong` import. If we compose it with the `pong` component, however, we essentially wire those corresponding imports and exports together within the encapsulating component. Head back to the root of the project directory with `cd ..` and then we'll use WAC to perform the composition.
+
+WAC works by encoding a composed component based on the instructions defined in a .wac file. The .wac file uses a superset of WIT also called WAC. Here are the contents of `compose.wac`:
+
+```wit
+package demo:composition;
+
+let pong = new ping:pong { ... };
+let hello = new hello:there { "example:pong/pingpong": pong.pingpong, ... };
+
+export hello...;
+```
+This is a pretty simple composition, but the the design of WAC facilitates much more complex compositions of many components. You can learn more about WAC usage in the tool's [readme](https://github.com/bytecodealliance/wac/blob/main/README.md) and [language guide](https://github.com/bytecodealliance/wac/blob/main/LANGUAGE.md). 
+
+For this demo's purposes, we simply need to run `wac encode` while indicating the components we wish to compose with the `--dep` argument, naming our output file with `-o`, and specifying our `.wac` instructions:
+
+```shell
+wac encode --dep ping:pong=./pong/virt.wasm --dep hello:there=./http-hello2/build/http_hello_world_s.wasm -o output.wasm compose.wac
+```
+Now we have a new file: `output.wasm`. Taking a look at our composed component, we can see that we've ended up with a combination of both components:
 
 ```bash
-wash inspect --wit ./composed.wasm
+wash inspect --wit output.wasm
 ```
 ```wit
 package root:component;
 
 world root {
-  import wasi:cli/environment@0.2.0;
-  import wasi:cli/exit@0.2.0;
+  import wasi:random/random@0.2.0;
   import wasi:io/error@0.2.0;
   import wasi:io/streams@0.2.0;
+  import wasi:http/types@0.2.0;
+  import wasi:cli/environment@0.2.0;
+  import wasi:cli/exit@0.2.0;
   import wasi:cli/stdin@0.2.0;
   import wasi:cli/stdout@0.2.0;
   import wasi:cli/stderr@0.2.0;
   import wasi:clocks/wall-clock@0.2.0;
   import wasi:filesystem/types@0.2.0;
   import wasi:filesystem/preopens@0.2.0;
-  import wasi:random/random@0.2.0;
 
-  export wasmcloud:tools/convert;
+  export wasi:http/incoming-handler@0.2.0;
 }
 ```
-If we wish to explore the flexibility of components, we can take this example further by transpiling the now-composed component to run as a JavaScript module in the web&mdash;that is beyond the scope of this page, but you can find instructions in the [example's GitHub repository](https://github.com/brooksmtownsend/wit2wadm-ts/tree/main). 
+
+Let's try running it with Wasmtime:
+
+```shell
+wasmtime serve -S cli=y output.wasm
+```
+```shell
+curl localhost:8080
+Hello World! I got pong demo
+```
+We can run the composed component in wasmCloud as well:
+
+```shell
+wash app deploy wadm.yaml
+```
+Congratulations! You've composed a component that runs anywhere supporting WASI P2. 
 
 ## Keep reading
 

--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -155,67 +155,70 @@ Linking components at runtime is a two-step process:
 <details>
 <summary>Example: Two Components</summary>
 
-Here is an example manifest for a hypothetical application comprised of two components and an http-server provider:
+Here is an example manifest for an example application comprised of two components and an http-server provider:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: foobar
+  name: http-hello-world
   annotations:
-    version: v0.0.1 
-    description: 'Multi-component demo'
-    experimental: true
+    version: v0.0.2
+    description: "HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
 spec:
   components:
-    # The first component
-    - name: foo-component
+    - name: http-component
       type: component
       properties:
-        image: fooimage
+        image: file://./build/http_hello_world_s.wasm
       traits:
+        # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
             replicas: 1
-        # Link definition for foo-component -> bar-component
         - type: link
           properties:
-            target: bar-component
-            namespace: custom
-            package: bar
-            interfaces: [bar]
-    # The second component
-    - name: bar-component
+            target: pong-component
+            namespace: example
+            package: pong
+            interfaces: [pingpong]
+
+    - name: pong-component
       type: component
       properties:
-        image: barimage
+        image: file://../pong/virt.wasm
       traits:
+        # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
             replicas: 1
-    # The httpserver provider
+
+    # Add a capability provider that enables HTTP access
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.20.1
       traits:
-        # Link definition for httpserver -> bar-component
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8080 for incoming requests
         - type: link
           properties:
-            target: foo-component
+            target: http-component
             namespace: wasi
             package: http
-            interfaces: [incoming-handler] 
-            source_config: 
+            interfaces: [incoming-handler]
+            source_config:
               - name: default-http
-                properties: 
+                properties:
                   address: 127.0.0.1:8080
 
 ```
 
-* The foo-component is **exporting on the wasi-http interface** and **importing on a custom "bar" interface**. It is the importer in relation to the bar-component, so it is the source for that link. 
-* The bar-component is **exporting on the custom "bar" interface**. This is its only link relationship, and it is the exporter, so no links are defined as a trait of bar-component. 
-* The httpserver provider is **importing on the wasi-http interface**. It is the importer in relation to foo-component, so it is the source for that link, and basic configuration is performed in the `source_config`.
+* The http-component is **exporting on the wasi-http interface** and **importing on a custom "pingpong" interface**. It is the importer in relation to the pong-component, so it is the source for that link. 
+* The pong-component is **exporting on the custom "pingpong" interface**. This is its only link relationship, and it is the exporter, so no links are defined as a trait of pong-component. 
+* The httpserver provider is **importing on the wasi-http interface**. It is the importer in relation to http-component, so it is the source for that link, and basic configuration is performed in the `source_config`.
+
+If you would like to build and run the example described by this manifest, follow Steps 1 and 2 in the [composition example readme](https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/composition). 
 
 Remember that the [wit2wadm](https://github.com/brooksmtownsend/wit2wadm) tool is available to help you automatically generate a Wadm deployment manifest for a given component. Because it extrapolates link definitions from a component's WIT interfaces, it can be very helpful for not only generating manifests but understanding linking relationships in your application. 
 </details>

--- a/docs/developer/components/index.md
+++ b/docs/developer/components/index.md
@@ -15,3 +15,4 @@ The following pages will take you through the process of developing application 
 - [Configure](./configure)
 - [Iterate](./update)
 - [Publish](./publish)
+- [Virtualize](./virtualize)

--- a/docs/developer/components/virtualize.mdx
+++ b/docs/developer/components/virtualize.mdx
@@ -1,0 +1,145 @@
+---
+title: 'Virtualize'
+date: 2024-05-13T11:00:00+00:00
+sidebar_position: 6
+draft: false
+---
+
+In the course of developing some components, you may find that you need to be able to **virtualize** a component within another encapsulating component in order to abstract away certain requirements. For example, the component may use an import not available from either the host or another entity on the lattice. One common reason for this scenario is that a required import is not secure. Virtualization provides an additional layer of sandboxing.
+
+In conventional usage, components utilizing WASI APIs such as Sockets and Filesystem have access to core operating system interfaces. In order to run such APIs securely on wasmCloud, it is necessary to isolate the component with [**WASI Virt**](https://github.com/bytecodealliance/wasi-virt).
+
+WASI Virt is a [Bytecode Alliance](https://bytecodealliance.org/) project that enables encapsulation of a virtualized component within another component. WASI API usage is deny-by-default for virtualized components&mdash;interfaces must be explicitly enabled at the time of composition. WASI Virt supports the following WASI APIs:
+
+* Clocks
+* Environment
+* Exit
+* Filesystem
+* HTTP
+* Random
+* Sockets
+* Stdio
+
+WASI Virt's virtual adapters are implemented with Wasm, providing complete isolation between the application and virtualization layers. Because WASI Virt and wasmCloud use the common standards of the Component Model and WASI P2, components generated with WASI Virt may be deployed directly to wasmCloud.
+
+## Install WASI Virt
+
+WASI Virt requires the nightly release channel for [Rust](https://www.rust-lang.org/tools/install):
+
+```bash
+rustup toolchain install nightly
+```
+
+Install the `wasi-virt` command line tool with Rust's `cargo` package manager:
+
+```bash
+cargo +nightly install --git https://github.com/bytecodealliance/wasi-virt
+```
+
+## Example: Virtualized environment variables
+
+In this example, we'll use WASI Virt to virtualize a component that uses **environment variables** within an encapsulating component.
+
+In addition to WASI Virt, you will need [wasmCloud Shell (wash)](https://wasmcloud.com/docs/installation).
+
+The example files are included in the wasmCloud [monorepo](https://en.wikipedia.org/wiki/Monorepo) at [github.com/wasmcloud/wasmcloud](https://github.com/wasmcloud/wasmcloud). You can perform a "sparse" checkout to download only the relevant example directory (and associated documentation and metadata):
+
+```bash
+git clone --depth 1 --no-checkout https://github.com/wasmCloud/wasmCloud.git
+cd wasmcloud
+git sparse-checkout set ./examples/rust/composition
+git checkout
+cd examples/rust/composition
+```
+
+For this example, we will use only the `pong` directory.
+
+### Virtualizing a component
+
+Navigate to the `pong` directory. Here we have a Rust-based component with a custom interface called `pong` that will return a string "ping" on its exported `pingpong` interface. Build the component:
+
+```shell
+cd pong
+wash build
+```
+
+We can use `wash inspect` to take a look at the WIT for this component:
+
+```shell
+wash inspect --wit ./build/pong_s.wasm
+```
+```wit
+package root:component;
+
+world root {
+  import wasi:cli/environment@0.2.0;
+  import wasi:cli/exit@0.2.0;
+  import wasi:io/error@0.2.0;
+  import wasi:io/streams@0.2.0;
+  import wasi:cli/stdin@0.2.0;
+  import wasi:cli/stdout@0.2.0;
+  import wasi:cli/stderr@0.2.0;
+  import wasi:clocks/wall-clock@0.2.0;
+  import wasi:filesystem/types@0.2.0;
+  import wasi:filesystem/preopens@0.2.0;
+  import wasi:random/random@0.2.0;
+
+  export example:pong/pingpong;
+}
+```
+You can see the `pingpong` interface listed as an export and `wasi:cli/environment` as one of many imports. 
+
+Using WASI Virt, we can compose `pong_s.wasm` into an encapsulating component with an environment variable `PONG` set to `demo`. The resulting component will be named `virt.wasm`.
+
+```shell
+wasi-virt build/pong_s.wasm --allow-random -e PONG=demo -o virt.wasm
+```
+In this command...
+
+* We define the input component, `build/pong_s.wasm`
+* We use `--allow-random` to allow the virtualized component to import `wasi:random/random`, because we know the wasmCloud host can satisfy that requirement
+* We set an environment variable `PONG` to `demo` using the `-e` flag
+* We name the output component `virt.wasm`
+
+Now let's view the WIT for our virtualized component:
+
+```shell
+wash inspect --wit virt.wasm 
+```
+```wit
+package root:component;
+
+world root {
+  import wasi:random/random@0.2.0;
+
+  export example:pong/pingpong;
+}
+```
+The virtualized component still exports `pingpong` but no longer requires `wasi:cli/environment`&mdash;that import (and all of the others except `wasi:random/random`, which we added via a WASI Virt argument) is satisfied by the encapsulating component. If we run this component on wasmCloud, the host will be able to satisfy the `random` import&mdash;it will simply require another component to invoke it via the `pingpong` interface. 
+
+In the `http-hello2` directory, we have a modified `http-hello-world` component that imports the `pingpong` interface and calls for a string from `pong` to append to the hello world message. Let's navigate over to that directory and build the component.
+
+```shell
+cd ../http-hello2
+wash build
+```
+The `wadm.yaml` deployment manifest in this directory will launch both the virtualized `pong` component and the new `http-hello-world` we just built. When we deploy with this manifest, wasmCloud will automatically [**link the components at runtime**](/docs/concepts/linking-components/linking-at-runtime.mdx), so that `pong` can satisfy the import of `http-hello-world`. 
+
+```shell
+wash app deploy wadm.yaml
+```
+
+When we invoke `http-hello-world` via `curl`, it invokes `pong`:
+
+```shell
+curl localhost:8080
+Hello World! I got pong demo
+```
+
+The environment variable value `demo` from our virtualization is returned in the hello world message. 
+
+## Further reading
+
+For more information on using WASI Virt, see the [project repository on GitHub](https://github.com/bytecodealliance/wasi-virt).
+
+

--- a/docs/ecosystem/useful-webassembly-tools/index.mdx
+++ b/docs/ecosystem/useful-webassembly-tools/index.mdx
@@ -88,4 +88,14 @@ Install the `wasi-virt` command line tool with `cargo`:
 ```bash
 cargo +nightly install --git https://github.com/bytecodealliance/wasi-virt
 ```
+Learn more about using WASI Virt with wasmCloud on the [Virtualize](/docs/developer/components/virtualize) developer page.
 
+## Combine components with WebAssembly Compositions (WAC)
+
+[WAC](https://github.com/bytecodealliance/wac) is a powerful CLI tool for declaratively composing components, enabling you to [link components at build](/docs/concepts/linking-components/linking-at-build). WAC uses a superset of WIT called WAC to describe component relationships. You can learn how to use the WAC language in the [WAC language guide](https://github.com/bytecodealliance/wac/blob/main/LANGUAGE.md). 
+
+WAC requires [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html). Once you've installed Cargo:
+
+```shell
+cargo install wac-cli
+```


### PR DESCRIPTION
Makes the following additions:

* Replaces wit2wadm example with composition example in **Concepts -> Linking Components -> Linking at Build**
* Adds a **Virtualize** page on WASI Virt in **Developer Guide -> Components** with example (from composition example) on using environment variables from virtualized components
* Adds WAC to **Toolchain -> Useful WebAssembly Tools**

Also adds links to the new WASI Virt page in relevant spots and updates a component linking example.