### PR TITLE
docs: Add Capability Catalog, Capabilities platform page

### DIFF
--- a/docs/capabilities/_category_.json
+++ b/docs/capabilities/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Capability Catalog",
+  "position": 4,
+  "link": {
+    "type": "doc",
+    "id": "capabilities/index"
+  }
+}

--- a/docs/capabilities/index.mdx
+++ b/docs/capabilities/index.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Capability Catalog'
+---
+
+**Capabilities** are pluggable pieces of functionality for your applications. Plug them in and swap them out whenever you want.
+
+Every capability consists of a **standard API** and one or more swappable plugins called **capability providers**. Learn more about capabilities, providers, interfaces, and other core concepts in the [Platform Guide](/docs/concepts/index.mdx).
+
+## wasmCloud capabilities
+
+| NAME                   | INTERFACE                                                                                        | PROVIDERS                |
+|------------------------|--------------------------------------------------------------------------------------------------|--------------------------|
+| Blob Storage           | [`wasi:blobstore`](https://github.com/WebAssembly/wasi-blobstore)                                | [Azure](https://github.com/orgs/wasmCloud/packages/container/package/blobstore-azure), [Filesystem](https://github.com/orgs/wasmCloud/packages/container/package/blobstore-fs), [S3](https://github.com/orgs/wasmCloud/packages/container/package/blobstore-s3) |
+| Clocks                 | [`wasi:clocks`](https://github.com/WebAssembly/wasi-clocks)                                      | [Built-in](/docs/concepts/providers#built-in-providers) |
+| HTTP Client & Server   | [`wasi:http`](https://github.com/WebAssembly/wasi-http)                                          | [HTTP Server](https://github.com/orgs/wasmCloud/packages/container/package/http-server), [HTTP Client](https://github.com/orgs/wasmCloud/packages/container/package/http-client) |
+| Key-Value Storage      | [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue)                                  | [Redis](https://github.com/orgs/wasmCloud/packages/container/package/keyvalue-redis), [NATS](https://github.com/orgs/wasmCloud/packages/container/package/keyvalue-nats), [Vault](https://github.com/orgs/wasmCloud/packages/container/package/keyvalue-vault) |
+| Logging                | [`wasi:logging`](https://github.com/WebAssembly/wasi-logging)                                    | [Built-in](/docs/concepts/providers#built-in-providers) |
+| Messaging              | [`wasi:messaging`](https://github.com/WebAssembly/wasi-messaging)                                | [Kafka](https://github.com/orgs/wasmCloud/packages/container/package/messaging-kafka), [NATS](https://github.com/orgs/wasmCloud/packages/container/package/messaging-nats) |
+| Postgres               | [`wasmcloud:sqldb-postgres`](https://github.com/vados-cosmonic/wit-wasmcloud-postgres)           | [Postgres](https://github.com/wasmCloud/wasmCloud/pkgs/container/sqldb-postgres) |
+| Random                 | [`wasi:random`](https://github.com/WebAssembly/wasi-random) | [Built-in](/docs/concepts/providers#built-in-providers) |
+| Runtime Configuration  | [`wasi:runtime-config`](https://github.com/WebAssembly/wasi-runtime-config)                      | [Runtime](https://github.com/wasmCloud/wasmCloud/tree/main/crates/runtime) |
+| Secrets                | [`wasmcloud:secrets`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/secrets-types/wit) | [NATS Key-Value](https://github.com/wasmCloud/wasmCloud/tree/main/crates/secrets-nats-kv) |
+
+## Third-party capabilities
+
+| NAME                   | INTERFACE                                                                                                      | PROVIDERS             |
+|------------------------|----------------------------------------------------------------------------------------------------------------|-----------------------|
+| Couchbase              | [`wasmcloud:couchbase`](https://github.com/couchbaselabs/wasmcloud-provider-couchbase/tree/main/wit/couchbase) | [Couchbase](https://github.com/couchbaselabs/wasmcloud-provider-couchbase) |
+  
+
+:::info[Missing a capability you need?]
+wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own!
+:::

--- a/docs/capabilities/index.mdx
+++ b/docs/capabilities/index.mdx
@@ -29,5 +29,5 @@ Every capability consists of a **standard API** and one or more swappable plugin
   
 
 :::info[Missing a capability you need?]
-wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own!
+wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own! Learn more in the documentation on [creating a capability provider](/docs/developer/providers/).
 :::

--- a/docs/cli/_category_.json
+++ b/docs/cli/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "CLI (wash)",
-    "position": 6,
+    "position": 9,
     "link": {
         "type": "generated-index",
         "description": "Wash (wasmCloud Shell) CLI"

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -10,12 +10,13 @@ type: 'docs'
 
 A ***capability** is a pluggable piece of functionality for an application. More specifically, capabilities are common, abstracted functionalities&mdash;usually the sort of utilities that aren't core business logic for a given application, such as...
 
-* HTTP Client & Server
+* Key-Value Storage for caching (think Redis)
+* Messaging for persistent message (think Kafka)
+* Blob Storage for long term data storage (think S3)
+* Secrets for secret management (think Vault)
+* HTTP Client for sending HTTP requests
+* HTTP Server for receiving HTTP requests
 * Logging
-* Key-Value Storage
-* Messaging
-* Blob Storage
-* Secrets
 
 You can find a complete list of first-party capabilities in the [Capability Catalog](/docs/capabilities/index.mdx).
 

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -8,7 +8,7 @@ type: 'docs'
 
 ## Overview
 
-A ***capability** is a pluggable piece of functionality for an application. More specifically, capabilities are common, abstracted functionalities&mdash;usually the sort of utilities that aren't core business logic for a given application, such as...
+A ***capability** is a reusable, pluggable piece of functionality. Applications implement capabilities for common requirements like storing and retrieving data, accessing secrets, and more. Examples of capabilities include:
 
 * Key-Value Storage for caching (think Redis)
 * Messaging for persistent message (think Kafka)

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -26,7 +26,8 @@ Capabilities are enacted by an **interface** and one or more swappable **capabil
 
 For example...
 
-* The [Redis key-value storage provider](https://github.com/wasmCloud/wasmCloud/pkgs/container/keyvalue-redis) delivers the key-value capability to application components over the standard `wasi:keyvalue` API. 
+* The [Redis key-value storage provider](https://github.com/wasmCloud/wasmCloud/pkgs/container/keyvalue-redis) delivers the key-value capability to application components over the standard [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue/) API. 
+* The team can use the same `wasi:keyvalue` functions&mdash;for example, `get`, `set`, `delete`, and `exists`&mdash;regardless of your intended capability provider.
 * If the development team chooses to use Vault for key-value storage instead, they can swap out the Redis provider for the [Vault provider](https://github.com/wasmCloud/wasmCloud/pkgs/container/keyvalue-vault). 
 * The Vault capability provider will deliver a different implementation of the same capability *over the same API*.  
 

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -33,7 +33,11 @@ For example...
 
 ## Creating your own capabilities
 
-wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own providers, and write your own interfaces in the [WebAssembly Interface Type (WIT)](/docs/concepts/interfaces) interface description language. For more information, see...
+wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own providers, and write your own interfaces in the [WebAssembly Interface Type (WIT)](/docs/concepts/interfaces) interface description language. 
+
+For more information, see...
 
 * [Creating a provider](/docs/developer/providers/)
 * [Creating an interface](/docs/developer/interfaces/creating-an-interface)
+* [A simple template for custom providers in Go](https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/providers/custom-template) (Launch in `wash` with `wash new provider custom-provider --template-name custom-template-go`)
+* [A simple template for custom providers in Rust](https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/providers/custom-template) (Launch in `wash` with `wash new provider custom-provider --template-name custom-template-rust`)

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -1,0 +1,37 @@
+---
+title: 'Capabilities'
+icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
+description: 'Application declaration, deployment, and management'
+sidebar_position: 1
+type: 'docs'
+---
+
+## Overview
+
+A ***capability** is a pluggable piece of functionality for an application. More specifically, capabilities are common, abstracted functionalities&mdash;usually the sort of utilities that aren't core business logic for a given application, such as...
+
+* HTTP Client & Server
+* Logging
+* Key-Value Storage
+* Messaging
+* Blob Storage
+* Secrets
+
+You can find a complete list of first-party capabilities in the [Capability Catalog](/docs/capabilities/index.mdx).
+
+## How capabilities work
+
+Capabilities are enacted by an **interface** and one or more swappable **capability providers**. A provider delivers a specific implementation of a given capability by communicating with other entities in the common tongue of a standard API. 
+
+For example...
+
+* The [Redis key-value storage provider](https://github.com/wasmCloud/wasmCloud/pkgs/container/keyvalue-redis) delivers the key-value capability to application components over the standard `wasi:keyvalue` API. 
+* If the development team chooses to use Vault for key-value storage instead, they can swap out the Redis provider for the [Vault provider](https://github.com/wasmCloud/wasmCloud/pkgs/container/keyvalue-vault). 
+* The Vault capability provider will deliver a different implementation of the same capability *over the same API*.  
+
+## Creating your own capabilities
+
+wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own providers, and write your own interfaces in the [WebAssembly Interface Type (WIT)](/docs/concepts/interfaces) interface description language. For more information, see...
+
+* [Creating a provider](/docs/developer/providers/)
+* [Creating an interface](/docs/developer/interfaces/creating-an-interface)

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -22,7 +22,7 @@ You can find a complete list of first-party capabilities in the [Capability Cata
 
 ## How capabilities work
 
-Capabilities are enacted by an **interface** and one or more swappable **capability providers**. A provider delivers a specific implementation of a given capability by communicating with other entities in the common tongue of a standard API. 
+Capabilities are enacted by an **interface** and one or more swappable **capability providers**. A provider delivers a specific implementation of a given capability by communicating with other entities in the common tongue of a [standard API in WebAssembly Interface Type (WIT)](/docs/concepts/interfaces#webassembly-interface-type-wit). 
 
 For example...
 

--- a/docs/concepts/components.mdx
+++ b/docs/concepts/components.mdx
@@ -9,7 +9,7 @@ type: 'docs'
 
 ## Overview
 
-**Components** are portable, interoperable WebAssembly binaries (`.wasm` files) that implement stateless logic. In wasmCloud, components typically enact the core logic of an application (for example, the API for a web application), while leaving longer-lived, reusable [**capabilities**](/docs/concepts/capabilities/) such as key-value storage to [**providers**](/docs/concepts/providers/).
+**Components** are portable, interoperable WebAssembly binaries (`.wasm` files) that implement stateless logic. In wasmCloud, components typically enact the core logic of an application (for example, the API for a web application), while leaving abstracted, reusable [**capabilities**](/docs/concepts/capabilities/) such as key-value storage to [**capability providers**](/docs/concepts/providers/).
 
 In wasmCloud usage and documentation, the term **"component"** simply refers to a standard WebAssembly component. For example, the `wash new component` command creates a new component that could be executed with any WebAssembly runtime that supports components. The wasmCloud platform provides a way to run components distributedly.
 

--- a/docs/concepts/components.mdx
+++ b/docs/concepts/components.mdx
@@ -9,7 +9,7 @@ type: 'docs'
 
 ## Overview
 
-**Components** are portable, interoperable WebAssembly binaries (`.wasm` files) that implement stateless logic. In wasmCloud, components typically enact the core logic of an application (for example, the API for a web application), while leaving longer-lived, reusable processes such as key-value storage to [**providers**](/docs/concepts/providers/).
+**Components** are portable, interoperable WebAssembly binaries (`.wasm` files) that implement stateless logic. In wasmCloud, components typically enact the core logic of an application (for example, the API for a web application), while leaving longer-lived, reusable [**capabilities**](/docs/concepts/capabilities/) such as key-value storage to [**providers**](/docs/concepts/providers/).
 
 In wasmCloud usage and documentation, the term **"component"** simply refers to a standard WebAssembly component. For example, the `wash new component` command creates a new component that could be executed with any WebAssembly runtime that supports components. The wasmCloud platform provides a way to run components distributedly.
 

--- a/docs/concepts/hosts.mdx
+++ b/docs/concepts/hosts.mdx
@@ -2,7 +2,7 @@
 title: 'Hosts'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'The runtime environment for components and capability providers'
-sidebar_position: 3
+sidebar_position: 4
 type: 'docs'
 ---
 

--- a/docs/concepts/index.mdx
+++ b/docs/concepts/index.mdx
@@ -9,7 +9,7 @@ title: "Platform Overview"
 In wasmCloud, applications are comprised of **components** and **providers**:
 
 1. [**Components**](/docs/concepts/components/) are portable, interoperable WebAssembly binaries that implement stateless logic. 
-2. [**Providers**](/docs/concepts/providers/) are executable host plugins that implement longer-lived processes, typically providing reusable capabilities (such as key-value storage).
+2. [**Providers**](/docs/concepts/providers/) are executable host plugins that implement longer-lived processes, typically providing reusable [capabilities](/docs/concepts/capabilities) (such as key-value storage).
 
 ![Simple diagram of application, comprised of component and provider](../../static/img/platform-app.png)
 
@@ -49,6 +49,7 @@ wasmCloud can stand alone *or* run on Kubernetes with the [**wasmCloud Kubernete
 The best way to learn how wasmCloud works is to follow the [**Quickstart**](/docs/tour/hello-world). If you've completed the Quickstart or wish to explore the core concepts of wasmCloud in more depth, see the following pages in this section, which are best read in order:
 
 - [Components](/docs/concepts/components/)
+- [Capabilities](/docs/concepts/capabilities/)
 - [Providers](/docs/concepts/providers/)
 - [Interfaces](/docs/concepts/interfaces/)
 - [Hosts](/docs/concepts/hosts/)

--- a/docs/concepts/interfaces.mdx
+++ b/docs/concepts/interfaces.mdx
@@ -3,7 +3,7 @@ title: 'Interfaces'
 date: 2020-05-01T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'A quick guide to wasmCloud interfaces'
-sidebar_position: 2
+sidebar_position: 3
 type: 'docs'
 ---
 
@@ -174,7 +174,7 @@ While similar frameworks and languages like [gRPC][grpc] and [Smithy][smithy] ar
 
 ## Interface-driven development
 
-Interface-driven development (IDD) is a development approach that focuses on defining what capabilities components require before the specifics of how you will meet those needs. Systems developed using IDD&mdash;especially distributed systems&mdash;are loosely coupled, robust, and maintainable.
+Interface-driven development (IDD) is a development approach that focuses on defining what [capabilities](/docs/concepts/capabilities) components require before the specifics of how you will meet those needs. Systems developed using IDD&mdash;especially distributed systems&mdash;are loosely coupled, robust, and maintainable.
 
 ## Keep reading
 

--- a/docs/concepts/interfaces.mdx
+++ b/docs/concepts/interfaces.mdx
@@ -174,7 +174,9 @@ While similar frameworks and languages like [gRPC][grpc] and [Smithy][smithy] ar
 
 ## Interface-driven development
 
-Interface-driven development (IDD) is a development approach that focuses on defining what [capabilities](/docs/concepts/capabilities) components require before the specifics of how you will meet those needs. Systems developed using IDD&mdash;especially distributed systems&mdash;are loosely coupled, robust, and maintainable.
+Interface-driven development (IDD) is a development approach that focuses on defining what [capabilities](/docs/concepts/capabilities) components require before the specifics of how you will meet those needs. 
+
+Systems developed using IDD&mdash;especially distributed systems&mdash;are loosely coupled, robust, and maintainable.
 
 ## Keep reading
 

--- a/docs/concepts/lattice.mdx
+++ b/docs/concepts/lattice.mdx
@@ -2,7 +2,7 @@
 title: 'Lattice'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'A self-forming, self-healing mesh network'
-sidebar_position: 4
+sidebar_position: 5
 type: 'docs'
 ---
 

--- a/docs/concepts/linking-components/_category_.json
+++ b/docs/concepts/linking-components/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Linking Components",
-    "position": 5,
+    "position": 6,
     "link": {
       "type": "doc",
       "id": "concepts/linking-components/index"

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -3,13 +3,13 @@ title: 'Providers'
 date: 2024-04-01T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'Reusable, non-functional requirements'
-sidebar_position: 1
+sidebar_position: 2
 type: 'docs'
 ---
 
 ## Overview
 
-**Providers** are executable [host](/docs/concepts/hosts) plugins dedicated to longer-lived processes fulfilling non-functional requirements (sometimes called **capabilities**). Providers are typically responsible for functionality that is not considered part of the core business logic of an application, such as...
+**Providers** are swappable [host](/docs/concepts/hosts) plugins&mdash;executables (usually dedicated to longer-lived processes) that deliver common functionalities called **capabilities**. Providers are typically responsible for capabilities that are not considered part of the core business logic of an application, such as...
 
 - Sending notifications
 - Fetching secret values

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -9,7 +9,7 @@ type: 'docs'
 
 ## Overview
 
-**Providers** are swappable [host](/docs/concepts/hosts) plugins&mdash;executables (usually dedicated to longer-lived processes) that deliver common functionalities called **capabilities**. Providers are typically responsible for capabilities that are not considered part of the core business logic of an application, such as...
+**Providers** are swappable [host](/docs/concepts/hosts) plugins&mdash;executables (usually dedicated to longer-lived processes) that deliver common functionalities called **capabilities**. Providers are typically responsible for [capabilities](/docs/concepts/capabilities) that are not considered part of the core business logic of an application, such as...
 
 - Sending notifications
 - Fetching secret values

--- a/docs/deployment/_category_.json
+++ b/docs/deployment/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Operator Guide",
-  "position": 5,
+  "position": 7,
   "link": {
     "type": "generated-index",
     "description": "In this section, we will share patterns, practices, and specific instructions on how to deploy, provision, secure, and maintain wasmCloud in a real production environment."

--- a/docs/developer/_category_.json
+++ b/docs/developer/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Developer Guide",
-  "position": 4,
+  "position": 6,
   "link": {
     "type": "generated-index",
     "description": "Guides for developing with wasmCloud"

--- a/docs/ecosystem/_category_.json
+++ b/docs/ecosystem/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Toolchain",
-  "position": 3,
+  "position": 5,
   "link": null
 }

--- a/docs/hosts/_category_.json
+++ b/docs/hosts/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Hosts",
-    "position": 5,
+    "position": 8,
     "link": {
         "type": "generated-index",
         "description": "Detailed background on wasmCloud hosts."

--- a/docs/reference/_category_.json
+++ b/docs/reference/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Reference",
-  "position": 8,
+  "position": 10,
   "link": null
 }


### PR DESCRIPTION
Add a top-level page ("Capability Catalog") highlighting available capabilities, along with Platform Overview page on the capability abstraction. Updates sidebar ordering and adds links to the new pages. Resolves #499 