### PR TITLE
chore: remove announcement bar, redirect WCID landing page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -207,8 +207,8 @@ const config = (async (): Promise<Config> => {
         ],
       },
 //      announcementBar: {
-//        id: 'innovation-day',
-//        content: `📢 Join us virtually for <b>wasmCloud Innovation Day</b> on September 18! <a href="/innovation-day">Register now</a> for a day of immersive learning, demos, user talks, and more.`,
+//        id: 'announcement',
+//        content: `📢 Announcement content goes here.`,
 //      },
       footer: {
         links: [

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -206,10 +206,10 @@ const config = (async (): Promise<Config> => {
           }),
         ],
       },
-      announcementBar: {
-        id: 'innovation-day',
-        content: `📢 Join us virtually for <b>wasmCloud Innovation Day</b> on September 18! <a href="/innovation-day">Register now</a> for a day of immersive learning, demos, user talks, and more.`,
-      },
+//      announcementBar: {
+//        id: 'innovation-day',
+//        content: `📢 Join us virtually for <b>wasmCloud Innovation Day</b> on September 18! <a href="/innovation-day">Register now</a> for a day of immersive learning, demos, user talks, and more.`,
+//      },
       footer: {
         links: [
           {

--- a/netlify.toml
+++ b/netlify.toml
@@ -195,6 +195,7 @@ redirects = [
 
   { from = "/youtube", to = "https://www.youtube.com/@wasmCloud", status = 301 },
   { from = "/yt", to = "https://www.youtube.com/@wasmCloud", status = 301 },
-  { from = "/innovation-day", to = "https://www.youtube.com/watch?v=vEHbZCBmPok", status = 301 },
+  { from = "/innovation-day-2024", to = "https://www.youtube.com/watch?v=vEHbZCBmPok", status = 301 },
+  { from = "/innovation-day", to = "https://www.youtube.com/watch?v=vEHbZCBmPok", status = 302 },
 
 ]

--- a/netlify.toml
+++ b/netlify.toml
@@ -195,5 +195,6 @@ redirects = [
 
   { from = "/youtube", to = "https://www.youtube.com/@wasmCloud", status = 301 },
   { from = "/yt", to = "https://www.youtube.com/@wasmCloud", status = 301 },
+  { from = "/innovation-day", to = "https://www.youtube.com/watch?v=vEHbZCBmPok", status = 301 },
 
 ]


### PR DESCRIPTION
Removes announcement bar and redirects WCID landing page to recording now that the event is done.
