### PR TITLE
Fix Slack icon directing to Twitter

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -203,7 +203,7 @@ const config = (async (): Promise<Config> => {
           await svgIconNavItem({
             svgIconPath: './static/icons/slack.svg',
             label: 'Slack',
-            href: 'https://twitter.com/wasmCloud',
+            href: 'https://slack.wasmcloud.com/',
           }),
         ],
       },


### PR DESCRIPTION
## Feature or Problem
The Slack icon on the website directs to Twitter, rather than the Slack community.