### PR TITLE
Correct example manifest and typo

### DIFF
--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -399,32 +399,29 @@ metadata:
   name: hello-world
   annotations:
     version: v0.0.1
-    description: 'HTTP hello world demo using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    description: 'HTTP hello world demo'
 spec:
   components:
     - name: http-component
       type: component
       properties:
-        # Your manifest will point to the path of the built component, you can also
-        # start published components from OCI registries
+        # Your manifest deploys from a local .wasm file, but you can also use OCR registries as below
         image: wasmcloud.azurecr.io/http-hello-world:0.1.0
       traits:
         # One replica of this component will run
         - type: spreadscaler
           properties:
             replicas: 1
-
     # The httpserver capability provider, started from the official wasmCloud OCI artifact
     - name: httpserver
       type: capability
       properties:
         image: ghcr.io/wasmcloud/http-server:0.20.0
       traits:
-        # Link the HTTP server, and inform it to listen on port 8080
-        # on the local machine
+        # Link the HTTP server and set it to listen on the local machine's port 8080
         - type: link
           properties:
-            target: http-hello-world
+            target: http-component
             namespace: wasi
             package: http
             interfaces: [incoming-handler]

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -9,7 +9,7 @@ import washboard_hello from '../images/washboard_hello.png';
 
 ## Scaling up 📈
 
-WebAssembly can be easily scaled due to its small size, portability, and [wasmtime](https://wasmtime.dev/)'s ability to efficiently instantiate multiple instances of a single WebAssembly component. We leverage these aspects to make it simple to scale your applications with wasmCloud. Components only use resources when they're actively processing requests, so you can specify the number of replicas you want to run and wasmCloud will automatically scale up and down to meet demand. Let's scale up our hello world application to 50 replicas by editing `wadm.yaml`:
+WebAssembly can be easily scaled due to its small size, portability, and [wasmtime](https://wasmtime.dev/)'s ability to efficiently instantiate multiple instances of a single WebAssembly component. We leverage these aspects to make it simple to scale your applications with wasmCloud. Components only use resources when they're actively processing requests, so you can specify the number of replicas you want to run and wasmCloud will automatically scale up and down to meet demand. Let's scale up our hello world application to 100 replicas by editing `wadm.yaml`:
 
 ```yaml {17-19}
 apiVersion: core.oam.dev/v1beta1


### PR DESCRIPTION
Minor fixes to quickstart:

- In example manifest on "Hello World" page, `httpserver` link should target `http-component`.
- On "Scale and distribute" page, number of replicas in instructions should be 100, not 50.