### PR TITLE
fix: hello world tutorial, versions

### DIFF
--- a/community/2024-04-03-community-meeting.mdx
+++ b/community/2024-04-03-community-meeting.mdx
@@ -94,7 +94,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         # Compose with component to handle wasi:http calls
         - type: link
@@ -112,7 +112,7 @@ spec:
     - name: kvredis
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.23.0
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
 ```
 
 In this example, the kvcounter component has a link to the kvredis provider, and the httpserver provider also has a link to the component. The new link definitions are unidirectional&mdash;they have a source and a target. We no longer specify wasmCloud contracts (since those no longer exist in their previous form), and instead specify WASI interfaces. In the `target_config` field we can also provide configuration data that we give to a provider.

--- a/docs/concepts/applications.mdx
+++ b/docs/concepts/applications.mdx
@@ -8,9 +8,9 @@ type: 'docs'
 
 ## Overview
 
-Applications combine all of the previous concepts into a declarative, deployable unit. 
+Applications combine all of the previous concepts into a declarative, deployable unit.
 
-Applications are the primary abstraction for deployable workloads in a wasmCloud [lattice](/docs/concepts/lattice). Applications are declared, versioned, and defined using **application manifests**. Manifests conform to the [OAM manifest standard](https://oam.dev/) and may be written in YAML or JSON. 
+Applications are the primary abstraction for deployable workloads in a wasmCloud [lattice](/docs/concepts/lattice). Applications are declared, versioned, and defined using **application manifests**. Manifests conform to the [OAM manifest standard](https://oam.dev/) and may be written in YAML or JSON.
 
 Once deployed, applications are represented as **models** in the **wasmCloud Application Deployment Manager (Wadm)**. An application model may include multiple deployable versions. Model persistence is decoupled from deployments themselves and from any particular host.
 
@@ -22,14 +22,14 @@ A **wasmCloud application** is analogous to a **Kubernetes Deployment**.
 
 ### Application manifests
 
-wasmCloud application manifests are composed of two sections: metadata and `spec`. 
+wasmCloud application manifests are composed of two sections: metadata and `spec`.
 
-* The metadata contains the application's name, version, and description. 
-* The `spec` contains a list of the application's components and providers, each of which can have `traits`. Traits define configuration for the component, links, and how the component should be deployed. Examples of deployment traits include:
+- The metadata contains the application's name, version, and description.
+- The `spec` contains a list of the application's components and providers, each of which can have `traits`. Traits define configuration for the component, links, and how the component should be deployed. Examples of deployment traits include:
 
-- run a single instance on a specific host `foo`
-- run `N` instances on each host in the lattice
-- 80% on hosts with label `foo`, 20% on hosts with label `bar`
+* run a single instance on a specific host `foo`
+* run `N` instances on each host in the lattice
+* 80% on hosts with label `foo`, 20% on hosts with label `bar`
 
 The following is an example of a simple wasmCloud application manifest:
 
@@ -47,7 +47,7 @@ spec:
       type: component
       properties:
         # Run components from OCI registries as below or from a local .wasm component binary.
-        image: wasmcloud.azurecr.io/http-hello-world:0.1.0
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         # One replica of this component will run
         - type: spreadscaler
@@ -57,7 +57,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         # Link the HTTP server and set it to listen on the local machine's port 8080
         - type: link
@@ -73,7 +73,7 @@ spec:
 ```
 
 :::[Write less YAML]
