### PR TITLE
feat: Updates documentation with information on updating wit deps

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -53,6 +53,7 @@ This document contains the help content for the `wash` command-line program.
 * [`wash drain all`↴](#wash-drain-all)
 * [`wash drain oci`↴](#wash-drain-oci)
 * [`wash drain lib`↴](#wash-drain-lib)
+* [`wash drain dev`↴](#wash-drain-dev)
 * [`wash drain downloads`↴](#wash-drain-downloads)
 * [`wash get`↴](#wash-get)
 * [`wash get links`↴](#wash-get-links)
@@ -100,6 +101,10 @@ This document contains the help content for the `wash` command-line program.
 * [`wash update component`↴](#wash-update-component)
 * [`wash up`↴](#wash-up)
 * [`wash ui`↴](#wash-ui)
+* [`wash wit`↴](#wash-wit)
+* [`wash wit build`↴](#wash-wit-build)
+* [`wash wit deps`↴](#wash-wit-deps)
+* [`wash wit publish`↴](#wash-wit-publish)
 
 ## `wash`
 
@@ -136,6 +141,7 @@ This document contains the help content for the `wash` command-line program.
 * `update` — Update a component running in a host to newer image reference
 * `up` — Bootstrap a wasmCloud environment
 * `ui` — Serve a web UI for wasmCloud
+* `wit` — Create wit packages and fetch wit dependencies for a component
 
 ###### **Options:**
 
@@ -416,12 +422,15 @@ Build (and sign) a wasmCloud component or capability provider
 ###### **Options:**
 
 * `-p`, `--config-path <CONFIG_PATH>` — Path to the wasmcloud.toml file or parent folder to use for building
+* `--pkg-config <CONFIG>` — The path to the configuration file
+* `--pkg-cache <CACHE>` — The path to the cache directory. Defaults to the system cache directory
 * `--keys-directory <KEYS_DIRECTORY>` — Location of key files for signing. Defaults to $WASH_KEYS ($HOME/.wash/keys)
 * `-i`, `--issuer <ISSUER>` — Path to issuer seed key (account). If this flag is not provided, the seed will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found
 * `-s`, `--subject <SUBJECT>` — Path to subject seed key (module or service). If this flag is not provided, the seed will be sourced from $WASH_KEYS ($HOME/.wash/keys) or generated for you if it cannot be found
 * `--disable-keygen` — Disables autogeneration of keys if seed(s) are not provided
 * `--build-only` — Skip signing the artifact and only use the native toolchain to build
 * `--sign-only` — Skip building the artifact and only use configuration to sign
+* `--skip-fetch` — Skip wit dependency fetching and use only what is currently present in the wit directory (useful for airgapped or disconnected environments)
 
 
 
@@ -929,7 +938,7 @@ Start a developer loop to hot-reload a local wasmCloud component
 * `--nats-connect-only` — If a connection can't be established, exit and don't start a NATS server. Will be ignored if a remote_url and credsfile are specified
 * `--nats-version <NATS_VERSION>` — NATS server version to download, e.g. `v2.10.7`. See https://github.com/nats-io/nats-server/releases/ for releases
 
-  Default value: `v2.10.18`
+  Default value: `v2.10.20`
 * `--nats-host <NATS_HOST>` — NATS server host to connect to
 * `--nats-port <NATS_PORT>` — NATS server port to connect to. This will be used as the NATS listen port if `--nats-connect-only` isn't set
 * `--nats-websocket-port <NATS_WEBSOCKET_PORT>` — NATS websocket port to use. TLS is not supported. This is required for the wash ui to connect from localhost
@@ -938,7 +947,7 @@ Start a developer loop to hot-reload a local wasmCloud component
 * `--nats-js-domain <NATS_JS_DOMAIN>` — NATS Server Jetstream domain for extending superclusters
 * `--wasmcloud-version <WASMCLOUD_VERSION>` — wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud/releases for releases
 
-  Default value: `v1.2.1`
+  Default value: `v1.4.0`
 * `-x`, `--lattice <LATTICE>` — A unique identifier for a lattice, frequently used within NATS topics to isolate messages among different lattices
 * `--host-seed <HOST_SEED>` — The seed key (a printable 256-bit Ed25519 private key) used by this host to generate it's public key
 * `--rpc-host <RPC_HOST>` — An IP address or DNS name to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-host if not supplied
@@ -990,16 +999,20 @@ Start a developer loop to hot-reload a local wasmCloud component
 * `--host-path <HOST_PATH>` — Path to a binary that should be used to start the wasmCloud host
 * `--wadm-version <WADM_VERSION>` — wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases
 
-  Default value: `v0.14.0`
+  Default value: `v0.18.0`
 * `--disable-wadm` — If enabled, wadm will not be downloaded or run as a part of the up command
 * `--wadm-js-domain <WADM_JS_DOMAIN>` — The JetStream domain to use for wadm
 * `--wadm-manifest <WADM_MANIFEST>` — The path to a wadm application manifest to run while the host is up
+* `--pkg-config <CONFIG>` — The path to the configuration file
+* `--pkg-cache <CACHE>` — The path to the cache directory. Defaults to the system cache directory
 * `--host-id <host-id>` — ID of the host to use for `wash dev` if one is not selected, `wash dev` will attempt to use the single host in the lattice
 * `--work-dir <code-dir>` — Path to code directory
+* `--ignore-dir <ignore-dir>` — Directories to ignore when watching for changes. This should be set to directories where generated files are placed, such as `target/` or `dist/`. Can be specified multiple times
 * `--leave-host-running` — Leave the wasmCloud host running after stopping the devloop
 
   Default value: `false`
 * `--manifest-output-dir <MANIFEST_OUTPUT_DIR>` — Write generated WADM manifest(s) to a given folder (every time they are generated)
+* `--skip-fetch` — Skip wit dependency fetching and use only what is currently present in the wit directory (useful for airgapped or disconnected environments)
 
 
 
@@ -1050,6 +1063,7 @@ Manage contents of local wasmCloud caches
 * `all` — Remove all cached files created by wasmcloud
 * `oci` — Remove cached files downloaded from OCI registries by wasmCloud
 * `lib` — Remove cached binaries extracted from provider archives
+* `dev` — Remove files and logs from wash dev sessions
 * `downloads` — Remove downloaded and generated files from launching wasmCloud hosts
 
 
@@ -1075,6 +1089,14 @@ Remove cached files downloaded from OCI registries by wasmCloud
 Remove cached binaries extracted from provider archives
 
 **Usage:** `wash drain lib`
+
+
+
+## `wash drain dev`
+
+Remove files and logs from wash dev sessions
+
+**Usage:** `wash drain dev`
 
 
 
@@ -1592,17 +1614,18 @@ List installed plugins
 
 Push an artifact to an OCI compliant registry
 
-**Usage:** `wash push [OPTIONS] <url> <artifact>`
+**Usage:** `wash push [OPTIONS] <url> <artifact> [PROJECT_CONFIG]`
 
 ###### **Arguments:**
 
 * `<url>` — URL to push artifact to
 * `<artifact>` — Path to artifact to push
+* `<PROJECT_CONFIG>` — Path to wasmcloud.toml file to use to find registry configuration, defaults to searching for a wasmcloud.toml file in the current directory
 
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Registry of artifact. This is only needed if the URL is not a full (OCI) artifact URL (ie, missing the registry fragment)
-* `-c`, `--config <CONFIG>` — Path to config file, if omitted will default to a blank configuration
+* `-c`, `--config <CONFIG>` — Path to OCI config file, if omitted will default to a blank configuration
 * `--allow-latest` — Allow latest artifact tags
 * `-a`, `--annotation <annotations>` — Optional set of annotations to apply to the OCI artifact manifest
 * `-u`, `--user <USER>` — OCI username, if omitted anonymous authentication will be used
@@ -2090,7 +2113,7 @@ Bootstrap a wasmCloud environment
 * `--nats-connect-only` — If a connection can't be established, exit and don't start a NATS server. Will be ignored if a remote_url and credsfile are specified
 * `--nats-version <NATS_VERSION>` — NATS server version to download, e.g. `v2.10.7`. See https://github.com/nats-io/nats-server/releases/ for releases
 
-  Default value: `v2.10.18`
+  Default value: `v2.10.20`
 * `--nats-host <NATS_HOST>` — NATS server host to connect to
 * `--nats-port <NATS_PORT>` — NATS server port to connect to. This will be used as the NATS listen port if `--nats-connect-only` isn't set
 * `--nats-websocket-port <NATS_WEBSOCKET_PORT>` — NATS websocket port to use. TLS is not supported. This is required for the wash ui to connect from localhost
@@ -2099,7 +2122,7 @@ Bootstrap a wasmCloud environment
 * `--nats-js-domain <NATS_JS_DOMAIN>` — NATS Server Jetstream domain for extending superclusters
 * `--wasmcloud-version <WASMCLOUD_VERSION>` — wasmCloud host version to download, e.g. `v0.55.0`. See https://github.com/wasmCloud/wasmcloud/releases for releases
 
-  Default value: `v1.2.1`
+  Default value: `v1.4.0`
 * `-x`, `--lattice <LATTICE>` — A unique identifier for a lattice, frequently used within NATS topics to isolate messages among different lattices
 * `--host-seed <HOST_SEED>` — The seed key (a printable 256-bit Ed25519 private key) used by this host to generate it's public key
 * `--rpc-host <RPC_HOST>` — An IP address or DNS name to use to connect to NATS for RPC messages, defaults to the value supplied to --nats-host if not supplied
@@ -2151,7 +2174,7 @@ Bootstrap a wasmCloud environment
 * `--host-path <HOST_PATH>` — Path to a binary that should be used to start the wasmCloud host
 * `--wadm-version <WADM_VERSION>` — wadm version to download, e.g. `v0.4.0`. See https://github.com/wasmCloud/wadm/releases for releases
 
-  Default value: `v0.14.0`
+  Default value: `v0.18.0`
 * `--disable-wadm` — If enabled, wadm will not be downloaded or run as a part of the up command
 * `--wadm-js-domain <WADM_JS_DOMAIN>` — The JetStream domain to use for wadm
 * `--wadm-manifest <WADM_MANIFEST>` — The path to a wadm application manifest to run while the host is up
@@ -2171,4 +2194,82 @@ Serve a web UI for wasmCloud
   Default value: `3030`
 * `-v`, `--version <VERSION>` — Which version of the UI to run
 
-  Default value: `v0.4.0`
+  Default value: `v0.5.0`
+
+
+
+## `wash wit`
+
+Create wit packages and fetch wit dependencies for a component
+
+**Usage:** `wash wit <COMMAND>`
+
+###### **Subcommands:**
+
+* `build` — Build a WIT package from a directory. By default, this will fetch all dependencies needed and encode them in the WIT package. This will generate a lock file that can be used to fetch the dependencies in the future
+* `deps` — Fetch dependencies for a component. This will read the package containing the world(s) you have defined in the given wit directory (`wit` by default). It will then fetch the dependencies and write them to the `deps` directory along with a lock file. If no lock file exists, it will fetch all dependencies. If a lock file exists, it will fetch any dependencies that are not in the lock file and update the lock file
+* `publish` — Publish a WIT package to a registry. This will automatically infer the package name from the WIT package
+
+
+
+## `wash wit build`
+
+Build a WIT package from a directory. By default, this will fetch all dependencies needed and encode them in the WIT package. This will generate a lock file that can be used to fetch the dependencies in the future
+
+**Usage:** `wash wit build [OPTIONS]`
+
+###### **Options:**
+
+* `-d`, `--wit-dir <DIR>` — The directory containing the WIT files to build
+
+  Default value: `wit`
+* `-f`, `--file <OUTPUT_FILE>` — The name of the file that should be written. This can also be a full path. Defaults to the current directory with the name of the package
+* `--pkg-config <CONFIG>` — The path to the configuration file
+* `--pkg-cache <CACHE>` — The path to the cache directory. Defaults to the system cache directory
+* `-p`, `--config-path <CONFIG_PATH>` — Path to the wasmcloud.toml file or parent folder to use for building
+
+
+
+## `wash wit deps`
+
+Fetch dependencies for a component. This will read the package containing the world(s) you have defined in the given wit directory (`wit` by default). It will then fetch the dependencies and write them to the `deps` directory along with a lock file. If no lock file exists, it will fetch all dependencies. If a lock file exists, it will fetch any dependencies that are not in the lock file and update the lock file
+
+**Usage:** `wash wit deps [OPTIONS]`
+
+###### **Options:**
+
+* `-d`, `--wit-dir <DIR>` — The directory containing the WIT files to fetch dependencies for
+
+  Default value: `wit`
+* `-t`, `--type <OUTPUT_TYPE>` — The desired output type of the dependencies. Valid options are "wit" or "wasm" (wasm is the WIT package binary format)
+* `--pkg-config <CONFIG>` — The path to the configuration file
+* `--pkg-cache <CACHE>` — The path to the cache directory. Defaults to the system cache directory
+* `-p`, `--config-path <CONFIG_PATH>` — Path to the wasmcloud.toml file or parent folder to use for building
+
+
+
+## `wash wit publish`
+
+Publish a WIT package to a registry. This will automatically infer the package name from the WIT package
+
+**Usage:** `wash wit publish [OPTIONS] <FILE>`
+
+###### **Arguments:**
+
+* `<FILE>` — The file to publish
+
+###### **Options:**
+
+* `--wit-registry <REGISTRY>` — The registry domain to use. Overrides configuration file(s)
+* `--pkg-config <CONFIG>` — The path to the configuration file
+* `--pkg-cache <CACHE>` — The path to the cache directory. Defaults to the system cache directory
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>
+

--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -339,10 +339,10 @@ Link names can be set [imperatively with the `wash link put` command](/docs/cli/
       # bar configuration
 ```
 
-Once a link name is defined, in your component or provider's code, you can use [wasmCloud's `wasmcloud:bus` interface](https://github.com/wasmCloud/wasmCloud/blob/main/wit/bus.wit) to make a call to a target by link name. You can include the `wasmcloud:bus` interface in your WIT world by copying it into your `/wit/deps` folder and importing the interface in your top-level world:
+Once a link name is defined, in your component or provider's code, you can use [wasmCloud's `wasmcloud:bus` interface](https://github.com/wasmCloud/wasmCloud/blob/main/wit/bus.wit) to make a call to a target by link name. You can include the `wasmcloud:bus` interface by importing the interface in your top-level world:
 
 ```wit
-world world {
+world component {
   import wasmcloud:bus/lattice@1.0.0;
 }
 ```

--- a/docs/developer/components/build.mdx
+++ b/docs/developer/components/build.mdx
@@ -139,13 +139,11 @@ Without any additional configuration, `wash` can download dependencies from the 
 
 So in most basic cases, all of this dependency fetching and management should be fairly transparent! However, as your usage of Wasm grows, you are likely to use dependencies that are not in the above namespaces (such as internal registries or other remappings). Also, if you plan to publish any custom interfaces, you will need to configure your registry with credentials.
 
-The default configuration file for `wkg` is located inside of the standard configuration directory at `./wasm-pkg/config.toml`. This table shows the default configuration file locations for various operating systems:
+:::warning
+Please note the configuration format is subject to change, including some additional override configurations options within the `wasmcloud.toml` file. Things should be backwards compatible, but be aware that things may change (and will likely be simpler)!
+:::
 
-| Platform | Value                                 | Example                                                       |
-| -------- | ------------------------------------- | ------------------------------------------------------------- |
-| Linux    | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config/wasm-pkg/config.toml                      |
-| macOS    | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support/wasm-pkg/config.toml |
-| Windows  | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming\wasm-pkg\config.toml           |
+The default configuration file for `wash` is located inside of the standard configuration directory at `~/.wash/package_config.toml`. 
 
 Below is an extremely simple configuration showing the basics of a file that can be used to configure `wkg` to download and publish dependencies to/from a private registry. For more complete information on the configuration options, see the [Wasm package tooling documentation](https://github.com/bytecodealliance/wasm-pkg-tools#configuration).
 

--- a/docs/developer/components/build.mdx
+++ b/docs/developer/components/build.mdx
@@ -22,6 +22,8 @@ wash build
 In a Rust project, the wash build command encapsulates a few commands. You can always use the standard Rust toolchain and Bytecode Alliance tools to build your application components. However, the wash build command will automatically use the necessary tools and build your component for you. Under the hood, the wash build command will run the following commands:
 
 ```bash
+# Fetch wit dependencies
+wkg wit fetch
 # Build the Wasm module
 cargo build --release --target wasm32-wasi
 # Create a Wasm component from the Wasm module by using the wasmtime adapter
@@ -36,6 +38,8 @@ wash claims sign ./build/component.wasm --destination ./build/component_s.wasm
 In a TinyGo project, the wash build command encapsulates a few commands. You can always use the standard Go and TinyGo toolchain and Bytecode Alliance tools to build your application components. However, the wash build command will automatically use the necessary tools and build your component for you. Under the hood, the wash build command will run the following commands:
 
 ```bash
+# Fetch wit dependencies
+wkg wit fetch
 # Generate the types and bindings for the Wasm module
 go generate
 # Build the Wasm module
@@ -64,6 +68,8 @@ build_command = "npm run build"
 In our quickstart example, `wash build` runs a few commands for you in order to turn TypeScript code into a WebAssembly component:
 
 ```bash
+# Fetch wit dependencies
+wkg wit fetch
 # You must run `npm install` first
 npm install
 # Transpile TypeScript code to JavaScript
@@ -88,6 +94,8 @@ build_command = "componentize-py -d ./wit -w hello componentize app -o build/htt
 In our quickstart example, `wash build` runs a few commands for you in order to turn Python code into a WebAssembly component:
 
 ```bash
+# Fetch wit dependencies
+wkg wit fetch
 # Componentize Python code into a WebAssembly Component
 componentize-py -d ./wit -w hello componentize app -o build/http_hello_world.wasm
 # Sign the Wasm component with your generated keys, using information in wasmcloud.toml
@@ -117,3 +125,49 @@ Overriding the `build_command` allows you to use an external script or command t
     </TabItem>
 
 </Tabs>
+
+## Interface dependencies and `wash build`
+
+You may have noticed that one of the commands that `wash build` runs for you is the equivalent of `wkg wit fetch`. `wkg` is a CLI tool provided by the ByteCode Alliance as part of the [Wasm package tooling](https://github.com/bytecodealliance/wasm-pkg-tools) project. It is meant to be a standard set of configuration and tooling that can be used across all languages. `wash` is directly integrated into this tooling with some additional helpers to make it automatically aware of `wasmcloud` namespaced interfaces. If you use `wkg`, you will be using the same configuration and lock files that `wash` uses. The tooling works by reading the specified world in your wit files and downloading the appropriate dependencies automatically into the `wit/deps` directory. As such, in most cases you should add `wit/deps` to your `.gitignore` file and commit the generated `wkg.lock` file.
+
+Without any additional configuration, `wash` can download dependencies from the following namespaces (i.e. the `wasi` in `wasi:http@0.2.1`):
+
+- `wasi`
+- `wasmcloud`
+- `wrpc`
+- `ba`
+
+So in most basic cases, all of this dependency fetching and management should be fairly transparent! However, as your usage of Wasm grows, you are likely to use dependencies that are not in the above namespaces (such as internal registries or other remappings). Also, if you plan to publish any custom interfaces, you will need to configure your registry with credentials.
+
+The default configuration file for `wkg` is located inside of the standard configuration directory at `./wasm-pkg/config.toml`. This table shows the default configuration file locations for various operating systems:
+
+| Platform | Value                                 | Example                                                       |
+| -------- | ------------------------------------- | ------------------------------------------------------------- |
+| Linux    | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config/wasm-pkg/config.toml                      |
+| macOS    | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support/wasm-pkg/config.toml |
+| Windows  | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming\wasm-pkg\config.toml           |
+
+Below is an extremely simple configuration showing the basics of a file that can be used to configure `wkg` to download and publish dependencies to/from a private registry. For more complete information on the configuration options, see the [Wasm package tooling documentation](https://github.com/bytecodealliance/wasm-pkg-tools#configuration).
+
+```toml
+[namespace_registries]
+# The namespace maps to a configuration that tells the client where to download dependencies from.
+# If you are running a heavily used and/or large registry, see https://github.com/bytecodealliance/wasm-pkg-tools#well-known-metadata
+# for more information on how to configure a well-known metadata file, which simplifies this configuration section.
+custom = { registry = "custom", metadata = { preferredProtocol = "oci", "oci" = { registry = "ghcr.io", namespacePrefix = "myorg/interfaces/" } } }
+
+# The registry section is used to configure the client to authenticate to the registry. The name
+# "custom" must match the `registry` key in the namespace_registries section.
+[registry."custom".oci]
+auth = { username = "open", password = "sesame" }
+```
+
+With the above configuration, if a package named `custom:regex@0.1.0` is found, it will attempt to download it from `ghcr.io/myorg/interfaces/custom/regex:0.1.0`, using the credentials provided in the `auth` section (if needed). If the registry is public, you can omit the `registry` section at the bottom entirely.
+
+### Migrating from `wit-deps`
+
+Older versions of `wash` required a separate step using a `wit-deps` tool to download dependencies. This is no longer necessary with the newest versions of `wash`. To preserve backwards compatibility, if a `deps.toml` file is found in the `wit` directory of the project, `wash` will not fetch dependencies for you. To migrate to the new deps management, simply remove the `deps.toml` file and run `wash build` again. `wash build` will automatically remove all the old dependencies and download the new ones into your `wit/deps` directory.
+
+:::warning
+If you are using some of the provided wrpc interfaces like `wrpc:blobstore`, you will need to continue using `wit-deps`. This is due to an issue where some of the wrpc interfaces use syntax that is not yet available in the main WIT parser (but will be when WASI 0.3 is released) which causes the dependency resolution to fail.
+:::

--- a/docs/developer/components/configure.mdx
+++ b/docs/developer/components/configure.mdx
@@ -66,25 +66,7 @@ wash start component ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0 he
 
 ## Using Configuration
 
-:::info[Prerequisite]
-To fetch the interface for runtime configuration, you'll need [wit-deps](https://github.com/bytecodealliance/wit-deps) installed.
-:::
-
-Components access configuration at runtime by using the [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) interface. To use this interface, you'll need to add it to your WIT dependencies, and then import the `wasi:config/runtime` interface in your component.
-
-In your `wit/deps.toml`:
-
-```toml
-config = "https://github.com/WebAssembly/wasi-config/archive/c667fe67ffa158925511810775155af582d22928.tar.gz"
-```
-
-Then, fetch your dependencies:
-
-```bash
-wit-deps
-```
-
-Lastly, update your component to import the `wasi:config/runtime` interface inside of your `wit/world.wit` file. This may be named differently depending on your component, but the interface should be imported in the same way.
+Components access configuration at runtime by using the [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) interface. To use this interface, you'll need to import the `wasi:config/runtime` interface inside of your `wit/world.wit` file. This may be named differently depending on your component, but the interface should be imported in the same way.
 
 ```wit
 package wasmcloud:hello;

--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -57,7 +57,6 @@ package example:http-server;
 
 world hello {
   include wasmcloud:component-go/imports@0.1.0;
-
   export wasi:http/incoming-handler@0.2.0;
 }
 ```
@@ -289,6 +288,22 @@ To clean up, stop `wash dev` with CTRL+C.
 
 `wash` simplifies set up for a Go project, but it is not required to build a Go-based component. For users who wish to use or understand the underlying tooling, the steps below replicate the initial set up above without `wash`.
 
+You'll also need to install the `wkg` cli to fetch your component's interface dependencies. Installation instructions can be found [here](https://github.com/bytecodealliance/wasm-pkg-tools#installation).
+
+Once that is installed, run the following command to edit your wasm package tools configuration `wkg` to know the location of `wasmcloud` namespaced interface dependencies:
+
+```shell
+wkg config edit
+```
+
+Replace all content in that file with the following:
+
+```toml
+[namespace_registries]
+wasmcloud = "wasmcloud.com"
+wasi = "wasi.dev"
+```
+
 Create a new Go project:
 
 ```shell
@@ -302,8 +317,7 @@ Now we'll add the Component SDK and `wasilog` packages to our project:
 ```shell
 go get go.wasmcloud.dev/component go.wasmcloud.dev/component/log/wasilog 
 ```
-
-Create a `/wit/` directory and a `world.wit` file:
+Create a `wit/` directory and a file in that directory called `world.wit`:
 
 ```shell
 mkdir wit && touch ./wit/world.wit
@@ -323,6 +337,7 @@ Add the `wasm-tools-go` package to a `tools.go` file in your project:
 ```shell
 touch tools.go
 ```
+
 ```go
 //go:build tools
 
@@ -336,6 +351,12 @@ import (
 Then update your Go module:
 ```shell
 go mod tidy
+```
+
+Then fetch your dependencies:
+
+```shell
+wkg wit fetch
 ```
 
 Finally, we'll write our HTTP server in a new `hello.go` file. Using the Component SDK, this looks like a standard server using the HTTP standard library.

--- a/docs/ecosystem/useful-webassembly-tools/index.mdx
+++ b/docs/ecosystem/useful-webassembly-tools/index.mdx
@@ -35,24 +35,6 @@ npm ci && npm run install-plugin
 
 The [tree-sitter-wit](https://github.com/liamwh/tree-sitter-wit/) Tree-sitter parser maintained by [liamwh](https://github.com/liamwh) can be installed with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter). Installation instructions can be found on either of the two linked repositories.
 
-## WIT dependency management with `wit-deps`
-
-It's important to ensure consistency between the WIT dependencies defined in your `deps.toml` manifest and the actual files in your project. [`wit-deps`](https://github.com/bytecodealliance/wit-deps) is a simple dependency management CLI tool maintained by the Bytecode Alliance that ensures your dependencies are consistently and correctly populated.
-
-You will need [Rust and `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html). Install `wit-deps` by running:
-
-```shell
-cargo install wit-deps-cli
-```
-
-Run `wit-deps` from the root of a wasmCloud project directory (one level above `wit`) to populate the `deps` directory with the definitions specified in `deps.toml` and create a `deps.lock` file:
-
-```shell
-wit-deps
-```
-
-For more detail on `wit-deps`, see the [documentation in the project README](https://github.com/bytecodealliance/wit-deps).
-
 ## WebAssembly artifact manipulation with `wasm-tools`
 
 Sometimes you might want to observe or manipulate a component independently of wasmCloud&mdash;perhaps to view the component's WIT interface, compose Wasm components into one, or even for more niche jobs like converting a WebAssembly module to a component. The [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools) CLI tool is a utility belt with a long list of options.

--- a/docs/ecosystem/wash/plugin-developer.md
+++ b/docs/ecosystem/wash/plugin-developer.md
@@ -25,7 +25,8 @@ that demonstrates how to use all of the available functionality.
 
 The Plugin API is defined via WIT and is a small wrapper around the standard `wasi:cli/run`
 interface. The WIT is defined in the `wash-lib` crate and can be found
-[here](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-lib/wit).
+[here](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-lib/wit). To use this wit, just
+add `wasmcloud:wash/subcommand@0.1.0;` to your component's `world.wit` file.
 
 A plugin can be any component that exports `wasi:cli/run` and the wasmCloud-defined interface called
 `wasmcloud:wash/subcommand`. This is a very small interface that expects a single function called

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -37,32 +37,35 @@ See the [`build` docs](https://github.com/wasmCloud/wasmCloud/tree/main/crates/w
 | name          | string |                                   | Name of the project                                                                    |
 | version       | string |                                   | Semantic version of the project                                                        |
 | path          | string | `{pwd}`                           | Path to the project directory to determine where built and signed artifacts are output |
+| wit           | string | `./wit`                           | Path to the directory where the WIT world and dependencies can be found                |
+| build         | string | `./build`                         | Path to the directory where the built artifacts should be written                      |
 | language      | enum   | [rust, tinygo]                    | Language that component or provider is written in                                      |
 | type          | enum   | [component, provider, interface ] | Type of wasmcloud artifact that is being generated                                     |
 | wasm_bin_name | string | "name" setting                    | Expected name of the wasm module binary that will be generated                         |
+| overrides     | object |                                   | Overrides for wit dependencies (often used for local dependencies)                     |
 
-### Language Config - [tinygo]
+### Language Config - `[tinygo]`
 
-| Setting             | Type    | Default        | Description                                                   |
-| ------------------- | ------- | -------------- | ------------------------------------------------------------- |
-| tinygo_path         | string  | `which tinygo` | The path to the tinygo binary                                 |
+| Setting             | Type    | Default        | Description                                                    |
+| ------------------- | ------- | -------------- | -------------------------------------------------------------- |
+| tinygo_path         | string  | `which tinygo` | The path to the tinygo binary                                  |
 | disable_go_generate | boolean | false          | Whether to disable the 'go generate' step in the build process |
 
-### Language Config - [rust]
+### Language Config - `[rust]`
 
 | Setting     | Type   | Default       | Description                             |
 | ----------- | ------ | ------------- | --------------------------------------- |
 | cargo_path  | string | `which cargo` | The path to the cargo binary            |
 | target_path | string | `./target`    | Path to cargo/rust's `target` directory |
 
-### Registry Config - [registry]
+### Registry Config - `[registry]`
 
 | Setting     | Type   | Default | Description                                                                                     |
 | ----------- | ------ | ------- | ----------------------------------------------------------------------------------------------- |
 | url         | string | N/A     | URL for the container registry to use when pushing images (i.e. `wash push`)                    |
 | credentials | string |         | Path to a credentials file to use when pushing to container registries (ex. specified by `url`) |
 
-### Type Config - [component]
+### Type Config - `[component]`
 
 | Setting        | Type    | Default                                   | Description                                                                                                                                                                                                                                                                                                                   |
 | -------------- | ------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,16 +79,34 @@ See the [`build` docs](https://github.com/wasmCloud/wasmCloud/tree/main/crates/w
 | build_command  | string  | Language specific command                 | Optional command to run instead of inferring the default language toolchain build command. Supports commands in the format of `command ...arg`. `wash` expects that the build command will result in an artifact under the project `build` folder named either `{wasm_bin_name}.wasm` if supplied or `{name}.wasm` otherwise. |
 | destination    | string  | /path/to/project/build/{filename}\_s.wasm | File path to output the destination WebAssembly artifact after building and signing.                                                                                                                                                                                                                                          |
 
-### Type Config - [provider]
+### Type Config - `[provider]`
 
 | Setting       | Type   | Default | Description                       |
 | ------------- | ------ | ------- | --------------------------------- |
 | capability_id | string |         | The capability ID of the provider |
 | vendor        | string |         | The vendor name of the provider   |
 
-### Type Config - [interface]
+### Type Config - `[interface]`
 
 | Setting        | Type   | Default  | Description               |
 | -------------- | ------ | -------- | ------------------------- |
 | html_target    | string | `./html` | Directory to output HTML  |
 | codegen_config | string | `.`      | Path to codegen.toml file |
+
+### Overrides config - `[overrides]`
+
+Overrides are key-value pairs that can be used to override locations of wit dependencies. The key name should match the package reference without a version (e.g. `wasi:http`).
+
+For example, if you have a dependency called `my:local-dep@0.1.0` that is located in another directory, you can tell `wash` how to find it with the following overrides section:
+
+```toml
+[overrides]
+"my:local-dep" = { path = "../path/to/my/local/dep" }
+```
+
+It can also be used to override a version requirement for a package, but this is a highly advanced use case and should be used with caution.
+
+```toml
+[overrides]
+"my:local-dep" = { version = "^0.1.0" }
+```


### PR DESCRIPTION
This attempts to find any place that references the old `wit-deps` method and remove that information. It also adds a new subsection to the developer docs section on building to explain the automatic dependency fetching