### PR TITLE
feat: extend developer workflow docs for new wash commands

### DIFF
--- a/docs/cli/app.md
+++ b/docs/cli/app.md
@@ -18,7 +18,7 @@ When deploying apps using [wadm](../ecosystem/wadm/index.md), the easiest way to
 ### `list`
 This will retrieve a list of all applications that wadm knows about. Application specifications (also referred to in our documentation and code as "models") are stored in a model store and are associated to your lattice.
 
-Usage: 
+Usage:
 
 ```
 wash app list
@@ -77,6 +77,12 @@ wash app deploy <name> [version]
 wash app deploy petclinic v0.0.1
 ```
 
+You can also *replace* a wadm application manifest with the `--replace` option:
+
+```
+wash app deploy --replace path/to/wadm.yaml
+```
+
 ### `undeploy`
 Undeploying an application spec tells wadm to stop monitoring that deployment. By default, all resources originally provisioned for an application will be removed after that application is undeployed.
 
@@ -87,44 +93,52 @@ wash app undeploy <name>
 wash app undeploy petclinic
 ```
 
+### `validate`
+Figure out if a wadm manifest has any issues that might prevent it from working properly.
+
+Usage:
+
+```
+wash app validate path/to/wadm.yaml
+```
 
 ### Options
 The following options can be specified with all of the above subcommands for a finer control of your environment.
 
-#### --output 
+#### --output
 Alias: `-o`.
         Specify output format (text or json). The default value is text.
-        
-#### --ctl-host 
+
+#### --ctl-host
 Alias: `-r`.
         CTL Host for connection. The default value is 127.0.0.1 for local nats [env: WASMCLOUD_CTL_HOST=]
 
 #### --experimental
 Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
 
-#### --ctl-port 
+#### --ctl-port
 Alias: `-p`.
         CTL Port for connections, defaults to 4222 for local nats [env: WASMCLOUD_CTL_PORT=]
 
-#### --ctl-jwt 
+#### --ctl-jwt
 JWT file for CTL authentication. Must be supplied with ctl_seed [env: WASMCLOUD_CTL_JWT]
 
-#### --ctl-seed 
+#### --ctl-seed
 Seed file or literal for CTL authentication. Must be supplied with ctl_jwt [env: WASMCLOUD_CTL_SEED]
 
-#### --ctl-credsfile 
+#### --ctl-credsfile
 Credsfile for CTL authentication. Combines ctl_seed and ctl_jwt. See https://docs.nats.io/using-nats/developer/connecting/creds for details [env: WASH_CTL_CREDS]
 
-#### --js-domain 
+#### --js-domain
 JS domain for wasmCloud control interface. Defaults to None [env: WASMCLOUD_JS_DOMAIN]
 
-#### --lattice-prefix 
+#### --lattice-prefix
 Alias: `-x`.
         Lattice name for wasmCloud control interface. The default value is "default". [env: WASMCLOUD_LATTICE_PREFIX=]
 
-#### --timeout-ms 
+#### --timeout-ms
 Alias: `-t`.
         Timeout length to await a control interface response. The default value is 2000 milliseconds [env: WASMCLOUD_CTL_TIMEOUT_MS=] [default: 2000]
 
-#### --context 
+#### --context
 Path to a context with values to use for CTL connection and authentication

--- a/docs/cli/up.md
+++ b/docs/cli/up.md
@@ -180,3 +180,7 @@ If enabled, wasmCloud will not be downloaded if it's not installed
 wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases [env: WADM_VERSION=] [default: v0.6.0]
 
 #### --disable-wadm
+
+#### --wadm-manifest
+
+Specify a wadm application manifest to run right after starting the host.

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -10,7 +10,7 @@ As a developer using wasmCloud, there are a number of common day-to-day workflow
 
 The following is a list of developer workflows _sorted_ from **_most to least common_**.
 
-### Building Components
+## Building Components
 
 The most common thing application developers will do is build [components](/docs/concepts/components). Components encompass pure business logic in wasmCloud, and only communicate with non-functional requirements through capability providers and abstract [interfaces](/docs/concepts/interfaces).
 
@@ -29,7 +29,7 @@ The developer's _iteration loop_ for building a component looks something like t
 
 As of wash 0.18.0, there is now a `wash dev` command that automates this process for you. See the [Customizing the component](/docs/developer/components/update) section for more details on how to use it.
 
-### Building Providers
+## Building Providers
 
 The workflow for building a capability provider is similar to that of building a component. Once you've located and declared a dependency on the _interface_ implemented by your capability provider, the _iteration loop_ looks something like this:
 
@@ -64,7 +64,7 @@ Previous guides used `wash reg push`, which is now deprecated and will be remove
 See [the wash command ref componenting RFC](https://github.com/wasmCloud/wash/issues/538) for more information and to provide feedback
 :::
 
-### Allowing unauthenticated OCI registry access
+## Allowing unauthenticated OCI registry access
 
 The wasmCloud host runtime will, by default, require that all OCI references use authentication in order to resolve and download. This is a security measure that is enabled by default to keep the system as secure as possible.
 
@@ -72,8 +72,54 @@ However, if you're running the local docker-supplied registry with its default s
 
 This can be done by setting the environment variable `WASMCLOUD_OCI_ALLOWED_INSECURE` to include the URL of your local registry, e.g. `localhost:5000`. You can either supply this as an environment variable directly when you start a local wasmCloud host via `iex` or the release binary, or you can modify your shell profile to always set this variable on your development workstation.
 
-### Purging the OCI cache
+## Purging the OCI cache
 
 The wasmCloud host runtime caches the files that it receives from OCI registries beneath whatever `temp` directory your operating system prefers. Because images in an OCI registry are supposed to be _immutable_ (another reason we recommend against using `latest` when requesting an image version), the wasmCloud host has no reason to automatically purge or overwrite these files in the cache.
 
 During your local development iterations, you will likely find yourself pushing the same file with the same OCI reference over and over again. In order for the wasmCloud host to see these changes, you'll need to _drain_ the wasmCloud host cache. This can be done by executing one of the variants of `wash drain`, such as `wash drain all`.
+
+## Testing wadm manifests faster with `wash`
+
+As of `wash` v0.29.0, deploying applications and iterative development has become much easier with the help of a few new commands.
+
+### Validate wadm application manifests before deploying them
+
+Misspelled interfaces, missing links, and other issues can be hard to find in a wadm application manifest.
+
+To find potential issues *before* you `wash app deploy` your manifest, use `wash app validate`:
+
+```console
+wash app validate path/to/your/wadm.yaml
+```
+
+`wash app validate` will check for common issues and errors in your wadm manifest, and notify you of any issues.
+
+### Start a host and deploy a wadm application manifest in one command
+
+The easiest way to test a wadm application is to start a host, deploy the application, and start using it.
+
+To quickly run a host and deploy a *single* wadm manifest, run `wash up` with `--wadm-manifest`:
+
+```console
+wash up --wadm-manifest path/to/your/wadm.yaml
+```
+
+When run this way, `wash up` will start a single host lattice as normal, but *also* deploy your provided manifest to the running lattice, so you can interact with your application as soon as possible.
+
+### Easily deploy a wadm application manifest continuously
+
+If you have your host running in a seperate shell/terminal window and want to avoid having to constantly `wash app delete` in-between changes to your project and/or manifest, you can run `wash app deploy` with the `--replace` option:
+
+```console
+wash app deploy --replace path/to/your/wadm.yaml
+```
+
+Running `wash app deploy` with the `--replace` flag makes wash attempt to delete the application before attempting to deploy it.
+
+Combine this with a tool like [`cargo watch`][cargo-watch] (in the Rust ecosystem) and you can continously re-deploy your manifest any time your Rust project changes:
+
+```console
+cargo watch -- wash app deploy --replace path/to/your/wadm.yaml
+```
+
+[cargo-watch]: https://crates.io/crates/cargo-watch


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

This commit extends the developer workflow docs with the new commands that were added to wash and released in version 0.29.0:

- `wash app validate`
- `wash up --manifest`
- `wash app deploy --replace`

These commands make the workflow quicker (and are the precursors to `wash app dev`), so having some docs around them will hopefully improve DX.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