-The design of WebAssembly Interface Type (WIT) interfaces makes it possible to automate the generation of a manifest for a given component. Use the [`wit2wadm`](https://github.com/brooksmtownsend/wit2wadm) tool to quickly generate manifests from your components on the command line. 
+The design of WebAssembly Interface Type (WIT) interfaces makes it possible to automate the generation of a manifest for a given component. Use the [`wit2wadm`](https://github.com/brooksmtownsend/wit2wadm) tool to quickly generate manifests from your components on the command line.
 :::
 
 ### wasmCloud Application Deployment Manager (wadm)

--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -11,12 +11,12 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-A **runtime link** is a declared connection between a component and another entity. Runtime links are typically defined in [Wadm deployment manifests](/docs/ecosystem/wadm/) and resolved on instantiation, regardless of where the linked entities are running. 
+A **runtime link** is a declared connection between a component and another entity. Runtime links are typically defined in [Wadm deployment manifests](/docs/ecosystem/wadm/) and resolved on instantiation, regardless of where the linked entities are running.
 
 Link definitions have both a **source** and a **target**, corresponding to the [component imports and exports](/docs/concepts/linking-components/), and specify the relevant WASI interfaces.
 
-* In a link declaration, the **source** is the **importer**. You can think of it as the source of the requirement that needs to be fulfilled. 
-* The **target** is the **exporter**. Specifically, it is the function exposed in an export that the source will call.
+- In a link declaration, the **source** is the **importer**. You can think of it as the source of the requirement that needs to be fulfilled.
+- The **target** is the **exporter**. Specifically, it is the function exposed in an export that the source will call.
 
 Link definitions are **unidirectional**: the source (importer) can call the target (exporter), but not the other way around.From a [component's](/docs/concepts/components) point of view, code _only_ refers to an interface, e.g. `wasi-keyvalue`. Components do not know which specific entity is on the other side of a link.
 
@@ -24,9 +24,9 @@ Link definitions are **unidirectional**: the source (importer) can call the targ
 
 Linking at runtime makes sense when...
 
-* You want components to be able to scale and failover independently
-* You want to be able to update components independently
-* Data sources for each component are distributed, and you want each component to run as close to its data source as possible to reduce data transmitted over the wire
+- You want components to be able to scale and failover independently
+- You want to be able to update components independently
+- Data sources for each component are distributed, and you want each component to run as close to its data source as possible to reduce data transmitted over the wire
 
 ## Exploring a link definition
 
@@ -47,9 +47,9 @@ components:
           package: keyvalue
           interfaces: [store]
           target_config:
-          - name: redis-url
-            properties:
-              url: redis://127.0.0.1:6379
+            - name: redis-url
+              properties:
+                url: redis://127.0.0.1:6379
 ```
 
 **A link is always defined as a trait of the source**&mdash;that is, the importer. In addition to a target, the link definition has properties including...
@@ -73,13 +73,13 @@ In wasmCloud, components may be linked to...
 
 The wasmCloud host provides several functions available for import by components through built-in providers:
 
-* Logging (using the [`wasi-logging`](https://github.com/WebAssembly/wasi-logging) interface)
-* Random (using the [`wasi-random`](https://github.com/WebAssembly/wasi-random) interface)
-* Clocks (using the [`wasi-clocks`](https://github.com/WebAssembly/wasi-clocks) interface)
+- Logging (using the [`wasi-logging`](https://github.com/WebAssembly/wasi-logging) interface)
+- Random (using the [`wasi-random`](https://github.com/WebAssembly/wasi-random) interface)
+- Clocks (using the [`wasi-clocks`](https://github.com/WebAssembly/wasi-clocks) interface)
 
-For example, the wasmCloud host's built-in logging function could satisfy a component's logging import. Built-in providers form wasmCloud's **trusted compute base**&mdash;they represent highly-vetted code that provides basic, commonly-used functionalities. 
+For example, the wasmCloud host's built-in logging function could satisfy a component's logging import. Built-in providers form wasmCloud's **trusted compute base**&mdash;they represent highly-vetted code that provides basic, commonly-used functionalities.
 
-To use a built-in provider, you need *only* include the import in a component's `world.wit` and call it using the WASI interface in question. It is not necessary to include built-in providers in a deployment manifest&mdash;since they are already present on any wasmCloud host, the host will fulfill the imports automatically.
+To use a built-in provider, you need _only_ include the import in a component's `world.wit` and call it using the WASI interface in question. It is not necessary to include built-in providers in a deployment manifest&mdash;since they are already present on any wasmCloud host, the host will fulfill the imports automatically.
 
 <details>
 <summary>Example: Logging</summary>
@@ -89,6 +89,7 @@ Generate a new Rust project:
 ```shell
 wash new component hello --template-name hello-world-rust
 ```
+
 Add logging to the project's `world.wit` file in the `wit` directory:
 
 ```wit
@@ -100,6 +101,7 @@ world hello {
   export wasi:http/incoming-handler@0.2.0;
 }
 ```
+
 Update the Rust code to add a logging message:
 
 ```rust
@@ -113,7 +115,7 @@ struct HttpServer;
 impl Guest for HttpServer {
     fn handle(_request: IncomingRequest, response_out: ResponseOutparam) {
         // Add logging // [!code ++:6]
-        wasi::logging::logging::log( 
+        wasi::logging::logging::log(
             wasi::logging::logging::Level::Info,
             "",
             &format!("Hello to your logs from Rust"),
@@ -133,6 +135,7 @@ impl Guest for HttpServer {
 
 export!(HttpServer);
 ```
+
 Remember: it is not necessary to include built-in providers in a deployment manifest.
 
 Launch a local wasmCloud host with `wash up` and deploy:
@@ -146,11 +149,12 @@ When you invoke the component with `curl localhost:8080`, in addition to an HTTP
 ```shell
 INFO handle_invocation{params=IncomingHttpHandle component_id="http_hello_world-http_component" component_ref="file:///Users/user/wasmcloud/wip/linking/logtest/build/http_hello_world_s.wasm"}:log: wasmcloud_host::wasmbus::handler: Hello to your logs from Rust component_id="http_hello_world-http_component" level=Level::Info context=""
 ```
+
 </details>
 
 ### Other components
 
-A component may be linked to another component at runtime (over the [lattice](/docs/concepts/lattice)) or [build (via composition)](/docs/concepts/linking-components/linking-at-build). 
+A component may be linked to another component at runtime (over the [lattice](/docs/concepts/lattice)) or [build (via composition)](/docs/concepts/linking-components/linking-at-build).
 
 Linking components at runtime is a two-step process:
 
@@ -169,7 +173,7 @@ metadata:
   name: http-hello-world
   annotations:
     version: v0.0.2
-    description: "HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
+    description: 'HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
 spec:
   components:
     - name: http-component
@@ -202,7 +206,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.1
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8080 for incoming requests
@@ -216,21 +220,21 @@ spec:
               - name: default-http
                 properties:
                   address: 127.0.0.1:8080
-
 ```
 
-* The http-component is **exporting on the wasi-http interface** and **importing on a custom "pingpong" interface**. It is the importer in relation to the pong-component, so it is the source for that link. 
-* The pong-component is **exporting on the custom "pingpong" interface**. This is its only link relationship, and it is the exporter, so no links are defined as a trait of pong-component. 
-* The httpserver provider is **importing on the wasi-http interface**. It is the importer in relation to http-component, so it is the source for that link, and basic configuration is performed in the `source_config`.
+- The http-component is **exporting on the wasi-http interface** and **importing on a custom "pingpong" interface**. It is the importer in relation to the pong-component, so it is the source for that link.
+- The pong-component is **exporting on the custom "pingpong" interface**. This is its only link relationship, and it is the exporter, so no links are defined as a trait of pong-component.
+- The httpserver provider is **importing on the wasi-http interface**. It is the importer in relation to http-component, so it is the source for that link, and basic configuration is performed in the `source_config`.
 
-If you would like to build and run the example described by this manifest, follow Steps 1 and 2 in the [composition example readme](https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/composition). 
+If you would like to build and run the example described by this manifest, follow Steps 1 and 2 in the [composition example readme](https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/composition).
 
-Remember that the [wit2wadm](https://github.com/brooksmtownsend/wit2wadm) tool is available to help you automatically generate a Wadm deployment manifest for a given component. Because it extrapolates link definitions from a component's WIT interfaces, it can be very helpful for not only generating manifests but understanding linking relationships in your application. 
+Remember that the [wit2wadm](https://github.com/brooksmtownsend/wit2wadm) tool is available to help you automatically generate a Wadm deployment manifest for a given component. Because it extrapolates link definitions from a component's WIT interfaces, it can be very helpful for not only generating manifests but understanding linking relationships in your application.
+
 </details>
 
 ### Providers
 
-[Providers](/docs/concepts/providers) are longer-lived host plugins which may facilitate connections to external resources. A component may be linked at runtime to a provider, which may be running either on the same wasmCloud host or another host on the lattice. 
+[Providers](/docs/concepts/providers) are longer-lived host plugins which may facilitate connections to external resources. A component may be linked at runtime to a provider, which may be running either on the same wasmCloud host or another host on the lattice.
 
 A provider only ever dispatches messages to&mdash;or receives messages from&mdash;components. When a link is established for a particular component, the provider can remember that component's identity and use it for subsequent dispatches. As a result, the only information a linked provider needs is the component's identity. This identity is typically used for managing specific resources on behalf of the component, such as database connections, open TCP sockets, etc.
 
@@ -247,7 +251,7 @@ kind: Application
 metadata:
   name: hello-world
   annotations:
-    version: v0.0.1 
+    version: v0.0.1
     description: 'HTTP hello world demo'
 spec:
   components:
@@ -255,7 +259,7 @@ spec:
     - name: http-component
       type: component
       properties:
-        image: wasmcloud.azurecr.io/http-hello-world:0.1.0
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         - type: spreadscaler
           properties:
@@ -275,12 +279,12 @@ spec:
     - name: kvredis
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
     # The httpserver provider
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         # Link definition for httpserver -> http-component
         - type: link
@@ -288,29 +292,29 @@ spec:
             target: http-component
             namespace: wasi
             package: http
-            interfaces: [incoming-handler] 
-            source_config: 
+            interfaces: [incoming-handler]
+            source_config:
               - name: default-http
-                properties: 
+                properties:
                   address: 127.0.0.1:8080
-
 ```
 
-* The http-component is **importing functions on the keyvalue interface**. It is the **importer** in relation to **kvredis**, meaning that it is the source for the link definition: the link is defined as a trait of http-component. 
+- The http-component is **importing functions on the keyvalue interface**. It is the **importer** in relation to **kvredis**, meaning that it is the source for the link definition: the link is defined as a trait of http-component.
 
-* The http-component is **exposing a function on the http interface**. It is the **exporter** in relation to the **http-server** provider&mdash;in this case, the http-server provider is the source and the http-component is the target.
+- The http-component is **exposing a function on the http interface**. It is the **exporter** in relation to the **http-server** provider&mdash;in this case, the http-server provider is the source and the http-component is the target.
 
-* Both the kvredis and httpserver providers are configured in the link definition, using a `target_config` field (if the provider is the target) or a `source_config` field (if the provider is the source).
+- Both the kvredis and httpserver providers are configured in the link definition, using a `target_config` field (if the provider is the target) or a `source_config` field (if the provider is the source).
 
-Remember that the [wit2wadm](https://github.com/brooksmtownsend/wit2wadm) tool is available to help you automatically generate a Wadm deployment manifest for a given component. Because it extrapolates link definitions from a component's WIT interfaces, it can be very helpful for not only generating manifests but understanding linking relationships in your application. 
+Remember that the [wit2wadm](https://github.com/brooksmtownsend/wit2wadm) tool is available to help you automatically generate a Wadm deployment manifest for a given component. Because it extrapolates link definitions from a component's WIT interfaces, it can be very helpful for not only generating manifests but understanding linking relationships in your application.
+
 </details>
 
 ## Defining and using link names
 
 In some cases, you may wish to assign names to links. This can be useful when a source component needs to use the same interface with different configurations under different circumstances.
 
-* For example, a component may use the `wasi:keyvalue` interface to link to both a local key-value cache for ephemeral storage and a cloud-based store for more resilient storage.
-* In this example, you're using the same key-value interface and the same operations, but the interface needs to be configured differently. These different configurations of the interface can be differentiated with a link name. 
+- For example, a component may use the `wasi:keyvalue` interface to link to both a local key-value cache for ephemeral storage and a cloud-based store for more resilient storage.
+- In this example, you're using the same key-value interface and the same operations, but the interface needs to be configured differently. These different configurations of the interface can be differentiated with a link name.
 
 Link names can be set [imperatively with the `wash link put` command](/docs/cli/link#put) or [declaratively via Wadm manifest](#exploring-a-link-definition), but are typically easiest to manage from a manifest. Link names are an optional field in a link definition and default to the value `default` if not specified. Below is an excerpt of a manifest defining names for two differently configured links:
 
@@ -358,13 +362,14 @@ let yourinterface = wasmcloud::bus::lattice::CallTargetInterface::new(
 // Sets the operative link for interface to the named link foo
 wasmcloud::bus::lattice::set_link_name("foo", yourinterface);
 // Calls over link foo to perform a keyvalue operation
-let x = wasi::keyvalue::store::function(args); 
+let x = wasi::keyvalue::store::function(args);
 
 // Sets the operative link for interface to the named link bar
 wasmcloud::bus::lattice::set_link_name("bar", yourinterface);
 // Calls over link bar to perform a keyvalue operation
-let y = wasi::keyvalue::store::function(args); 
+let y = wasi::keyvalue::store::function(args);
 ```
+
   </TabItem>
   <TabItem value="tinygo" label="TinyGo">
 
@@ -390,19 +395,15 @@ let y = world.WasiKeyvalue0_2_0_draft_StoreFunction
   <TabItem value="typescript" label="TypeScript">
 
 ```js
-let yourInterface = callTargetInterface.new(
-    "wasi",
-    "keyvalue",
-    "store",
-);
+let yourInterface = callTargetInterface.new('wasi', 'keyvalue', 'store');
 
 // Sets the operative link for interface to the named link foo
-setLinkName("foo", yourInterface);
+setLinkName('foo', yourInterface);
 // Calls over link foo to perform a keyvalue operation
 keyvalueFunction(args);
 
 // Sets the operative link for interface to the named link bar
-setLinkName("bar", yourInterface);
+setLinkName('bar', yourInterface);
 // Calls over link bar to perform a keyvalue operation
 keyvalueFunction(args);
 ```
@@ -451,5 +452,3 @@ Runtime links can be created **imperatively** using the `wash` CLI, which can be
 
 - For more on Wadm deployment manifests, see the Toolchain section for [Declarative Application Deployment (Wadm)](/docs/ecosystem/wadm/).
 - For more information about linking at build, including a step-by-step example of composing components, check out [Linking at build](/docs/concepts/linking-components/linking-at-build).
-
-

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -28,11 +28,11 @@ Providers may be **first-party** (meaning they are maintained as part of the was
 
 You can find a complete list of first-party providers on the [wasmCloud GitHub Packages page](https://github.com/orgs/wasmCloud/packages?repo_name=wasmCloud). First-party providers are named to specify the [interface](/docs/concepts/interfaces) being used and the specific functionality implemented with the interface (e.g. "keyvalue" for the WASI interface and "Redis" for the specific functionality).
 
-First-party providers may be **external** or **built-in**. External providers run on the wasmCloud [lattice](/docs/concepts/lattice/) like components&mdash;they are "external" in the sense that they are external to any given wasmCloud host. All third-party providers are external, and generally, when we talk about providers, we are talking about external providers. There is, however, a small set of **built-in** providers that represent wasmCloud's trusted compute base and are built directly into the wasmCloud host. 
+First-party providers may be **external** or **built-in**. External providers run on the wasmCloud [lattice](/docs/concepts/lattice/) like components&mdash;they are "external" in the sense that they are external to any given wasmCloud host. All third-party providers are external, and generally, when we talk about providers, we are talking about external providers. There is, however, a small set of **built-in** providers that represent wasmCloud's trusted compute base and are built directly into the wasmCloud host.
 
 ### External providers
 
-Since external providers are standalone entities on the lattice, they may be scaled and updated independently of any given wasmCloud host. 
+Since external providers are standalone entities on the lattice, they may be scaled and updated independently of any given wasmCloud host.
 
 External first-party providers include:
 
@@ -45,15 +45,15 @@ External first-party providers include:
 - [messaging-kafka](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-messaging-kafka)
 - [messaging-nats](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-messaging-nats)
 
-In [Wadm manifests](/docs/ecosystem/wadm/), you can refer to the [wasmCloud GitHub Packages registry](https://github.com/orgs/wasmCloud/packages?repo_name=wasmCloud) for OCI images of providers&mdash;for example: `ghcr.io/wasmcloud/keyvalue-redis:0.23.0`
+In [Wadm manifests](/docs/ecosystem/wadm/), you can refer to the [wasmCloud GitHub Packages registry](https://github.com/orgs/wasmCloud/packages?repo_name=wasmCloud) for OCI images of providers&mdash;for example: `ghcr.io/wasmcloud/keyvalue-redis:0.27.0`
 
 ### Built-in providers
 
 Because built-in providers are part of the wasmCloud host itself, they do not communicate over NATS and run in the same process as the host. Updating a built-in provider requires updating the host. Built-in providers include:
 
-* Logging (using the [`wasi-logging`](https://github.com/WebAssembly/wasi-logging) interface)
-* Random (using the [`wasi-random`](https://github.com/WebAssembly/wasi-random) interface)
-* Clocks (using the [`wasi-clocks`](https://github.com/WebAssembly/wasi-clocks) interface)
+- Logging (using the [`wasi-logging`](https://github.com/WebAssembly/wasi-logging) interface)
+- Random (using the [`wasi-random`](https://github.com/WebAssembly/wasi-random) interface)
+- Clocks (using the [`wasi-clocks`](https://github.com/WebAssembly/wasi-clocks) interface)
 
 Built-in providers form wasmCloud's **trusted compute base**&mdash;carefully vetted code providing core functionalities. You can learn more about using built-in providers on the [Linking at runtime](/docs/concepts/linking-components/linking-at-runtime#built-in-providers) page.
 

--- a/docs/deployment/k8s/index.mdx
+++ b/docs/deployment/k8s/index.mdx
@@ -19,12 +19,12 @@ When running wasmCloud on Kubernetes, you can use `kubectl` to deploy [wasmCloud
 The wasmCloud operator can be found on GitHub at [https://github.com/wasmCloud/wasmcloud-operator](https://github.com/wasmCloud/wasmcloud-operator) and enables...
 
 1. Deployment of wasmCloud Hosts onto a Kubernetes cluster via Custom Resource Definition (`WasmCloudHostConfig`)
-2. Interoperability with the [wasmCloud Application Deployment Manager (wadm)](/docs/ecosystem/wadm/) for deploying wasmcloud applications defined in the [OAM spec](https://oam.dev/) format. 
+2. Interoperability with the [wasmCloud Application Deployment Manager (wadm)](/docs/ecosystem/wadm/) for deploying wasmcloud applications defined in the [OAM spec](https://oam.dev/) format.
 3. Automated creation of Kubernetes Services pointing to wasmCloud applications deployed with a HTTP Server capability (in the future this will become configurable&mdash;today it's automatic).
 
-In order to follow the instructions on this page, you will need a Kubernetes cluster and appropriate access credentials as well as a [Helm](https://helm.sh/) installation. It will also be useful to have [wasmCloud Shell (`wash`)](/docs/installation) installed locally. 
+In order to follow the instructions on this page, you will need a Kubernetes cluster and appropriate access credentials as well as a [Helm](https://helm.sh/) installation. It will also be useful to have [wasmCloud Shell (`wash`)](/docs/installation) installed locally.
 
-You can watch a [video of the setup on YouTube](https://www.youtube.com/embed/239Q_hAKqPw?si=y0nHeFHfCPOdItNU&amp;start=235&amp;end=780):
+You can watch a [video of the setup on YouTube](https://www.youtube.com/embed/239Q_hAKqPw?si=y0nHeFHfCPOdItNU&start=235&end=780):
 
 <YouTube url="https://www.youtube.com/watch?v=239Q_hAKqPw&start=235&amp;end=780" />
 
@@ -48,25 +48,27 @@ Add the NATS Helm repo:
 ```shell
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 ```
+
 Install the upstream NATS Helm chart to start a cluster with the `values.yaml` file from the quickstart:
 
 ```shell
 helm upgrade --install -f https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/nats-values.yaml nats nats/nats
 ```
+
 Validate the installation with:
 
 ```shell
 kubectl rollout status deploy,sts -l app.kubernetes.io/instance=nats
 ```
 
-
 #### Deploy wadm
 
-You can deploy wadm to your Kubernetes cluster with a Helm chart hosted by wasmCloud. 
+You can deploy wadm to your Kubernetes cluster with a Helm chart hosted by wasmCloud.
 
 ```shell
 helm install wadm -f https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/wadm-values.yaml oci://ghcr.io/wasmcloud/charts/wadm
 ```
+
 Validate the installation with:
 
 ```shell
@@ -80,6 +82,7 @@ To deploy the operator:
 ```shell
 kubectl apply -k https://github.com/wasmCloud/wasmcloud-operator/deploy/base
 ```
+
 Validate the installation with:
 
 ```shell
@@ -96,11 +99,13 @@ Apply the `wasmcloud-host` manifest:
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/wasmcloud-host.yaml
 ```
+
 Check wasmCloud host status:
 
 ```shell
 kubectl describe wasmcloudhostconfig wasmcloud-host
 ```
+
 You can also check logs for a given host with:
 
 ```shell
@@ -118,7 +123,7 @@ metadata:
   name: hello-world
   annotations:
     version: v0.0.1
-    description: "HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)"
+    description: 'HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
     wasmcloud.dev/authors: wasmCloud team
     wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rusg/components/http-hello-world/wadm.yaml
     wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rusg/components/http-hello-world/README.md
@@ -141,7 +146,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.21.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
@@ -159,7 +164,7 @@ spec:
                   address: 0.0.0.0:8080
 ```
 
-Run `kubectl apply`: 
+Run `kubectl apply`:
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/hello-world-application.yaml
@@ -170,6 +175,7 @@ Check the deployment status:
 ```shell
 kubectl get application
 ```
+
 ```shell
 APPLICATION   DEPLOYED VERSION   LATEST VERSION   STATUS
 hello-world   v0.0.1             v0.0.1           Deployed
@@ -182,6 +188,7 @@ Port-forward into the NATS service running in your Kubernetes cluster. `4222` is
 ```shell
 kubectl port-forward svc/nats 4222:4222 4223:4223
 ```
+
 Now you can connect to wasmCloud on Kubernetes with your local wash toolchain:
 
 ```shell

--- a/docs/developer/components/configure.mdx
+++ b/docs/developer/components/configure.mdx
@@ -57,7 +57,7 @@ Then, when starting your component with `wash`, you can supply the configuration
 
 ```bash
 # wash start component <component_ref> <component_id> --config <config-name>
-wash start component wasmcloud.azurecr.io/http-hello-world:0.1.0 hello --config custom-config
+wash start component ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0 hello --config custom-config
 ```
 
     </TabItem>
@@ -202,7 +202,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         - type: link
           properties:

--- a/docs/developer/components/run.mdx
+++ b/docs/developer/components/run.mdx
@@ -56,7 +56,7 @@ wash get inventory
 We know our new component needs a web server, so let's start the HTTP server capability provider.
 
 ```bash
-wash start provider ghcr.io/wasmcloud/http-server:0.20.1 http-server
+wash start provider ghcr.io/wasmcloud/http-server:0.22.0 http-server
 ```
 
 ### Add a link

--- a/docs/ecosystem/wadm/api.md
+++ b/docs/ecosystem/wadm/api.md
@@ -32,7 +32,7 @@ wadm.api.{lattice-id}.{category}.{operation}.{object}
 ```
 
 The `operation` is usually a verb, and `object` is an optional scope-limiter to the operation. In
-many cases, the `object` will be something like a model name. 
+many cases, the `object` will be something like a model name.
 
 All requests and responses on this topic are encoded as JSON, except for the creation of models.
 
@@ -48,7 +48,7 @@ In wasmCloud, models are versioned representations of application workloads stor
 buckets. The following operations pertain to storing and retrieving models. Persistence of models is
 explicitly and deliberately separated from deployment management. Any model can have multiple
 versions stored, and any one of those versions can be deployed. Model persistence is similarly
-decoupled from any particular host. 
+decoupled from any particular host.
 
 ### Store models
 
@@ -93,7 +93,7 @@ used as a reserved word for indicating that the latest version should be deploye
 
 Please note that versions are entirely optional. Wadm will by default generate a
 [ULID](https://github.com/ulid/spec) for the model when it is pushed if no version is set. However,
-versions must still be unique 
+versions must still be unique
 
 ### Get model list
 
@@ -156,63 +156,61 @@ to fetch a specific version
   "result": "error|success|notfound",
   "message": "Successfully fetched model http-hello-world",
   "manifest": {
-      "apiVersion": "core.oam.dev/v1beta1",
-      "kind": "Application",
-      "metadata": {
-        "annotations": {
-          "description": "HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)",
-          "version": "v0.0.1"
-        },
-        "name": "http-hello-world"
+    "apiVersion": "core.oam.dev/v1beta1",
+    "kind": "Application",
+    "metadata": {
+      "annotations": {
+        "description": "HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)",
+        "version": "v0.0.1"
       },
-      "spec": {
-        "components": [
-          {
-            "name": "http-component",
-            "properties": {
-              "image": "wasmcloud.azurecr.io/echo:0.3.7"
-            },
-            "traits": [
-              {
-                "properties": {
-                  "instances": 1
-                },
-                "type": "spreadscaler"
-              }
-            ],
-            "type": "component"
+      "name": "http-hello-world"
+    },
+    "spec": {
+      "components": [
+        {
+          "name": "http-component",
+          "properties": {
+            "image": "wasmcloud.azurecr.io/echo:0.3.7"
           },
-          {
-            "name": "httpserver",
-            "properties": {
-              "image": "ghcr.io/wasmcloud/http-server:0.20.1"
-            },
-            "traits": [
-              {
-                "properties": {
-                  "interfaces": [
-                    "incoming-handler"
-                  ],
-                  "namespace": "wasi",
-                  "package": "http",
-                  "source_config": [
-                    {
-                      "name": "default-http",
-                      "properties": {
-                        "address": "127.0.0.1:8080"
-                      }
+          "traits": [
+            {
+              "properties": {
+                "instances": 1
+              },
+              "type": "spreadscaler"
+            }
+          ],
+          "type": "component"
+        },
+        {
+          "name": "httpserver",
+          "properties": {
+            "image": "ghcr.io/wasmcloud/http-server:0.22.0"
+          },
+          "traits": [
+            {
+              "properties": {
+                "interfaces": ["incoming-handler"],
+                "namespace": "wasi",
+                "package": "http",
+                "source_config": [
+                  {
+                    "name": "default-http",
+                    "properties": {
+                      "address": "127.0.0.1:8080"
                     }
-                  ],
-                  "target": "http-component"
-                },
-                "type": "link"
-              }
-            ],
-            "type": "capability"
-          }
-        ]
-      }
+                  }
+                ],
+                "target": "http-component"
+              },
+              "type": "link"
+            }
+          ],
+          "type": "capability"
+        }
+      ]
     }
+  }
 }
 ```
 
@@ -245,7 +243,7 @@ Each of the items in the response list describes a revision and indicates whethe
 the deployed one. Remember that the ordering of the list does not reflect the semantic versioning as
 we do not require that the version field be semver. If no manual versions were set, all IDs will be
 also be lexicographically sortable to be the same as insertion order since they will be
-[ULIDs](https://github.com/ulid/spec) 
+[ULIDs](https://github.com/ulid/spec)
 
 ### Delete models
 
@@ -261,7 +259,7 @@ Empty body or
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.0"
 }
 ```
 

--- a/docs/ecosystem/wadm/model.md
+++ b/docs/ecosystem/wadm/model.md
@@ -78,7 +78,7 @@ To define a **capability provider**, we include a `capability` component, as fol
 - name: keyvalue
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
         id: kvredis
         config:
           - name: url
@@ -241,5 +241,5 @@ spec:
     - name: keyvalue
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
 ```

--- a/docs/reference/cloud-event-list.mdx
+++ b/docs/reference/cloud-event-list.mdx
@@ -287,7 +287,7 @@ The `provider_started` event is emitted when a provider is started.
   "time": "2023-05-13T18:00:53.856590Z",
   "data": {
     "host_id": "NCQDNJWGAISVBPU4VF45AKDTOTU6NI74WZFNW73ZR7K7NJ72AV7PUDHP",
-    "image_ref": "ghcr.io/wasmcloud/keyvalue-redis:0.24.0",
+    "image_ref": "ghcr.io/wasmcloud/keyvalue-redis:0.27.0",
     "provider_id": "rust_http_kv-kvredis",
     "annotations": {
       "key": "value"
@@ -336,7 +336,7 @@ The `provider_start_failed` event is emitted when a provider fails to start.
   "specversion": "1.0",
   "time": "2023-06-13T00:00:00+00:00Z",
   "data": {
-    "image_ref": "ghcr.io/wasmcloud/keyvalue-redis:0.24.0",
+    "image_ref": "ghcr.io/wasmcloud/keyvalue-redis:0.27.0",
     "provider_id": "rust_http_kv-kvredis",
     "error": "Failed to start provider"
   }

--- a/docs/reference/wasi/support.md
+++ b/docs/reference/wasi/support.md
@@ -16,7 +16,7 @@ wasmCloud supports many WASI APIs out of the box. Any WebAssembly component that
 Inspecting the component from the [Hello World](/docs/tour/hello-world/) example shows the following imports and exports:
 
 ```bash
-wash inspect --wit wasmcloud.azurecr.io/http-hello-world:0.1.0
+wash inspect --wit ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
 ```
 
 ```wit

--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -28,10 +28,7 @@ Let's extend this application to do more than just say "Hello from Rust!" Using 
 
 ```rust
 wit_bindgen::generate!({
-    world: "hello",
-    exports: {
-        "wasi:http/incoming-handler": HttpServer,
-    },
+  generate_all
 });
 
 use exports::wasi::http::incoming_handler::Guest;
@@ -66,6 +63,8 @@ impl Guest for HttpServer {
       ResponseOutparam::set(response_out, Ok(response));
   }
 }
+
+export!(HttpServer);
 ```
 
   </TabItem>
@@ -523,7 +522,6 @@ kind: Application
 metadata:
   name: hello-world
   annotations:
-    version: v0.0.2 # Increment the version number # [!code ++]
     description: 'HTTP hello world demo, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
 spec:
   components:
@@ -532,7 +530,7 @@ spec:
       properties:
         # Your manifest will point to the path of the built component, you can also
         # start published components from OCI registries
-        image: wasmcloud.azurecr.io/http-hello-world:0.1.0
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         - type: spreadscaler
           properties:
@@ -552,21 +550,21 @@ spec:
     - name: kvredis
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.24.0
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         - type: link
           properties:
             target: http-component
             namespace: wasi
             package: http
-            interfaces: [incoming-handler] 
-            source_config: 
+            interfaces: [incoming-handler]
+            source_config:
               - name: default-http
-                properties: 
+                properties:
                   address: 127.0.0.1:8080
 ```
 
@@ -574,8 +572,7 @@ spec:
 You'll notice that the kvredis and httpserver providers are pulled from images hosted on GitHub Packages. The wasmCloud ecosystem uses the [OCI image specification](https://github.com/opencontainers/image-spec) to package components and providers&mdash;these component and provider images are not container images, but conform to OCI standards and may be stored on any OCI-compatible registry.
 :::
 
-
-For the last step, we can deploy the `v0.0.3` version of our application. Then, again, we can test our new functionality.
+Deploy the latest version of our application including the key-value provider. Then, again, we can test our new functionality.
 
 ```bash
 > wash app deploy wadm.yaml
@@ -589,6 +586,6 @@ Hello x1, Alice!
 
 ## Moving on
 
-In this tutorial, you added a few more features and persistent storage to a simple microservice. You also got to see the process of developing with interfaces, where the code you write is purely functional, doesn't require you to pick a library or vendor upfront, and allows you to change your application separately from its non-functional requirements. You can continue to build on this application by adding more features, or you can explore additional first-party providers in [the wasmCloud repo](https://github.com/wasmCloud/wasmCloud/tree/main/crates) (see any provider-* directory) to get an idea of what is possible with wasmCloud.
+In this tutorial, you added a few more features and persistent storage to a simple microservice. You also got to see the process of developing with interfaces, where the code you write is purely functional, doesn't require you to pick a library or vendor upfront, and allows you to change your application separately from its non-functional requirements. You can continue to build on this application by adding more features, or you can explore additional first-party providers in [the wasmCloud repo](https://github.com/wasmCloud/wasmCloud/tree/main/crates) (see any provider-\* directory) to get an idea of what is possible with wasmCloud.
 
 The next page demonstrates scaling via Wadm manifest and gives a high level overview of why this application that you've built already eliminates complexity and pain that developers often face when building applications for the cloud.

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -19,7 +19,7 @@ Looking for an introduction to the basic concepts of WebAssembly components and 
 
 :::
 
-In this guide, we'll take a tour through the wasmCloud ecosystem with a "Hello world" example. Once you're finished, you'll have a good understanding of how to use [**wasmCloud Shell (`wash`)**](/docs/ecosystem/wash/) to build and deploy wasmCloud applications. 
+In this guide, we'll take a tour through the wasmCloud ecosystem with a "Hello world" example. Once you're finished, you'll have a good understanding of how to use [**wasmCloud Shell (`wash`)**](/docs/ecosystem/wash/) to build and deploy wasmCloud applications.
 
 ## Start the wasmCloud host
 
@@ -29,16 +29,16 @@ If you haven't installed `wash` yet, follow the [installation guide](../installa
 
 :::
 
-All wasmCloud applications need a [host](/docs/concepts/hosts) to run on, so let's use `wash` to start one now. You can start a wasmCloud host on your local machine with `wash up` or run a host in a Docker container. 
+All wasmCloud applications need a [host](/docs/concepts/hosts) to run on, so let's use `wash` to start one now. You can start a wasmCloud host on your local machine with `wash up` or run a host in a Docker container.
 
 <Tabs groupId="env" queryString>
   <TabItem value="local" label="Local">
 
-To start a host, simply run: 
+To start a host, simply run:
 
 ```shell
 wash up
-``` 
+```
 
 The default settings should work well for this tutorial. The host can be killed at any time with `CTRL+c`.
 
@@ -183,7 +183,7 @@ Feel free to take a look at the code and the project structure. We'll take a loo
 ## Build the application
 
 :::info
-If you prefer not to build anything yet, you can use `wasmcloud.azurecr.io/http-hello-world:0.1.0` as the image inside of `wadm.yaml` instead to pull our prebuilt example component.
+If you prefer not to build anything yet, you can use `ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0` as the image inside of `wadm.yaml` instead to pull our prebuilt example component.
 :::
 
 We can use the open source httpserver provider to serve our application, so the only thing you'll need to build is the component. Change directory into the generated `hello` directory and run `wash build` to build your component:
@@ -398,15 +398,14 @@ kind: Application
 metadata:
   name: hello-world
   annotations:
-    version: v0.0.1
     description: 'HTTP hello world demo'
 spec:
   components:
     - name: http-component
       type: component
       properties:
-        # Your manifest deploys from a local .wasm file, but you can also use OCR registries as below
-        image: wasmcloud.azurecr.io/http-hello-world:0.1.0
+        # Your manifest deploys from a local .wasm file, but you can also use OCR registries like below
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         # One replica of this component will run
         - type: spreadscaler
@@ -416,7 +415,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.22.0
       traits:
         # Link the HTTP server and set it to listen on the local machine's port 8080
         - type: link

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -11,21 +11,19 @@ import washboard_hello from '../images/washboard_hello.png';
 
 WebAssembly can be easily scaled due to its small size, portability, and [wasmtime](https://wasmtime.dev/)'s ability to efficiently instantiate multiple instances of a single WebAssembly component. We leverage these aspects to make it simple to scale your applications with wasmCloud. Components only use resources when they're actively processing requests, so you can specify the number of replicas you want to run and wasmCloud will automatically scale up and down to meet demand. Let's scale up our hello world application to 100 replicas by editing `wadm.yaml`:
 
-```yaml {17-19}
+```yaml {15-17}
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
   name: hello-world
   annotations:
-    # Make sure to bump the version so wadm knows to update the application
-    version: v0.0.3
     description: 'HTTP hello world demo using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
 spec:
   components:
     - name: http-component
       type: component
       properties:
-        image: wasmcloud.azurecr.io/http-hello-world:0.1.0
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         - type: spreadscaler
           properties:
@@ -41,21 +39,19 @@ No matter where your components and capability providers run, they can seamlessl
 
 Distributing your application just requires updating your manifest to include spread information and making sure there are available wasmCloud hosts in the desired locations. We can update our hello application to run in multiple locations by editing `wadm.yaml`:
 
-```yaml {19-29}
+```yaml {17-27}
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
   name: hello-world
   annotations:
-    # Make sure to bump the version so wadm knows to update the application
-    version: v0.0.4
     description: 'HTTP hello world demo using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
 spec:
   components:
     - name: http-component
       type: component
       properties:
-        image: wasmcloud.azurecr.io/http-hello-world:0.1.0
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
       traits:
         - type: spreadscaler
           properties:


### PR DESCRIPTION
## Feature or Problem
This PR fixes a bug in the Rust hello world example, removes versions from the tutorial wadm manifests for simplicity, and updates OCI references for http-server/keyvalue-redis

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
