### PR TITLE
chore: update .NET blog to reflect revised timelines

### DIFF
--- a/blog/2024-09-05-build-wasm-components-dotnet-wasmcloud/index.mdx
+++ b/blog/2024-09-05-build-wasm-components-dotnet-wasmcloud/index.mdx
@@ -9,13 +9,11 @@ description: "Learn how to compile .NET/C# code to a WebAssembly component and r
 
 ![Build native WebAssembly components with .NET and C# and deploy on wasmCloud](./images/build-wasm-components-dotnet-wasmcloud.webp)
 
-Building WebAssembly components in .NET/C# is easier than ever before, with native WASI P2 support arriving in the .NET 9 SDK (final release scheduled for November 2024). 
-
-In this post, we'll take a look at the landscape of .NET tooling for components, explore how to get started today, and find out how easy it is to compile .NET/C# code to a component and run it on wasmCloud.
+Building WebAssembly components in .NET/C# is easier than ever before. In this post, we'll take a look at the landscape of .NET tooling for components, explore how to get started today, and find out how easy it is to compile .NET/C# code to a component and run it on wasmCloud.
 
 ## The WASI P2 and .NET landscape
 
-WebAssembly (Wasm) in general has a strong history of support in .NET, and today there is an increasingly mature ecosystem for building Wasm components with the .NET SDK. In addition to the native WASI P2 support coming to .NET's [Mono](https://github.com/dotnet/runtime/tree/main/src/mono) runtime in .NET 9, the [NativeAOT-LLVM](https://github.com/dotnet/runtimelab/tree/feature/NativeAOT-LLVM) compiler supports WASI P2 (with both .NET 8 and 9), giving developers two compiler options for native WASI P2 support. 
+WebAssembly (Wasm) in general has a strong history of support in .NET, and today there is an increasingly mature ecosystem for building Wasm components with the .NET SDK. The [NativeAOT-LLVM](https://github.com/dotnet/runtimelab/tree/feature/NativeAOT-LLVM) compiler supports WASI P2 (with both .NET 8 and 9), giving developers native WASI P2 support. 
 
 As in languages like Rust and TinyGo, native support means the ability to write "idiomatic" code&mdash;ordinary C# that compiles into a portable, interoperable component with no fuss and no need to learn any additional APIs or bindings. 
 
@@ -24,7 +22,7 @@ In terms of *developer experience*, the most important piece of the toolchain is
 * **Bundling**: `componentize-dotnet` bundles parts of the toolchain that you're going to need anyway (like the WASI SDK and dependency management tooling), largely keeping them out of sight and automating the processes. You can simply add a package to your project, compile, and generate a `.wasm` binary that conforms to WASI P2 and the Component Model. 
 * **Interfaces**: The ability to create custom, language-agnostic [interfaces](/docs/concepts/interfaces) in WebAssembly Interface Type (WIT) is one of components' signature superpowers, and `componentize-dotnet` not only makes it straightforward, but delivers a streamlined, forward-looking experience in which WIT interfaces can be easily fetched from OCI registries. We'll see this workflow in action in a moment.  
 
-There is one significant limitation to note: `componentize-dotnet` is currently limited to Windows machines. Maintainers expect macOS and Linux support soon&mdash;more on the future of the project and .NET-based components at the end of the blog.
+There is one significant limitation to note: `componentize-dotnet` is currently limited to Windows machines. Maintainers expect macOS and Linux support soon.
 
 ## Prerequisites
 


### PR DESCRIPTION
Updating blog to reflect revised expectations for work on Mono.
