### PR TITLE
chore: update to CLI doc contrib guide

### DIFF
--- a/docs/contributing/documentation.mdx
+++ b/docs/contributing/documentation.mdx
@@ -37,7 +37,7 @@ npm run serve
 
 ## Generating CLI documentation
 
-The [command-line documentation](/docs/cli/) at [`docs/cli/index.mdx`](https://github.com/wasmCloud/wasmcloud.com/tree/main/docs/cli) is generated using the `--help-markdown` argument with `wash`. An easy way to run the command is `wash app list --help-markdown > help.md`. Once you've generated CLI documentation, copy the contents to the `index.mdx` file linked above. Note that you will need to place some angle brackets within backticks (&#96;) for the page to render correctly.
+The [command-line documentation](/docs/cli/) at [`docs/cli/index.mdx`](https://github.com/wasmCloud/wasmcloud.com/tree/main/docs/cli) is generated using the `--help-markdown` argument with `wash`. An easy way to run the command is `wash app list --help-markdown > help.md`. Once you've generated CLI documentation, copy the contents to the `index.mdx` file linked above.
 
 ## Making a pull request
 


### PR DESCRIPTION
Removing an out-of-date line in the documentation contribution guidelines (no longer necessary to worry about incompatible backticks when generating CLI docs).