### PR TITLE
feat: add configure provider docs page

### DIFF
--- a/docs/developer/providers/configure.mdx
+++ b/docs/developer/providers/configure.mdx
@@ -8,14 +8,14 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Components can be passed a map of configuration at runtime to use when executing. This configuration should first be defined using [wash](/docs/ecosystem/wash/) or as a part of your [wadm](/docs/ecosystem/wadm/) manifest, and then fetched using the `wasi:config/runtime` interface.
+Capability providers can be passed a map of configuration at runtime to use when executing. This configuration should first be defined using [wash](/docs/ecosystem/wash/) or as a part of your [wadm](/docs/ecosystem/wadm/) manifest, and then given to the capability provider at runtime.
 
 ## Define Configuration
 
 <Tabs groupId="tool" queryString>
     <TabItem value="wadm" label="wadm" default>
 
-If you're using [wadm](/docs/ecosystem/wadm/) to declaratively define applications, you can use the `config` field to define configuration for your component. Wadm will automatically manage creating the configuration for you and supplying it to the component at runtime.
+If you're using [wadm](/docs/ecosystem/wadm/) to declaratively define applications, you can use the `config` field to define configuration for your provider. Wadm will automatically manage creating the configuration for you and supplying it to the provider at runtime.
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
@@ -24,13 +24,13 @@ metadata:
   name: hello-world
   annotations:
     version: v0.0.1
-    description: 'Component that uses wasi:http and wasi:config/runtime'
+    description: 'Capability provider that uses wasi:http and runtime configuration'
 spec:
   components:
-    - name: http-component
-      type: component
+    - name: http-server
+      type: capability
       properties:
-        image: file://./build/http_hello_world_s.wasm
+        image: file://./build/http-server.par.gz
         config: # [!code ++]
           - name: custom-config # [!code ++]
             properties: # [!code ++]
@@ -53,11 +53,11 @@ If you're using [wash](/docs/ecosystem/wash/) to imperatively start your compone
 wash config put custom-config foo=bar log-level=debug
 ```
 
-Then, when starting your component with `wash`, you can supply the configuration using the `--config` flag:
+Then, when starting your capability provider with `wash`, you can supply the configuration using the `--config` flag:
 
 ```bash
