### PR TITLE
docs: update CLI docs for wasmCloud 1.2

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -188,6 +188,7 @@ List all applications available within the lattice
 
   Default value: `2000`
 * `--context <CONTEXT>` — Name of a context to use for CTL connection and authentication
+* `--watch` — Switches to a real-time, live-updating application list
 
 
 
@@ -918,7 +919,7 @@ Start a developer loop to hot-reload a local wasmCloud component
 * `--nats-connect-only` — If a connection can't be established, exit and don't start a NATS server. Will be ignored if a remote_url and credsfile are specified
 * `--nats-version <NATS_VERSION>` — NATS server version to download, e.g. `v2.10.7`. See https://github.com/nats-io/nats-server/releases/ for releases
 
-  Default value: `v2.10.7`
+  Default value: `v2.10.18`
 * `--nats-host <NATS_HOST>` — NATS server host to connect to
 * `--nats-port <NATS_PORT>` — NATS server port to connect to. This will be used as the NATS listen port if `--nats-connect-only` isn't set
 * `--nats-websocket-port <NATS_WEBSOCKET_PORT>` — NATS websocket port to use. TLS is not supported. This is required for the wash ui to connect from localhost
@@ -927,7 +928,7 @@ Start a developer loop to hot-reload a local wasmCloud component
 * `--nats-js-domain <NATS_JS_DOMAIN>` — NATS Server Jetstream domain for extending superclusters
 * `--wasmcloud-version <WASMCLOUD_VERSION>` — wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud/releases for releases
 
-  Default value: `v1.1.0`
+  Default value: `v1.2.0`
 * `-x`, `--lattice <LATTICE>` — A unique identifier for a lattice, frequently used within NATS topics to isolate messages among different lattices
 * `--host-seed <HOST_SEED>` — The seed key (a printable 256-bit Ed25519 private key) used by this host to generate it's public key
 * `--rpc-host <RPC_HOST>` — An IP address or DNS name to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-host if not supplied
@@ -973,9 +974,11 @@ Start a developer loop to hot-reload a local wasmCloud component
 * `--max-execution-time-ms <MAX_EXECUTION_TIME>` — Defines the Max Execution time (in ms) that the host runtime will execute for
 
   Default value: `600000`
+* `--secrets-topic <SECRETS_TOPIC>` — If provided, enables interfacing with a secrets backend for secret retrieval over the given topic prefix
+* `--policy-topic <POLICY_TOPIC>` — If provided, enables policy checks on start actions and component invocations
 * `--wadm-version <WADM_VERSION>` — wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases
 
-  Default value: `v0.13.0`
+  Default value: `v0.14.0`
 * `--disable-wadm` — If enabled, wadm will not be downloaded or run as a part of the up command
 * `--wadm-js-domain <WADM_JS_DOMAIN>` — The JetStream domain to use for wadm
 * `--wadm-manifest <WADM_MANIFEST>` — The path to a wadm application manifest to run while the host is up
@@ -2076,7 +2079,7 @@ Bootstrap a wasmCloud environment
 * `--nats-connect-only` — If a connection can't be established, exit and don't start a NATS server. Will be ignored if a remote_url and credsfile are specified
 * `--nats-version <NATS_VERSION>` — NATS server version to download, e.g. `v2.10.7`. See https://github.com/nats-io/nats-server/releases/ for releases
 
-  Default value: `v2.10.7`
+  Default value: `v2.10.18`
 * `--nats-host <NATS_HOST>` — NATS server host to connect to
 * `--nats-port <NATS_PORT>` — NATS server port to connect to. This will be used as the NATS listen port if `--nats-connect-only` isn't set
 * `--nats-websocket-port <NATS_WEBSOCKET_PORT>` — NATS websocket port to use. TLS is not supported. This is required for the wash ui to connect from localhost
@@ -2085,7 +2088,7 @@ Bootstrap a wasmCloud environment
 * `--nats-js-domain <NATS_JS_DOMAIN>` — NATS Server Jetstream domain for extending superclusters
 * `--wasmcloud-version <WASMCLOUD_VERSION>` — wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud/releases for releases
 
-  Default value: `v1.1.0`
+  Default value: `v1.2.0`
 * `-x`, `--lattice <LATTICE>` — A unique identifier for a lattice, frequently used within NATS topics to isolate messages among different lattices
 * `--host-seed <HOST_SEED>` — The seed key (a printable 256-bit Ed25519 private key) used by this host to generate it's public key
 * `--rpc-host <RPC_HOST>` — An IP address or DNS name to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-host if not supplied
@@ -2131,9 +2134,11 @@ Bootstrap a wasmCloud environment
 * `--max-execution-time-ms <MAX_EXECUTION_TIME>` — Defines the Max Execution time (in ms) that the host runtime will execute for
 
   Default value: `600000`
+* `--secrets-topic <SECRETS_TOPIC>` — If provided, enables interfacing with a secrets backend for secret retrieval over the given topic prefix
+* `--policy-topic <POLICY_TOPIC>` — If provided, enables policy checks on start actions and component invocations
 * `--wadm-version <WADM_VERSION>` — wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases
 
-  Default value: `v0.13.0`
+  Default value: `v0.14.0`
 * `--disable-wadm` — If enabled, wadm will not be downloaded or run as a part of the up command
 * `--wadm-js-domain <WADM_JS_DOMAIN>` — The JetStream domain to use for wadm
 * `--wadm-manifest <WADM_MANIFEST>` — The path to a wadm application manifest to run while the host is up
@@ -2154,6 +2159,3 @@ Serve a web UI for wasmCloud
 * `-v`, `--version <VERSION>` — Which version of the UI to run
 
   Default value: `v0.4.0`
-
-
-


### PR DESCRIPTION
Update CLI docs for wasmCloud 1.2 / `wash` 0.31.0.