### PR TITLE
Update troubleshooting docs

### DIFF
--- a/docs/cli/drain.md
+++ b/docs/cli/drain.md
@@ -5,7 +5,13 @@ sidebar_position: 10
 description: "wash drain command reference"
 --- 
 
-Wash drain helps you in managing contents of local wasmCloud caches. This command allows you to clear caches selectively for various items downloaded while working on a wasmCloud environment. Following are the subcommands available under `wash drain`:
+`wash drain` helps you in managing contents of local wasmCloud caches. This command allows you to clear caches selectively for various items downloaded while working on a wasmCloud environment. 
+
+:::warning
+`wash drain` does not remove all data associated with wasmCloud on a given machine. NATS streams and buckets are decoupled from the rest of the system&mdash;see the [host troubleshooting](/docs/developer/debugging/host) page for instructions on how to achieve a complete wipe of a local wasmCloud environment.
+:::
+
+Following are the subcommands available under `wash drain`: 
 
 - `all`
 - `oci`

--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -20,7 +20,7 @@ wash link query
 ```
 
 ### `put`
-Adds a link definition in the lattice associated with a component and provider and having an associated contract. If you want to name the link, you may pass a value to the `--link-name` flag. Be default, the link name is "default".
+Adds a link definition in the lattice associated with a component and provider and having an associated contract. If you want to name the link, you may pass a value to the `--link-name` flag. By default, the link name is "default".
 
 #### Usage
 ```
@@ -32,7 +32,7 @@ Deletes a link definition in the lattice. If it is named other than "default" th
 
 #### Usage
 ```
-wash link del [OPTIONS] --namespace <WIT_NAMESPACE> --package <WIT_PACKAGE> <source-id>
+wash link del [OPTIONS] <source-id> <wit-namespace> <wit-package>
 ```
 
 #### Options

--- a/docs/concepts/applications.mdx
+++ b/docs/concepts/applications.mdx
@@ -8,9 +8,11 @@ type: 'docs'
 
 ## Overview
 
-Applications combine all of the previous concepts into a declarative, deployable unit. wasmCloud supports the imperative management of [components](/docs/concepts/components), [providers](/docs/concepts/providers), and [links](/docs/concepts/linking-components/), which can be useful for experimentation or debuggging. However, these are generally considered low-level operations. wasmCloud supports complex distributed applications that can be dynamically adjusted at runtime, and managing a combination of components, providers, links, and configuration one command at a time quickly becomes unwieldy.
+Applications combine all of the previous concepts into a declarative, deployable unit. 
 
