### PR TITLE
docs: fix error on secrets backend page

### DIFF
--- a/docs/concepts/secrets.mdx
+++ b/docs/concepts/secrets.mdx
@@ -110,88 +110,108 @@ A link-scoped secret is only accessible in the context of a link. For a componen
 
 ### Sample manifest
 
-Below is a sample manifest that shows how secrets can be defined in a wasmCloud application:
+Below is a sample manifest (from the [secrets example in the wasmCloud monorepo](https://github.com/wasmCloud/wasmCloud/tree/main/examples/security/secrets)) that shows how secrets can be defined in a wasmCloud application:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: App with secrets
+  name: keyvalue-counter-auth
   annotations:
-    version: v0.0.1
-    description: 'HTTP hello world demo in Rust'
+    description: 'HTTP counter application with authentication, using the wasmcloud:secrets interface'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/security/secrets/component-keyvalue-counter-auth/wadm.yaml
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/security/secrets/component-keyvalue-counter-auth
+    wasmcloud.dev/categories: |
+      http,http-server,keyvalue,secrets,rust,example
 spec:
+  # The policy block allows reuse of secrets backend configurations across components and providers
+  policies:
+    - name: nats-kv
+      type: policy.secret.wasmcloud.dev/v1alpha1
+      properties:
+        backend: nats-kv
   components:
-    - name: http-component
+    - name: counter
       type: component
       properties:
-        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+        image: file://./component-keyvalue-counter-auth/build/component_keyvalue_counter_auth_s.wasm
+        id: auth-counter
+        # Provide the api_password secret to this component, fetching from nats-kv
         secrets:
-          - name: test
+          - name: api_password
             properties:
-              backend: vault
-              key: 'path/to/key'
+              policy: nats-kv
+              key: api_password
       traits:
         # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
-            replicas: 1
+            instances: 100
+        # Link the component to Redis on the default Redis port
+        #
+        # Establish a unidirectional link to the `kvredis` (the keyvalue capability provider),
+        # so the `counter` component can make use of keyvalue functionality provided by the Redis
+        # (i.e. using a keyvalue cache)
         - type: link
           properties:
-            target: httpclient
             namespace: wasi
-            package: http
-            interfaces: [outgoing-handler]
-        - type: link
-          properties:
-            namespace: wasmcloud
-            package: postgres
-            interfaces: [managed-query]
+            package: keyvalue
+            interfaces: [atomics, store]
             target:
-              name: sql-postgres
-              secrets:
-                - name: db-password
-                  properties:
-                    backend: vault
-                    key: secrets/myapp/db-password
-                    version: 1
+              name: kvredis
               config:
-                - name: foo
+                - name: redis-url
                   properties:
-                    value: whatever
+                    url: 127.0.0.1:6379
+              # Provide the redis_password secret to the target of the link, kvredis. This is used
+              # to connect to Redis with the password at runtime.
+              secrets:
+                - name: redis_password
+                  properties:
+                    policy: nats-kv
+                    key: redis_password
+
+    # Add a capability provider that enables Redis access
+    - name: kvredis
+      type: capability
+      properties:
+        image: file://./provider-keyvalue-redis-auth/build/wasmcloud-example-auth-kvredis.par.gz
+        id: auth-kvredis
+        # Provide the default_redis_password secret to the provider. The Redis provider can use this
+        # secret as needed to authenticate with Redis.
+        secrets:
+          - name: default_redis_password
+            properties:
+              policy: nats-kv
+              key: default_redis_password
 
     # Add a capability provider that enables HTTP access
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.20.0
+        image: ghcr.io/wasmcloud/http-server:0.23.1
+        id: auth-http-server
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8080 for incoming requests
+        #
+        # Since the HTTP server calls the `counter` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `counter` component (the "target"), so the server can invoke
+        # the component to handle a request.
         - type: link
           properties:
             namespace: wasi
             package: http
             interfaces: [incoming-handler]
             target:
-              name: http-component
-              secrets: ...
+              name: counter
             source:
               config:
                 - name: default-http
                   properties:
-                    address: 127.0.0.1:8080
-              secrets:
-
-    - name: httpclient
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/http-client:0.9.0
-
-    - name: sqldb-postgres
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/provider-sqldb-postgres:0.1.0
+                    address: 0.0.0.0:8080
 ```
 
 ## Defining secrets on the command line

--- a/docs/deployment/security/secrets.mdx
+++ b/docs/deployment/security/secrets.mdx
@@ -8,14 +8,25 @@ wasmCloud hosts retrieve secrets from secrets backends, which communicate with h
 
 ## Implementing a secrets backend
 
-A secrets backend implementation is identified by a single string as a name and will receive credentials requests on a NATS subject that includes this name prefix. The canonical default root prefix for the subject is `wasmcloud.secrets`. A specific deploy of a secrets backend is required to set a unique name for the backend and listens for requests on the subject `wasmcloud.secrets.$backend.$api_version.$operation`.
+A secrets backend implementation is identified by a single string as a name and will receive credentials requests on a NATS subject that includes this name prefix. The canonical default root prefix for the subject is `wasmcloud.secrets`. A specific deploy of a secrets backend is required to set a unique name for the backend and listens for requests on the subject `wasmcloud.secrets.$api_version.$backend.$operation`.
 
 A secrets store must handle the following operations (using `nats-kv` as an example backend):
 
 | Name          | Subject                                        | Return Payload             |
 | ------------- | ---------------------------------------------- | -------------------------- |
-| `get`         | `wasmcloud.secrets.nats-kv.v1alpha1.get`       | Encrypted `SecretResponse` |
-| `server_xkey` | `wasmcloud.secrets.vault.v1alpha1.server_xkey` | Unencrypted String         |
+| `get`         | `wasmcloud.secrets.v1alpha1.nats-kv.get`       | Encrypted `SecretResponse` |
+| `server_xkey` | `wasmcloud.secrets.v1alpha1.vault.server_xkey` | Unencrypted String         |
+
+When an application that makes use of a backend is deployed, you can use the policy block to allow reuse of secrets backend configurations across components and providers.
+
+```yaml
+spec:
+  policies:
+    - name: nats-kv
+      type: policy.secret.wasmcloud.dev/v1alpha1
+      properties:
+        backend: nats-kv
+```
 
 See the following section for more details on the secrets backend API.
 


### PR DESCRIPTION
Corrects error in subject that secrets backends listen for:

from `wasmcloud.secrets.$backend.$api_version`
to `wasmcloud.secrets.$api_version.$backend`

Also updates sample manifest on Secrets page in Platform Overview. 