### PR TITLE
feat(registry): Adds well-known file for wasm package tools

### DIFF
--- a/static/.well-known/wasm-pkg/registry.json
+++ b/static/.well-known/wasm-pkg/registry.json
@@ -1,0 +1,7 @@
+{
+    "preferredProtocol": "oci",
+    "oci": {
+        "registry": "ghcr.io",
+        "namespacePrefix": "wasmcloud/interfaces/"
+    }
+}


### PR DESCRIPTION
This is in preparation for pushing all of our custom interfaces to OCI so it is easier to configure wkg tooling