### PR TITLE
chore: pin tinygo example to git branch

### DIFF
--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -189,9 +189,9 @@ Now that we've installed `wash` and our language toolchain, it's time to create 
 In your terminal, run:
 
 ```shell
-wash new component hello --template-name hello-world-tinygo
-
+wash new component hello --git wasmcloud/wasmcloud --subfolder examples/golang/components/http-hello-world --branch v1.4.0
 ```
+
 After a moment, `wash` will create a new directory called `hello` with all of the required project files for building a component from your chosen language. 
 
 Navigate to the `hello` project directory:


### PR DESCRIPTION
## Feature or Problem
In the interest of not breaking the example for a small time after https://github.com/wasmCloud/wasmCloud/pull/3402 merges, this temporary patch will ensure that the current quickstart still works between wash releases.

Will revert this in #659 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