-Applications are the primary way to deploy workloads in a wasmCloud [lattice](/docs/concepts/lattice). Applications are declarative, versioned, defined using a familiar syntax (YAML or JSON), and leverage an [existing manifest standard](https://oam.dev/). Define your app, hit "deploy", and wasmCloud will take care of the rest.
+Applications are the primary abstraction for deployable workloads in a wasmCloud [lattice](/docs/concepts/lattice). Applications are declared, versioned, and defined using **application manifests**. Manifests conform to the [OAM manifest standard](https://oam.dev/) and may be written in YAML or JSON. 
+
+Once deployed, applications are represented as **models** in the **wasmCloud Application Deployment Manager (Wadm)**. An application model may include multiple deployable versions. Model persistence is decoupled from deployments themselves and from any particular host.
 
 :::info
 
@@ -18,9 +20,12 @@ If you're familiar with Kubernetes or Nomad, you can think of a wasmCloud applic
 
 :::
 
-### Application Manifests
+### Application manifests
 
-wasmCloud application manifests are composed of two sections: metadata and a `spec`. The metadata contains the application's name, version, and description. The `spec` contains a list of the application's components (application components and capability providers), each of which can have `traits`. Traits define configuration for the component, links, and how the component should be deployed. Examples of deployment traits include:
+wasmCloud application manifests are composed of two sections: metadata and `spec`. 
+
+* The metadata contains the application's name, version, and description. 
+* The `spec` contains a list of the application's components and providers, each of which can have `traits`. Traits define configuration for the component, links, and how the component should be deployed. Examples of deployment traits include:
 
 - run a single instance on a specific host `foo`
 - run `N` instances on each host in the lattice
@@ -63,8 +68,18 @@ spec:
             replicas: 1
 ```
 
-### wasmCloud Application Deployment Manager (WADM)
+:::[Write less YAML]
+The design of WebAssembly Interface Type (WIT) interfaces makes it possible to automate the generation of a manifest for a given component. Use the [`wit2wadm`](https://github.com/brooksmtownsend/wit2wadm) tool to quickly generate manifests from your components on the command line. 
+:::
 
-To deploy and manage applications, wasmcloud uses WADM. WADM uses a control loop to react to events and reconcile requested state with desired state.
+### wasmCloud Application Deployment Manager (Wadm)
 
-For an in-depth guide into how how wasmCloud manages applications, see the [WADM documentation](/docs/ecosystem/wadm/).
+To deploy and manage applications, wasmcloud uses Wadm. Wadm uses a control loop to react to events and reconcile requested state with desired state.
+
+For an in-depth guide into how how wasmCloud manages applications, see the [Wadm documentation](/docs/ecosystem/wadm/).
+
+:::info[Imperative or declarative?]
+While wasmCloud supports the imperative management of [components](/docs/concepts/components), [providers](/docs/concepts/providers), and [links](/docs/concepts/linking-components/) (which can be useful for experimentation or debuggging), these are generally considered low-level operations. Declarative application management is generally better-suited to complex distributed applications that can be dynamically adjusted at runtime.
+:::
+
+Application models are stored in a NATS key-value bucket and persist beyond a particular host. For more information on how Wadm handles models, see the [reference for the Wadm API](https://wasmcloud.com/docs/ecosystem/wadm/api).

--- a/docs/developer/debugging/components.mdx
+++ b/docs/developer/debugging/components.mdx
@@ -55,7 +55,7 @@ The command line wasmCloud shell (aka [wash](https://github.com/wasmCloud/wasmCl
 
 If any of the component ID, provider ID, link name, or contract ID are misspelled or omitted, then the host will deny the invocation.
 
-## Debugging Invocations
+## Debugging invocations
 
 :::info
 

--- a/docs/developer/debugging/host.mdx
+++ b/docs/developer/debugging/host.mdx
@@ -8,21 +8,15 @@ draft: false
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-:::info
-
-The primary wasmCloud host runtime is the [`wasmcloud-host`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/host), which you'll be using if you're running the host from wash, a released binary, or with the [wasmcloud](https://hub.docker.com/r/wasmcloud/wasmcloud) docker image.
-
-The Javascript host has different log messages, and it's recommended to create an issue in the [wasmcloud-js repo](https://github.com/wasmCloud/wasmcloud-js/issues/new) if you are running into errors in the browser.
-
-:::
+## Using logs
 
 The first place to check when troubleshooting the host is logs. wasmCloud host logs include the following:
 
 1. Logs from the host runtime
 1. Logs from components
-1. Logs from capability providers
+1. Logs from providers
 
-### Finding the Logs
+### Finding the logs
 
 <Tabs queryString="installation">
   <TabItem value="binary" label="wash" default>
@@ -89,7 +83,7 @@ Note that all components and providers inherit the same log level settings as th
 
 :::
 
-### Log Format
+### Log format
 
 By default, the wasmCloud host emits logs as unstructured text. However, structured logs can be enabled via the `--enable-structured-logging` flag, or by setting the `WASMCLOUD_STRUCTURED_LOGGING_ENABLED` environment variable to `true`. Structured logs are convenient when forwarding logs to an aggregation tool.
 
@@ -102,3 +96,79 @@ Structured logs look like the following:
 {"timestamp":"2023-12-19T22:16:06.402034Z","level":"INFO","fields":{"message":"bucket already exists. Skipping creation.","bucket":"CONFIGDATA_default"},"target":"wasmcloud_host::wasmbus"}
 {"timestamp":"2023-12-19T22:16:06.406203Z","level":"INFO","fields":{"message":"wasmCloud host started","host_id":"NC3CUT4IP43REAEQDE33652YNK4Z7KFE7KI3XGUMHVNSP2TNY3CFAH4M"},"target":"wasmcloud_host::wasmbus"}
 ```
+
+## Cleaning the slate
+
+In the course of troubleshooting, you may wish to completely clear your existing wasmCloud environment and start with a fresh installation. You can follow these steps to do so, but **note that the process will remove all existing data associated with wasmCloud** including application models stored on the lattice.
+
+### Drain and uninstall `wash`
+
+Run `wash drain` to clear caches (including OCI artifacts and provider binaries) and then uninstall `wash` in the same way you installed it. (The example below assumes an install via Cargo.)
+
+```shell
+wash drain
+# Uninstall wash the same way you installed it
+cargo uninstall wash-cli
+# Ensure the wash directory is clear
+rm -r ~/.wash
+```
+
+### Clear NATS streams and buckets 
+
+Several **streams** and **key-value buckets** used by wasmCloud persist on NATS even if `wash` is uninstalled, since the model store is decoupled from any given host. 
+
+You can interact directly with NATS using the NATS CLI. Find instructions to install the CLI on the [NATS CLI GitHub repo](https://github.com/nats-io/natscli). 
+
+You can list all streams on your NATS instance with:
+
+```shell
+nats stream list -a
+```
+
+The `-a` flag includes system streams in the list. The listed streams will include:
+
+* `wadm_commands`
+* `wadm_events`
+* `wadm_mirror`
+* `wadm_notify`
+* `KV_CONFIGDATA_default`
+* `KV_wadm_manifests`
+* `KV_wadm_state`
+* `wadm_status`
+* `KV_LATTICEDATA_default`
+
+To delete a NATS stream:
+
+```shell
+nats stream del STREAM_NAME
+```
+For example: `nats stream del wadm_status`
+
+You can list all key-value buckets on your NATS instance with:
+
+```shell
+nats kv list
+```
+
+The listed key-value buckets will include:
+
+* `CONFIGDATA_default`
+* `wadm_manifests`
+* `wadm_state`
+* `LATTICEDATA_default`
+
+To delete a NATS key-value bucket:
+
+```shell
+nats kv del BUCKET_NAME CONTEXT_NAME
+```
+Unless you've added or edited a context, the CONTEXT_NAME value is `host_default`.
+
+For example: `nats kv del wadm_state host_default`
+
+For a total reset, delete all buckets and streams. These buckets and streams will be automatically regenerated when you run `wash up` from your new `wash` installation. 
+
+### Reinstall `wash`
+
+[Install `wash`](https://wasmcloud.com/docs/installation) again according to the instructions for your installation method.
+

--- a/docs/ecosystem/wadm/api.md
+++ b/docs/ecosystem/wadm/api.md
@@ -7,7 +7,7 @@ type: 'docs'
 sidebar_position: 4
 ---
 
-The normal way to interact with a `wadm` installation (which could be a single server or a cluster)
+The most common way to interact with a Wadm installation (which could be a single server or a cluster)
 is through the [wash](./usage.md) command-line tool. However, if you are planning on
 creating your own integration or writing a non-Rust language binding, then this reference will help.
 
@@ -15,16 +15,16 @@ creating your own integration or writing a non-Rust language binding, then this 
 _wadm and its corresponding API are not currently 1.0_. This means the API is likely to
 undergo changes and there may be some pieces that aren't yet implemented. This document will be
 updated as we continue to work on the API. All API changes will also be communicated via the release
-notes for wadm
+notes for Wadm.
 :::
 
 Please note that in production deployments, you will likely be using separate NATS credentials for
-accessing wadm. Please see the [deployment guide](/docs/deployment/wadm/) for more information for running
-wadm in production.
+accessing Wadm. Please see the [operator guide](/docs/deployment/wadm/) for more information for running
+Wadm in production.
 
-## Topic Space
+## Topic space
 
-The wadm API is exposed entirely as a NATS service on a topic space. All of the API operations will
+The Wadm API is exposed entirely as a NATS service on a topic space. All of the API operations will
 occur as _requests_ (_not_ simple publishes) on a topic in the following format:
 
 ```
@@ -32,7 +32,7 @@ wadm.api.{lattice-id}.{category}.{operation}.{object}
 ```
 
 The `operation` is usually a verb, and `object` is an optional scope-limiter to the operation. In
-many cases, the `object` will be something like a model name.
+many cases, the `object` will be something like a model name. 
 
 All requests and responses on this topic are encoded as JSON, except for the creation of models.
 
@@ -42,13 +42,11 @@ governing NATS topic segments. For example, they cannot contain spaces, commas, 
 characters, or periods.
 :::
 
-## Model Persistence
+## Model persistence
 
-The following operations pertain to storing and retrieving models. Persistence of models is
-explicitly and deliberately separated from deployment management. Any model can have multiple
-versions stored, and any one of those versions can be deployed
+In wasmCloud, models are versioned representations of application workloads stored in NATS key-value buckets. The following operations pertain to storing and retrieving models. Persistence of models is explicitly and deliberately separated from deployment management. Any model can have multiple versions stored, and any one of those versions can be deployed. Model persistence is similarly decoupled from any particular host. 
 
-### Store Models
+### Store models
 
 `wadm.api.{lattice}.model.put`
 
@@ -91,7 +89,7 @@ If the model and version being submitted already exist, the request will be _rej
 this won't automatically deploy a model, it only affects storage. The response will tell the caller
 how many versions are on file and the current version number _after_ the operation completed.
 
-### Get Model List
+### Get model list
 
 `wadm.api.{lattice-id}.model.list`
 
@@ -123,7 +121,7 @@ required to be semver, only recommended). The `deployed_version` field will be s
 that is currently deployed. If no version is deployed, this field will be set to `null`. Please note
 that `description` can also be `null` if no description was set
 
-### Get a Model Spec
+### Get a model spec
 
 `wadm.api.{lattice}.model.get.{name}`
 
@@ -214,7 +212,7 @@ to fetch a specific version
 Note that the `manifest` field is the JSON serialization of the [OAM
 model](https://github.com/wasmCloud/wadm/tree/main/oam)
 
-### Version History
+### Version history
 
 `wadm.api.{lattice}.model.versions.{name}`
 
@@ -240,7 +238,7 @@ Each of the items in the response list describes a revision and indicates whethe
 the deployed one. Remember that the ordering of the list does not reflect the semantic versioning as
 we do not require that the version field be semver.
 
-### Delete Models
+### Delete models
 
 `wadm.api.{lattice}.model.del.{name}`
 
@@ -270,7 +268,7 @@ currently deployed, then the resources will be undeployed automatically as well.
 The response indicates success, failure, or noop (i.e. nothing was deleted because it didn't exist),
 and if an `undeploy` operation occurred as part of the delete.
 
-## Managing Deployments
+## Managing deployments
 
 Deployments are discrete instances of autonomous control agents that monitor an application model
 against the real-time, discovered state of a lattice. This agent monitors lattice events, compares
@@ -357,7 +355,7 @@ It's important to note that the success/fail of this call doesn't indicate compl
 only success or failure of the receipt of the deployment request. In other words, the response is an
 _ack_. `notfound` is a specific error condition that indicates the model or version was not found
 
-### Deployment Status
+### Deployment status
 
 :::warning
 This functionality is not yet implemented. The documentation below is what we plan on implementing


### PR DESCRIPTION
A bunch of updates aiming to fill some gaps I noticed when troubleshooting, most notably:

* Updating `wash link del` usage
* Clarifying the relationship between applications and models
* Clarifying the behavior and implementation of models, including where they are stored
* Instructions for achieving a “clean slate” new installation on the Host Troubleshooting page

I’d appreciate someone double-checking the NATS details on that last bullet. Thanks!