### PR TITLE
docs: add Recovering from Failure page to Operator Guide

### DIFF
--- a/docs/deployment/recovery/_category_.json
+++ b/docs/deployment/recovery/_category_.json
@@ -1,0 +1,9 @@
+{
+    "label": "Recovering from Failure",
+    "position": 16,
+    "link": {
+      "type": "doc",
+      "id": "deployment/recovery/index"
+    }
+  }
+  

--- a/docs/deployment/recovery/index.mdx
+++ b/docs/deployment/recovery/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "Recovering from failure"
+---
+
+If you run into an error when operating wasmCloud, the first step is to diagnose the problem. Typically, this will mean checking three sources of information:
+
+* Logs for the [wasmCloud host](/docs/concepts/hosts.mdx) process
+* Logs for the [wasmCloud Application Deployment Manager (`wadm`)](/docs/ecosystem/wadm/index.md) process
+* Activity on [NATS](/docs/ecosystem/nats/index.mdx)
+
+## Troubleshooting on Kubernetes
+
+When deploying [wasmCloud on Kubernetes](/docs/deployment/k8s/index.mdx), you can access logs for wasmCloud hosts and `wadm` with `kubectl`. 
+
+To check logs for `wadm`:
+
+```shell
+kubectl logs -f -l app.kubernetes.io/instance=wadm -c wadm
+```
+
+To check logs for a wasmCloud host:
+
+```shell
+kubectl logs -f -l app.kubernetes.io/instance=my-wasmcloud-cluster -c wasmcloud-host
+```
+
+## Observing NATS
+
+You can observe [NATS](/docs/ecosystem/nats/) activity using the NATS CLI. Installation instructions for the CLI are available on the [NATS CLI GitHub repo](https://github.com/nats-io/natscli). 
+
+To list all streams on the NATS network:
+
+```shell
+nats stream list
+```
+
+The listed streams for a wasmCloud lattice will include:
+
+* `wadm_commands`
+* `wadm_events`
+* `wadm_mirror`
+* `wadm_notify`
+* `wadm_status`
+
+To list all key-value buckets on the NATS instance:
+
+```shell
+nats kv list
+```
+
+The listed key-value buckets for wasmCloud will include:
+
+* `CONFIGDATA_default`
+* `wadm_manifests`
+* `wadm_state`
+* `LATTICEDATA_default`


### PR DESCRIPTION
Adds (the start of!) a "Recovering from failure" page to the Operator Guide.