### PR TITLE
docs(installation): remove snap package manager from the installation…

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -500,13 +500,6 @@ main
 </details>
 
   </TabItem>
-  <TabItem value="snap" label="Snap">
-
-```bash
-snap install wash --devmode --edge
-```
-
-  </TabItem>
   <TabItem value="mac" label="MacOS">
 
 ```bash


### PR DESCRIPTION
… sources

## Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Listing snap as a viable option to install wash should be not listed after https://github.com/wasmCloud/wasmCloud/pull/3438 is merged.

To avoid inconsistency we should delete the option after `>=0.82.x`. As far as I know there are no patches/improvements after `0.82.x`, but correct me if I am wrong.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

https://github.com/wasmCloud/wasmCloud/issues/2895
and 
https://github.com/wasmCloud/wasmCloud/pull/3438

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
