### PR TITLE
chore: tidy Go prereqs and guide

### DIFF
--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -283,7 +283,7 @@ PASS
 ok  	github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world	0.299s
 ```
 
-To clean up, stop `wash dev` with CTRL+C:
+To clean up, stop `wash dev` with CTRL+C.
 
 ### Reference: Set up without `wash`
 

--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -34,9 +34,8 @@ In this walkthrough, we will create an HTTP server from scratch using the [Go co
 
 * [Go](https://go.dev/doc/install) 1.23.0+
 * [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+
-* [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.32.1+ for building and deploying components
-  {/* TODO: Remove after https://github.com/wasmCloud/wasmCloud/pull/3270 is released (est. wash-cli@v0.36.0) */}
-* [`wasm-pkg-tools`](https://github.com/bytecodealliance/wasm-pkg-tools) 0.7.4+ for WIT dependency management
+* [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.36.0+ for building and deploying components
+* [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) for Go binding generation
 
 ### Step 1: Set up with `wash`
 
@@ -61,12 +60,6 @@ world hello {
 
   export wasi:http/incoming-handler@0.2.0;
 }
-```
-
-Use the `wkg` cli tool to download the wit dependencies:
-
-```shell
-wkg wit fetch
 ```
 
 Finally, we'll delete the contents of `hello.go` and write our HTTP server, which will return a simple "hello world."
@@ -175,15 +168,12 @@ world root {
 
 Now we can deploy on wasmCloud and try the component manually.
 
-* Start wasmCloud locally (and in detached mode) with `wash up -d`
-* Deploy with `wash app deploy wadm.yaml`. 
+* Start a developer loop with `wash dev`
 
-The `wadm.yaml` deployment manifest configures the application to run on localhost:8080.
-
-Now we can `curl` the application and you should see the "hello world" response:
+In another tab, we can `curl` the application and you should see the "hello world" response:
 
 ```console
-$ curl localhost:8080
+$ curl localhost:8000
 hello world!
 ```
 
@@ -293,14 +283,7 @@ PASS
 ok  	github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world	0.299s
 ```
 
-To clean up, delete the application from your local wasmCloud and stop the host:
-
-```shell
-wash app delete tinygo-hello-world
-```
-```shell
-wash down
-```
+To clean up, stop `wash dev` with CTRL+C:
 
 ### Reference: Set up without `wash`
 

--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -34,7 +34,7 @@ In this walkthrough, we will create an HTTP server from scratch using the [Go co
 
 * [Go](https://go.dev/doc/install) 1.23.0+
 * [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+
-* [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.36.0+ for building and deploying components
+* [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.36.1+ for building and deploying components
 * [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) for Go binding generation
 
 ### Step 1: Set up with `wash`

--- a/docs/developer/languages/go/providers.mdx
+++ b/docs/developer/languages/go/providers.mdx
@@ -22,7 +22,7 @@ To build a capability provider in Go, you'll need...
 
 * [Go](https://go.dev/doc/install) 1.23.0+
 * [The Rust toolchain](https://www.rust-lang.org/tools/install)
-* [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) installed with `cargo install wit-bindgen-cli`
+* [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) for Go binding generation
 * [`wrpc`](https://github.com/wrpc/wrpc/) 0.9+ installed with `cargo install wrpc`
 * [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.32.1+ for building and deploying components
 

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -114,7 +114,7 @@ On **macOS or Linux**, you can use the official install script to download `rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Once you've installed Rust on macOS or Linux, use `rustup` to add the `wasm32-wasip1` target:
+Once you've installed the Rust toolchain, use `rustup` to add the `wasm32-wasip1` target:
 
 ```shell
 rustup target add wasm32-wasip1

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -132,7 +132,7 @@ rustup toolchain install stable-msvc
 
 Note: On Windows, you will also need Visual Studio's C++ tools.
 
-Once you've installed Rust on Windows, use `rustup` to add the `wasm32-wasip1` target:
+Once you've installed Rust, use `rustup` to add the `wasm32-wasip1` target:
 
 ```shell
 rustup target add wasm32-wasip1

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -96,7 +96,7 @@ scoop install tinygo
 scoop install binaryen
 ```
 
-You will also need to [download the binary for the latest version of `wasm-tools` for your architecture](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
+You will also need to [install the latest version of `wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
 
   </TabItem>
   <TabItem value="rust" label="Rust" default>

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -68,7 +68,7 @@ Requirements:
 
 - [Go](https://go.dev/doc/install) 1.23.0+
 - [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+:
-- [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen)
+- [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation)
 
 On macOS or Linux, you can use [Homebrew](https://brew.sh/) to install the Go toolchain:
 
@@ -96,7 +96,7 @@ scoop install tinygo
 scoop install binaryen
 ```
 
-You will also need to [download the binary for the latest version of `wit-bindgen` for your architecture](https://github.com/bytecodealliance/wit-bindgen/releases) and add it to your PATH.
+You will also need to [download the binary for the latest version of `wasm-tools` for your architecture](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
 
   </TabItem>
   <TabItem value="rust" label="Rust" default>
@@ -114,6 +114,12 @@ On **macOS or Linux**, you can use the official install script to download `rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+Once you've installed Rust on macOS or Linux, use `rustup` to add the `wasm32-wasip1` target:
+
+```shell
+rustup target add wasm32-wasip1
+```
+
 On **Windows**, you can use [Chocolatey](https://chocolatey.org/) to install `rustup`, and then use `rustup` to install the Windows toolchain:
 
 ```shell
@@ -126,7 +132,7 @@ rustup toolchain install stable-msvc
 
 Note: On Windows, you will also need Visual Studio's C++ tools.
 
-**Once you've installed Rust on macOS, Linux, or Windows**, use `rustup` to add the `wasm32-wasip1` target:
+Once you've installed Rust on Windows, use `rustup` to add the `wasm32-wasip1` target:
 
 ```shell
 rustup target add wasm32-wasip1


### PR DESCRIPTION
A few small Go-related updates:

* Update prereqs across pages to consistently specify wasm-tools
* Remove wkg step from Go language guide now that wash 0.36+ is out
* Use wash dev instead of manual deployment in Go language guide
