### PR TITLE
chore: specifies version and cargo install option for wasm-tools

### DIFF
--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -68,7 +68,7 @@ Requirements:
 
 - [Go](https://go.dev/doc/install) 1.23.0+
 - [TinyGo](https://tinygo.org/getting-started/install/) =0.33.0:
-- [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation)
+- [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) 1.219+
 
 On macOS or Linux, you can use [Homebrew](https://brew.sh/) to install the Go toolchain:
 
@@ -82,7 +82,13 @@ brew extract --version 0.33.0 tinygo-org/tools/tinygo tinygo/tap
 brew install tinygo/tap/tinygo@0.33.0
 ```
 
-You will also need to [download the binary for the latest version of `wasm-tools` for your architecture](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
+You will also need the `wasm-tools` utility. If you have the [Rust toolchain](https://www.rust-lang.org/tools/install), you can use `cargo` to install `wasm-tools`:
+
+```shell
+cargo install wasm-tools
+```
+
+Otherwise, [download the binary for the latest version of `wasm-tools` for your architecture](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
 
 On Windows, you can use [Scoop](https://scoop.sh/) to install the Go toolchain (as well as the [`binaryen`](https://github.com/WebAssembly/binaryen) tool to compile components on Windows):
 
@@ -98,7 +104,13 @@ scoop install tinygo@0.33.0
 scoop install binaryen
 ```
 
-You will also need to [install the latest version of `wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
+You will also need the `wasm-tools` utility. If you have the [Rust toolchain](https://www.rust-lang.org/tools/install), you can use `cargo` to install `wasm-tools`:
+
+```shell
+cargo install wasm-tools
+```
+
+Otherwise, [download the binary for the latest version of `wasm-tools` for your architecture](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
 
   </TabItem>
   <TabItem value="rust" label="Rust" default>


### PR DESCRIPTION
Specifies minimum version and cargo install option for wasm-tools dependency for Go in quickstart.