### PR TITLE
fix(rust): use `wasm32-wasip1` target

### DIFF
--- a/docs/tour/adding-capabilities.mdx
+++ b/docs/tour/adding-capabilities.mdx
@@ -16,10 +16,10 @@ Going from "Hello World" to a full-fledged application is simply a matter of ide
   <TabItem value="rust" label="Rust">
 
 :::info[Rust & WebAssembly]
-To perform the steps in this guide, you'll need to have a [Rust toolchain](https://www.rust-lang.org/tools/install) installed locally and the wasm32 target installed:
+To perform the steps in this guide, you'll need to have a [Rust toolchain](https://www.rust-lang.org/tools/install) installed locally and the wasm32-wasip1 target installed:
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 :::

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -91,10 +91,10 @@ This component is a simple Rust project with a few extra goodies included for wa
 3. `wadm.yaml`: A declarative manifest for running the full application
 
 :::info[Rust dependencies]
-You don't need any Rust dependencies installed to run this example, but if you want to build it yourself you'll need to install the [Rust toolchain](https://www.rust-lang.org/tools/install) and the `wasm32-wasi` target.
+You don't need any Rust dependencies installed to run this example, but if you want to build it yourself you'll need to install the [Rust toolchain](https://www.rust-lang.org/tools/install) and the `wasm32-wasip1` target.
 
 ```bash
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 :::


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

`wasm32-wasi` is deprecated and should not be used, it appears that latest `wash` does not support it either and requires `wasm32-wasip1`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