-# wash start component <component_ref> <component_id> --config <config-name>
-wash start component ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0 hello --config custom-config
+# wash start provider <component_ref> <component_id> --config <config-name>
+wash start provider ghcr.io/wasmcloud/components/http-server:0.1.0 http-server --config custom-config
 ```
 
     </TabItem>
@@ -66,95 +66,88 @@ wash start component ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0 he
 
 ## Using Configuration
 
-:::info[Prerequisite]
-To fetch the interface for runtime configuration, you'll need [wit-deps](https://github.com/bytecodealliance/wit-deps) installed.
-:::
-
-Components access configuration at runtime by using the [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) interface. To use this interface, you'll need to add it to your WIT dependencies, and then import the `wasi:config/runtime` interface in your component.
-
-In your `wit/deps.toml`:
-
-```toml
-config = "https://github.com/WebAssembly/wasi-runtime-config/archive/main.tar.gz"
-```
-
-Then, update your dependencies to fetch the interface:
-
-```bash
-wit-deps update
-```
-
-Lastly, update your component to import the `wasi:config/runtime` interface inside of your `wit/world.wit` file. This may be named differently depending on your component, but the interface should be imported in the same way.
-
-```wit
-package wasmcloud:hello;
-
-world hello {
-    import wasi:config/runtime@0.2.0-draft;
-}
-```
-
-Now, you can fetch the configuration inside of your component using the runtime configuration interface.
+Capability providers are given configuration at startup and as a part of each link. You can use the
 
 <Tabs groupId="lang" queryString>
     <TabItem value="rust" label="Rust" default>
 
-```rust
-let log_level = wasi::config::runtime::get("log-level")
-    .expect("Unable to fetch value")
-    .unwrap_or_else(|| "config value not set".to_string());
+The [HostData](https://docs.rs/wasmcloud-provider-sdk/0.8.0/wasmcloud_provider_sdk/struct.HostData.html) contains configuration for the provider at startup:
 
-assert_eq!(log_level, "debug");
+```rust
+pub async fn run() -> anyhow::Result<()> {
+    initialize_observability!(
+        "my-provider",
+        std::env::var_os("FLAMEGRAPH_PATH")
+    );
+
+    let host_data = load_host_data().context("failed to load host data")?;
+    let config = host_data.config;
+    let my_provider = MyProvider::new(config)
+        .context("failed to create provider from hostdata configuration")?;
+    let shutdown = run_provider(my_provider, "my-provider")
+        .await
+        .context("failed to run provider")?;
+    shutdown.await;
+    Ok(())
+}
+```
+
+The functions on the [Provider](https://docs.rs/wasmcloud-provider-sdk/0.8.0/wasmcloud_provider_sdk/trait.Provider.html) trait in the SDK allow for handling links and fetching the configuration when it's established:
+
+```rust
+impl Provider for MyProvider {
+  async fn receive_link_config_as_source(
+    &self,
+    link: LinkConfig<'_>,
+  ) -> anyhow::Result<()> {
+    let config = link.config;
+    Ok(())
+  }
+
+  async fn receive_link_config_as_target(
+    &self,
+    link: LinkConfig<'_>,
+  ) -> anyhow::Result<()> {
+    let config = link.config;
+    Ok(())
+  }
+}
+
 ```
 
     </TabItem>
-    <TabItem value="tinygo" label="TinyGo">
+    <TabItem value="tinygo" label="Go">
+
+The [HostData](https://github.com/wasmCloud/provider-sdk-go/blob/main/host.go#L21) struct contains the configuration passed to the provider at startup, and the [InterfaceLinkDefinition](https://github.com/wasmCloud/provider-sdk-go/blob/main/link.go#L20) struct contains the configuration passed to the provider when a link is established.
 
 ```go
-import (
-	"fmt"
+package main
 
-	gen "github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world/gen"
+import (
+	"github.com/wasmCloud/provider-sdk-go"
 )
 
-// ...elided
+func main() {
+  p := &Provider{}
 
-logLevel := gen.WasiConfig0_2_0_draft_RuntimeGet("log-level").Unwrap().Unwrap()
-// Prints "debug"
-fmt.Println("%s", logLevel);
+	wasmcloudProvider, err := provider.New(
+		provider.SourceLinkPut(p.handleNewSourceLink),
+		provider.TargetLinkPut(p.handleNewTargetLink),
+	)
+
+  config := wasmcloudProvider.HostData().Config
+}
+
+func (p *Provider) handleNewSourceLink(link provider.InterfaceLinkDefinition) error {
+  config := link.SourceConfig
+	return nil
+}
+
+func (p *Provider) handleNewTargetLink(link provider.InterfaceLinkDefinition) error {
+  config := link.TargetConfig
+	return nil
+}
 ```
-
-    </TabItem>
-    <TabItem value="typescript" label="TypeScript">
-
-```typescript
-//@ts-expect-error -- these types aren't currently generated by JCO
-import { Get } from 'wasi:config/runtime@0.2.0-draft';
-
-// ...
-const logLevel = Get('log-level');
-// Prints "Log level is: debug"
-console.log(`Log level is: ${logLevel}`);
-```
-
-    </TabItem>
-    <TabItem value="python" label="Python">
-
-```python
-# Replace `hello` with the name of your WIT world
-from hello.imports.runtime import (get)
-
-# ...
-
-logLevel = get("log-level")
-# Prints "Log level: debug"
-print("Log level: {logLevel}")
-```
-
-    </TabItem>
-    <TabItem value="unlisted" label="My Language Isn't Listed">
-
-If your language supports bindings generation (either via [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) or other tool) you can use the `wasi:config/runtime` interface to get configuration. Follow the bindings generation documentation in order to call the `wasi:config/runtime.get` function, and supply the name of the configuration property to fetch, e.g. `log-level` to retrieve `debug` in the above example.
 
     </TabItem>
 

--- a/docs/developer/providers/test.md
+++ b/docs/developer/providers/test.md
@@ -7,14 +7,11 @@ draft: false
 
 To test a provider, we can run it in a local wasmCloud environment, interacting with a real host and real components. To set up the environment:
 
-1. Start a new local OCI registry. You can download the [Docker Compose YAML file](https://github.com/wasmCloud/wasmCloud/blob/main/examples/docker/docker-compose-full.yml) and run `docker compose up -d registry`. You'll also need to [allow unauthenticated OCI registry access](/docs/developer/workflow#allowing-unauthenticated-oci-registry-access) before starting the wasmCloud host.
-
-2. Upload the newly-created _provider archive_ to the local OCI registry (You can use `wash push ...`, or if you have one of the provider project Makefiles, `make push`) `make start` to start it.
-
-3. Upload a component that utilizes the provider to the local OCI registry (`wash build` from the component source folder to compile it, sign it, and then use `wash push` to upload it to the registry). Then, use `wash start` to start the actor from the local registry.
-
-4. Link the component in your Wadm manifest.
-
-5. Invoke the component.
+1. Run a local development environment with `wash up`
+1. Build the provider with `wash build`
+1. Using a `wadm.yaml` application manifest that includes the path to your provider, `wash app deploy wadm.yaml` to deploy your application
+   1. Alternatively, start the provider with `wash start provider ./path/to/provider.par.gz`
+   1. Start a component that interacts with the provider with `wash start component`, then [link](/docs/concepts/linking-components/) the two together
+1. Invoke the component or provider directly to test
 
 To see an example of this, refer to the [create](/docs/developer/providers/create.md#testing-the-provider) section for capability providers.


### PR DESCRIPTION
## Feature or Problem
Noticed a bit of asymmetry in what pages we offer in the developer guide between providers and components, so I added a configure page for providers.

Some of this is copied from the component config page to maintain a similar structure.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
