### PR TITLE
site: Update Innovation Day agenda

### DIFF
--- a/src/pages/innovation-day/index.mdx
+++ b/src/pages/innovation-day/index.mdx
@@ -24,41 +24,52 @@ Here’s what to expect…check out the full agenda below!
     <div>
         <h2>Agenda</h2>
 
-**Morning Session** 
+**Morning Session**  
 
-**10 - 11am ET: wasmCloud Weekly Community Meeting**
+**10 - 11 ET: wasmCloud Weekly Community Meeting**
 
-- Special edition: we’ll focus on the essential role of open source maintainers: explore what being a maintainer involves, and how you can work with us.
+- In a special edition of our [weekly community meeting](https://wasmcloud.com/community), we’ll focus on the essential role of open source maintainers, exploring what being a maintainer entails, and how you can be a part of the project.
 
-**11 - 11.15am: Opening Keynote:** **The Pitfalls of Modern Platform Engineering: [Bailey Hayes](https://github.com/ricochet)**
+**11 - 11.15: Opening Keynote:** **The Pitfalls of Modern Platform Engineering: [Bailey Hayes](https://github.com/ricochet)**
 
-- Ending the ‘rinse and repeat’ of application development
-- Improving life with Kubernetes
-- Running distributed workloads securely and efficiently
+- Learn how to end the ‘rinse and repeat’ of application development, improve life with Kubernetes, and run distributed workloads securely and efficiently.
 
-**11.15 - 12.15pm: wasmCloud 1:1, Technical Deep Dive**
+**11.15 - 12.15: wasmCloud 1:1, Technical Deep Dive**
 
-- **Secrets: [Brooks Townsend](https://github.com/brooksmtownsend)**    - Why this is the most requested feature amongst our enterprise customers and partners
-- **Evolution in Golang: [Lucas Fontes](https://github.com/lxfontes), [Brooks Townsend](https://github.com/brooksmtownsend)** - Go provider SDK; Go components with TinyGo
-- **wasmcloud-operator: Lucas Fontes**
-- **wash dev: [Taylor Thomas](https://github.com/thomastaylor312)**
-- **Custom Capabilities** - Postgres and Couchbase with [Victor Adossi](https://github.com/t3hmrman); Machine Learning with Christoph Brewing, BMW / Jochen Rau, MachineMetrics
-- Seamless distributed systems with **wRPC and NATS:** [Taylor Thomas](https://github.com/thomastaylor312) and [Roman Volosatvos](https://github.com/rvolosatovs)
+- **Secrets**
+    - [**Brooks Townsend**](https://github.com/brooksmtownsend) explains why this is the most requested feature amongst our enterprise customers and partners and digs into how secrets work in wasmCloud.
+- **Evolution in Golang**
+    - [**Lucas Fontes**](https://github.com/lxfontes) and [**Brooks Townsend**](https://github.com/brooksmtownsend) discuss the Go provider SDK and building Go components with TinyGo.
+- **wasmCloud-operator**
+    - [**Lucas Fontes**](https://github.com/lxfontes) explores the wasmCloud Kubernetes operator and how it helps users bring wasmCloud applications to Kubernetes clusters.
+- **wash dev**
+    - [**Taylor Thomas**](https://github.com/thomastaylor312) introduces and demonstrates the `wash dev` CLI feature.
+- **Custom Capabilities**
+    - Postgres and Couchbase with [**Victor Adossi**](https://github.com/vados-cosmonic)
+    - Machine Learning with community users
+- **wRPC and NATS**
+    - [**Taylor Thomas**](https://github.com/thomastaylor312) and [**Roman Volosatovs**](https://github.com/rvolosatovs) explore how to use wRPC and NATS for seamless distributed systems
 
-**12.15 - 12.30pm: Fireside Chat:** Community leaders in the CNCF and Bytecode Alliance join [Bailey Hayes](https://github.com/ricochet)
-    * What’s next in cloud native WASI proposals?
-    * Your Community Needs You! Bytecode Alliance community call to action  
+**12.15 - 1.30pm: Community Keynote and Demos**
 
-**12.30 - 1.30pm: Customer and User Demos**
-    * You don’t want to miss these demos! Details to follow!
+- **12.15 - 12.30: Fireside Chat:** Bytecode Alliance and Wasm industry leaders [Pat Hickey](https://github.com/pchickey) and [Yosh Wuyts](https://github.1git.de/yoshuawuyts) will join Bailey Hayes to discuss what’s next for the WebAssembly ecosystem, standards and community.
+    - What’s next in cloud native WASI proposals?
+    - Your Community Needs You! Bytecode Alliance community call to action
+- **12.30 - 1.30pm Customer and User Demos**
+    - **Akamai and the future of edge computing**
+    Senior Architect at **Akamai**, [Doug Rodrigues](https://github.com/djrodrigues), will discuss what the future of edge computing looks like for Akamai, and the role of Wasm and wasmCloud in addressing the problems inherent in deploying to edge locations.
+    - **wasmCloud in Industrial IoT**
+    [Jochen Rau](https://github.com/jocrau) and [Tyler Schoppe](https://github.com/tylerschoppe) from **MachineMetrics**’s Platform Engineering Team will share the secrets to bringing wasmCloud to industrial IoT use cases. After a successful PoC which proved it’s possible to better utilize edge resources with Wasm, the team is now progressing to deploying wasmCloud on manufacturing machinery! Join their session to find out how.
+    - **Infrastructure Transformation with wasmCloud**
+    Senior Software Engineer at **Adobe**, [Colin Murphy](https://github.com/cdmurph32), having brought wasmCloud to Adobe’s Kubernetes infrastructure, Colin will share how the use of wasmCloud is evolving at Adobe, and the different use cases emerging within the company.
 
 **1.30 - 2pm: Lunch**
 
 **2 - 6pm: Workshop and Gather Hangout**
 
-- Workshop! Build your own standup app with [Lachlan Heywood](https://github.com/lachieh)
+- Workshop! Build your own standup app with [Lachlan Heywood](https://www.notion.so/cd7e2b68ae934af5a9edd419f5f57817?pvs=21)
 - Meet the Bytecode Alliance team
-- Meet wasmCloud maintainers [Brooks](https://github.com/brooksmtownsend), [Taylor](https://github.com/thomastaylor312), [Bailey](https://github.com/ricochet), [Victor](https://github.com/t3hmrman) and the team and find out how to get involved
+- Meet wasmCloud maintainers Brooks, Taylor, Bailey, Victor and the team and find out how to get involved
 - Meet your community compatriots!
 
 **6pm: Event Closes**


### PR DESCRIPTION
Bring the agenda on the Innovation Day landing page to parity with the blog. 