### PR TITLE
chore: re-add wash reg to versioned docs, redirect new docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,7 +27,9 @@ redirects = [
   { from = "/docs/category/securing-applications", to = "/docs/deployment/lattice/security-patterns", status = 301 },
   { from = "/docs/category/wasmcloud-in-production", to = "/docs/deployment", status = 301 },
 
-  { from = "/docs/docs/getting-started", to = "/docs/installation", status = 301 },
+  { from = "/docs/cli/reg", to = "/docs/cli/push", status = 301 },
+
+  { from = "/docs/docs/getting-started", to = "/docs/installation",  status = 301 },
 
   { from = "/docs/downloads", to = "/docs/installation", status = 301 },
 

--- a/versioned_docs/version-0.82/cli/reg.md
+++ b/versioned_docs/version-0.82/cli/reg.md
@@ -1,0 +1,92 @@
+---
+title: "wash reg"
+draft: false
+sidebar_position: 18
+description: "wash reg command reference"
+---
+
+`wash reg` allows users to interact with OCI compliant registries and their artifacts. A user may pull artifacts from the registry to use in their projects. They may also push their own projects to registries to use in various lattices. Following are the subcommands available under `wash reg`.
+
+- `push`
+- `pull`
+- `ping`
+
+### `push`
+Push an artifact to an OCI compliant registry. A user needs to provide a registry URL and the path to the artifact that needs to be pushed.
+
+:::warning
+This subcommand will be deprecated in future versions. Please use `wash push` instead.
+:::
+
+#### Usage
+```
+wash reg push wasmcloud.azurecr.io/example:0.0.1 /path/to/artifact
+```
+
+#### Options
+
+`--config` (Alias `-c`) Path to config file, if omitted will default to a blank configuration
+
+`--output` (Alias `-o`) Specify output format (`text` or `json`) [default: `text`]
+
+`--experimental` Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
+
+`--allow-latest` Allow latest artifact tags
+
+`--annotation` (Alias `-a`) Optional set of annotations to apply to the OCI artifact manifest
+
+`--user` (Alias `-u`) OCI username, if omitted anonymous authentication will be used [env: `USER`]
+
+`--password` (Alias `-p`) OCI password, if omitted anonymous authentication will be used [env: `PASSWORD`]
+
+`--insecure` Allow insecure (HTTP) registry connections
+
+### `pull`
+Pull an artifact from an OCI compliant registry
+
+:::warning
+This subcommand will be deprecated in future versions. Please use `wash pull` instead.
+:::
+
+#### Usage
+```
+wash reg pull wasmcloud.azurecr.io/echo:0.3.7
+```
+
+#### Options
+
+`--destination` File destination of artifact
+
+`--output` Specify output format (`text` or `json`) [default: `text`]
+
+`--digest` (Alias `-d`) Digest to verify artifact against
+
+`--experimental` Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
+
+`--allow-latest` Allow latest artifact tags
+
+`--user` (Alias `-u`) OCI username, if omitted anonymous authentication will be used
+
+`--password` OCI password, if omitted anonymous authentication will be used
+
+`--insecure` Allow insecure (HTTP) registry connections
+
+### `ping`
+Ping (test url) to see if the OCI url has an artifact
+
+#### Usage
+```
+wash reg ping wasmcloud.azurecr.io/echo:0.3.7
+```
+
+#### Options
+
+`--output` Specify output format (`text` or `json`) [default: `text`]
+
+`--experimental` Whether or not to enable experimental features [env: WASH_EXPERIMENTAL=]
+
+`--user` (Alias `-u`) OCI username, if omitted anonymous authentication will be used
+
+`--password` OCI password, if omitted anonymous authentication will be used
+
+`--insecure` Allow insecure (HTTP) registry connections


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

The versioned 0.82 docs should still contain `wash reg` as an artifact of the past usage docs.

This is a follow-up to https://github.com/wasmCloud/wasmcloud.com/pull/483

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
