### PR TITLE
feat(quickstart): override Redis dependency instead of yaml edit

### DIFF
--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -243,7 +243,7 @@ A provider only ever dispatches messages to&mdash;or receives messages from&mdas
 
 The wasmCloud Quickstart (running through the "Adding capabilities" section) provides a great example of a component using two different providers. The component you build in the tutorial exports on the **wasi-http** interface (linking with the `http-server` provider) and imports on the **wasi-keyvalue** interface (linking with the `kvredis` provider).
 
-Here's the manifest for the [Extend and Deploy](/docs/tour/extend-and-deploy.mdx) step of the [Quickstart](/docs/tour/hello-world.mdx) example:
+Here's the manifest for the [Customize and Extend](/docs/tour/customize-and-extend/) step of the [Quickstart](/docs/tour/hello-world.mdx) example:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1

--- a/docs/ecosystem/wadm/model.md
+++ b/docs/ecosystem/wadm/model.md
@@ -218,7 +218,7 @@ The values in these fields are a simple key-value map that will be passed as lin
 
 ## Putting it all together
 
-So far we've seen bits and pieces of the application specification YAML. Here's the complete manifest for the [Extend and Deploy](/docs/tour/extend-and-deploy.mdx) step of the [Quickstart](/docs/tour/hello-world.mdx) example:
+So far we've seen bits and pieces of the application specification YAML. Here's the complete manifest for the [Customize and Extend](/docs/tour/customize-and-extend/) step of the [Quickstart](/docs/tour/hello-world.mdx) example:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -196,7 +196,7 @@ It can also be used to override a version requirement for a package, but this is
 "my:local-dep" = { version = "^0.1.0" }
 ```
 
-### Dev Overrides Config (Imports) - `[[dev.overrides.imports]]`
+### Dev Overrides Config (Imports and Exports) - `[[dev.overrides.imports]]` or `[[dev.overrides.exports]]`
 
 Dev overrides enable users to override the `wash dev` process defaults when satisfying a capability requirement. For example, `wash dev` automatically satisfies a key-value store requirement with the NATS-KV provider, but a dev override could enable a user to use the Redis key-value provider in a dev loop.
 
@@ -207,3 +207,5 @@ Dev overrides can be useful for specifying third-party providers as well as prov
 | interface_spec | string | Interface specification (e.g., `"wasi:keyvalue@0.2.0-draft"`)           |
 | image_ref      | string | OCI image reference (e.g., `"ghcr.io/wasmcloud/keyvalue-redis:0.28.2"`) |
 | config         | object | Configuration (e.g., `{ values = { url = "redis://127.0.0.1:6379" } }`) |
+| secrets        | object | Secrets that should be provided to the entity                           |
+| link_name      | string | Link name that should be used to reference the component. This is only required when there are *multiple* conflicting overrides (i.e. there is no "default") |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -195,3 +195,15 @@ It can also be used to override a version requirement for a package, but this is
 [overrides]
 "my:local-dep" = { version = "^0.1.0" }
 ```
+
+### Dev Overrides Config (Imports) - `[[dev.overrides.imports]]`
+
+Dev overrides enable users to override the `wash dev` process defaults when satisfying a capability requirement. For example, `wash dev` automatically satisfies a key-value store requirement with the NATS-KV provider, but a dev override could enable a user to use the Redis key-value provider in a dev loop.
+
+Dev overrides can be useful for specifying third-party providers as well as providers for custom interfaces that are not well-known to the `wash dev` process.
+
+| Setting        | Type   | Description                                                             |
+| -------------- | ------ | ----------------------------------------------------------------------- |
+| interface_spec | string | Interface specification (e.g., `"wasi:keyvalue@0.2.0-draft"`)           |
+| image_ref      | string | OCI image reference (e.g., `"ghcr.io/wasmcloud/keyvalue-redis:0.28.2"`) |
+| config         | object | Configuration (e.g., `{ values = { url = "redis://127.0.0.1:6379" } }`) |

--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -85,7 +85,7 @@ docker run -d --name redis -p 6379:6379 redis
 On the [wasmCloud GitHub Packages page](https://github.com/orgs/wasmCloud/packages?repo_name=wasmCloud), we can find a [`keyvalue-redis` image](https://github.com/wasmCloud/wasmCloud/pkgs/container/keyvalue-redis) (also linked in the Capability Catalog) that enables us to deploy the provider:
 
 ```text
-ghcr.io/wasmcloud/keyvalue-redis:0.28.1
+ghcr.io/wasmcloud/keyvalue-redis:0.28.2
 ```
 
 :::note[What are those images?]
@@ -94,89 +94,34 @@ The wasmCloud ecosystem uses the [OCI image specification](https://github.com/op
 
 ### Deploying the application with a key-value provider
 
-First, let's start a local wasmCloud environment in "detached" mode so we can keep working in our terminal:
+We can still use `wash dev`, we'll just need to override the `wasi:keyvalue` capability dependency with the Redis provider. Open up the `wasmcloud.toml` file and add the following lines to the end:
 
-```shell
-wash up -d
+```toml
+name = "http-hello-world"
+version = "0.1.0"
+language = "<your_language>"
+type = "component"
+
+[component]
+wasm_target = "wasm32-wasip2"
+
+[[dev.overrides.imports]] # [!code ++:4]
+interface_spec = "wasi:keyvalue@0.2.0-draft"
+image_ref = "ghcr.io/wasmcloud/keyvalue-redis:0.28.2"
+config = { values = { url = "redis://127.0.0.1:6379" } }
 ```
 
-Instead of the default NATS `keyvalue` provider used by `wash dev`, we want to use the Redis provider:
+When `wash dev` finds your component's dependency on a `keyvalue` capability, it will instead deploy the Redis provider instead of the NATS provider.
 
 ![manual deploy diagram](../images/quickstart-diagram-2.png)
 
-To deploy a wasmCloud application manually, we use an [**application manifest**](/docs/ecosystem/wadm/model) written in YAML, much like a Kubernetes manifest.
-
-This `.yaml` file defines the relationships between the components and providers that make up our application, along with other important configuration details. It is conventionally named `wadm.yaml` after the [**wasmCloud Application Deployment Manager**](/docs/ecosystem/wadm/index.md) that handles scheduling.
-
-We can modify our `wadm.yaml` to include the Redis provider and match the diagram above.
-
-Open `wadm.yaml` in your code editor and make the changes below.
-
-```yaml
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: hello-world # [!code ++:3]
-  annotations:
-    description: 'HTTP hello world demo'
-spec:
-  components:
-    - name: http-component
-      type: component
-      properties:
-        # Your manifest will point to the path of the built component; you can also
-        # start published components from OCI registries
-        image: file://./build/http_hello_world_s.wasm
-      traits:
-        - type: spreadscaler
-          properties:
-            instances: 1
-        # The new key-value link configuration # [!code ++:11]
-        - type: link
-          properties:
-            target: kvredis
-            namespace: wasi
-            package: keyvalue
-            interfaces: [atomics, store]
-            target_config:
-              - name: redis-url
-                properties:
-                  url: redis://127.0.0.1:6379
-    # The new capability provider # [!code ++:5]
-    - name: kvredis
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
-    - name: httpserver
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/http-server:0.25.0
-      traits:
-        - type: link
-          properties:
-            target: http-component
-            namespace: wasi
-            package: http
-            interfaces: [incoming-handler]
-            source_config:
-              - name: default-http
-                properties:
-                  address: 127.0.0.1:8000
-```
-
-Once you save `wadm.yaml`, we can deploy from the project directory:
+Once you save `wasmcloud.toml`, we can start our developer loop up again. We'll take a look at the actual change this made to how `wash dev` generated your application later in the tutorial, so we can also output that application manifest to the current directory for later inspection.
 
 ```shell
-wash app deploy wadm.yaml
+wash dev --manifest-output-dir .
 ```
 
-Check the status of the app:
-
-```shell
-wash app list
-```
-
-Once the application status is `Deployed`, we can `curl` the application like before:
+Once your application is `Deployed`, we can `curl` the application like before:
 
 ```shell
 curl 'localhost:8000?name=Bob'
@@ -204,17 +149,77 @@ Hello x1, Alice!
 
 Note that our increments are starting over again&mdash;after all, we swapped out the dev key-value store for a totally different one!
 
-When you're done with the application, delete it from the wasmCloud environment:
+When you're done with development, you can stop `wash dev` with CTRL+C..
 
-```shell
-wash app delete hello-world
+## The Application Manifest
+
+In addition to the `wasmcloud.toml` file that contains information about how to build your application, `wash dev` generates an **application manifest** that describes how to deploy your application. This manifest is a YAML file that can be used to deploy your application to any wasmCloud host.
+
+Let's take a look at the application manifest that `wash dev` wrote out, which will be a filename like `dev-<session-id>-http-hello-world.yaml`:
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: dev-smdy8c-http-hello-world
+  annotations:
+    wasmcloud.dev/session-id: sMdY8c
+  labels:
+    wasmcloud.dev/generated-by: wash-dev-0.36.1
+spec:
+  components:
+    # Your Wasm component
+    - name: sMdY8c-http-hello-world
+      type: component
+      properties:
+        image: file:///Users/wasmcloud/path/to/build/http_hello_world_s.wasm
+        id: sMdY8c-http-hello-world
+      traits:
+        # Can handle 100 concurrent requests
+        - type: spreadscaler
+          properties:
+            instances: 100
+        # Link all `wasi:keyvalue` operations to the Redis provider
+        - type: link
+          properties:
+            namespace: wasi
+            package: keyvalue
+            interfaces:
+              - store
+              - atomics
+            target:
+              name: sMdY8c-dep-custom-wasi-keyvalue-atomics/store
+    # Your overridden key-value provider, Redis
+    - name: sMdY8c-dep-custom-wasi-keyvalue-atomics/store
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
+        config:
+          - name: custom-wasi-keyvalue-default
+            properties:
+              url: redis://127.0.0.1:6379
+      traits: []
+    - name: sMdY8c-dep-http-server
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.23.2
+      traits:
+        - type: link
+          properties:
+            namespace: wasi
+            package: http
+            interfaces:
+              - incoming-handler
+            source:
+              config:
+                - name: wasi-http-config
+                  properties:
+                    address: 127.0.0.1:8000
+            target:
+              name: sMdY8c-http-hello-world
 ```
 
-Shut down the environment:
-
-```shell
-wash down
-```
+{/* TODO: More detail */}
 
 Stop your Redis server:
 
@@ -240,22 +245,14 @@ docker stop redis
 
 ## Log files
 
-If you encounter any problems, wasmCloud log files may contain useful error messages, and it's good to know how to find them. The tabs below, organized by how you started the wasmCloud environment, show you where to find logs:
+If you encounter any problems, wasmCloud log files may contain useful error messages, and it's good to know how to find them. `wash dev` will create a unique log file for each session and will output the location of that log in the startup text:
 
-<Tabs groupId="env" queryString >
-  <TabItem value="local" label="Local" default>
-
-By default, logs from `wash up` are automatically output to your terminal. If you ran the command
-with the `--detached` flag, logs can be found in `~/.wash/downloads/wasmcloud.log`
-
-  </TabItem>
-  <TabItem value="docker" label="Docker">
-
-Logs from hosts running in Docker, if started with our docker compose, can be found by running
-`docker logs wasmcloud`.
-
-  </TabItem>
-</Tabs>
+```plaintext
+...
+🔧 Successfully started wasmCloud instance
+✅ Successfully started host, logs writing to /Users/wasmcloud/.wash/dev/<session_id>/wasmcloud.log
+...
+```
 
 ## Next steps
 

--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -115,7 +115,7 @@ When `wash dev` finds your component's dependency on a `keyvalue` capability, it
 
 ![manual deploy diagram](../images/quickstart-diagram-2.png)
 
-Once you save `wasmcloud.toml`, we can start our developer loop up again. We'll take a look at the actual change this made to how `wash dev` generated your application later in the tutorial, so we can also output that application manifest to the current directory for later inspection.
+After saving `wasmcloud.toml`, we'll start our developer loop again. This time, we'll use the `--manifest-output-dir` flag to generate an application manifest in the current directory. (We'll take a look at that file later in the tutorial.)
 
 ```shell
 wash dev --manifest-output-dir .
@@ -151,7 +151,7 @@ Note that our increments are starting over again&mdash;after all, we swapped out
 
 When you're done with development, you can stop `wash dev` with CTRL+C..
 
-## The Application Manifest
+## The application manifest
 
 In addition to the `wasmcloud.toml` file that contains information about how to build your application, `wash dev` generates an **application manifest** that describes how to deploy your application. This manifest is a YAML file that can be used to deploy your application to any wasmCloud host.
 
@@ -241,7 +241,6 @@ docker stop redis
 
   </TabItem>
 </Tabs>
-
 
 ## Log files
 

--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Extend and Deploy'
+title: 'Customize and Extend'
 sidebar_position: 2.5
+slug: customize-and-extend
 ---
 
 import Tabs from '@theme/Tabs';
@@ -12,7 +13,6 @@ Now we'll learn how to:
 
 - Explore capabilities available for wasmCloud applications
 - Extend our application by plugging in capability requirements
-- Deploy an application in a local wasmCloud environment
 
 :::info[Prerequisites]
 This tutorial assumes you're following directly from the previous steps. Make sure to complete [**Quickstart**](/docs/tour/hello-world.mdx) and [**Add Features**](/docs/tour/add-features.mdx) first.
@@ -115,10 +115,10 @@ When `wash dev` finds your component's dependency on a `keyvalue` capability, it
 
 ![manual deploy diagram](../images/quickstart-diagram-2.png)
 
-After saving `wasmcloud.toml`, we'll start our developer loop again. This time, we'll use the `--manifest-output-dir` flag to generate an application manifest in the current directory. (We'll take a look at that file later in the tutorial.)
+After saving `wasmcloud.toml`, we'll start our developer loop again.
 
 ```shell
-wash dev --manifest-output-dir .
+wash dev
 ```
 
 Once your application is `Deployed`, we can `curl` the application like before:
@@ -149,77 +149,7 @@ Hello x1, Alice!
 
 Note that our increments are starting over again&mdash;after all, we swapped out the dev key-value store for a totally different one!
 
-When you're done with development, you can stop `wash dev` with CTRL+C..
-
-## The application manifest
-
-In addition to the `wasmcloud.toml` file that contains information about how to build your application, `wash dev` generates an **application manifest** that describes how to deploy your application. This manifest is a YAML file that can be used to deploy your application to any wasmCloud host.
-
-Let's take a look at the application manifest that `wash dev` wrote out, which will be a filename like `dev-<session-id>-http-hello-world.yaml`:
-
-```yaml
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: dev-smdy8c-http-hello-world
-  annotations:
-    wasmcloud.dev/session-id: sMdY8c
-  labels:
-    wasmcloud.dev/generated-by: wash-dev-0.36.1
-spec:
-  components:
-    # Your Wasm component
-    - name: sMdY8c-http-hello-world
-      type: component
-      properties:
-        image: file:///Users/wasmcloud/path/to/build/http_hello_world_s.wasm
-        id: sMdY8c-http-hello-world
-      traits:
-        # Can handle 100 concurrent requests
-        - type: spreadscaler
-          properties:
-            instances: 100
-        # Link all `wasi:keyvalue` operations to the Redis provider
-        - type: link
-          properties:
-            namespace: wasi
-            package: keyvalue
-            interfaces:
-              - store
-              - atomics
-            target:
-              name: sMdY8c-dep-custom-wasi-keyvalue-atomics/store
-    # Your overridden key-value provider, Redis
-    - name: sMdY8c-dep-custom-wasi-keyvalue-atomics/store
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
-        config:
-          - name: custom-wasi-keyvalue-default
-            properties:
-              url: redis://127.0.0.1:6379
-      traits: []
-    - name: sMdY8c-dep-http-server
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/http-server:0.23.2
-      traits:
-        - type: link
-          properties:
-            namespace: wasi
-            package: http
-            interfaces:
-              - incoming-handler
-            source:
-              config:
-                - name: wasi-http-config
-                  properties:
-                    address: 127.0.0.1:8000
-            target:
-              name: sMdY8c-http-hello-world
-```
-
-{/* TODO: More detail */}
+When you're done with development, you can stop `wash dev` with CTRL+C.
 
 Stop your Redis server:
 

--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -57,9 +57,7 @@ As far as the key-value capability is concerned, the application looks like this
 
 ![wash dev diagram](../images/quickstart-diagram-1.png)
 
-If `wash dev` is still running from the previous tutorial, make sure to stop it with CTRL+C.
-
-For our manual deployment, let's **swap out a different key-value storage provider**. We'll use the [Redis provider](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-keyvalue-redis), which will only require us to have `redis-server` or Docker installed. The Redis provider will mediate a connection to the Redis server, which is running external to wasmCloud.
+Now we'll **swap out a different key-value storage provider**. We'll use the [Redis provider](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-keyvalue-redis), which will only require us to have `redis-server` or Docker installed. The Redis provider will mediate a connection to the Redis server, which is running external to wasmCloud.
 
 <Tabs groupId="env" queryString>
   <TabItem value="local" label="Local Redis Server" default>
@@ -94,7 +92,7 @@ The wasmCloud ecosystem uses the [OCI image specification](https://github.com/op
 
 ### Deploying the application with a key-value provider
 
-We can still use `wash dev`, we'll just need to override the `wasi:keyvalue` capability dependency with the Redis provider. Open up the `wasmcloud.toml` file and add the following lines to the end:
+We can still use `wash dev`&mdash;we'll just need to override the `wasi:keyvalue` capability dependency with the Redis provider. Open up the `wasmcloud.toml` configuration file and add the following lines to the end:
 
 ```toml
 name = "http-hello-world"
@@ -111,17 +109,17 @@ image_ref = "ghcr.io/wasmcloud/keyvalue-redis:0.28.2"
 config = { values = { url = "redis://127.0.0.1:6379" } }
 ```
 
-When `wash dev` finds your component's dependency on a `keyvalue` capability, it will instead deploy the Redis provider instead of the NATS provider.
+Now the `wash dev` process will deploy the Redis provider (rather than the default NATS-KV provider) to satisfy your component's dependency on a `keyvalue` capability.
 
-![manual deploy diagram](../images/quickstart-diagram-2.png)
+![deploy diagram](../images/quickstart-diagram-2.png)
 
-After saving `wasmcloud.toml`, we'll start our developer loop again.
+Save `wasmcloud.toml`. If `wash dev` is still running from the previous tutorial, make sure to stop it with CTRL+C and restart the developer loop. 
 
 ```shell
 wash dev
 ```
 
-Once your application is `Deployed`, we can `curl` the application like before:
+Once the application is `Deployed`, we can `curl` the application like before:
 
 ```shell
 curl 'localhost:8000?name=Bob'

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Scale and Distribute'
+title: 'Deploy and Scale'
 sidebar_position: 3
+slug: deploy-and-scale
 ---
 
 import Tabs from '@theme/Tabs';
@@ -11,17 +12,86 @@ In the previous steps, we started a developer loop, added two [**interfaces**](/
 
 Now we'll learn how to:
 
-- Scale our application to handle multiple parallel requests
+- Declaratively deploy an application in a local wasmCloud environment
+- Scale an application to handle multiple parallel requests
 - Distribute an application globally
 - Use the wasmCloud dashboard
 
 :::info[Prerequisites]
-This tutorial assumes you're following directly from the previous steps. Make sure to complete [**Quickstart**](/docs/tour/hello-world.mdx), [**Add Features**](/docs/tour/add-features.mdx), and [**Extend and Deploy**](/docs/tour/extend-and-deploy.mdx) first.
+This tutorial assumes you're following directly from the previous steps. Make sure to complete [**Quickstart**](/docs/tour/hello-world.mdx), [**Add Features**](/docs/tour/add-features.mdx), and [**Customize and Extend**](/docs/tour/customize-and-extend/) first.
 :::
+
+### Declaratively deploying the application
+
+We will continue to use the Redis key-value capability provider as in the [Customize and Extend](/docs/tour/customize-and-extend/) step, but this time we will specify the provider using a declarative [**application manifest**](/docs/ecosystem/wadm/model) written in YAML, much like a Kubernetes manifest.
+
+This `.yaml` file defines the relationships between the components and providers that make up our application, along with other important configuration details. It is conventionally named `wadm.yaml` after the [**wasmCloud Application Deployment Manager**](/docs/ecosystem/wadm/index.md) that handles scheduling.
+
+We can modify our `wadm.yaml` to include the Redis provider.
+
+Open `wadm.yaml` in your code editor and make the changes below.
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: hello-world # [!code ++:3]
+  annotations:
+    description: 'HTTP hello world demo'
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        # Your manifest will point to the path of the built component; you can also
+        # start published components from OCI registries
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 1
+        # The new key-value link configuration # [!code ++:11]
+        - type: link
+          properties:
+            target: kvredis
+            namespace: wasi
+            package: keyvalue
+            interfaces: [atomics, store]
+            target_config:
+              - name: redis-url
+                properties:
+                  url: redis://127.0.0.1:6379
+    # The new capability provider # [!code ++:5]
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.25.0
+      traits:
+        - type: link
+          properties:
+            target: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source_config:
+              - name: default-http
+                properties:
+                  address: 127.0.0.1:8000
+```
+
+* `kvredis` is defined as a `capability` provider and fetched from an OCI image.
+* `http-component` connects to `kvredis` via a runtime `link`.
+    - The **link definition** specifies the interface and configuration through which the component and provider will communicate.
+
+Save your changes to `wadm.yaml`.
 
 ## Scaling up 📈
 
-So far, our application can only handle a single request at a time. This is because only a single **instance** is defined for it in the application manifest (`wadm.yaml`), as a property of the `spreadscaler`:
+So far, our application can only handle a single request at a time. This is because only a single **instance** is defined for it in the application manifest as a property of the `spreadscaler`:
 
 ```yaml {14-16}
 apiVersion: core.oam.dev/v1beta1
@@ -202,17 +272,20 @@ async function handle(req: IncomingRequest, resp: ResponseOutparam) { // [!code 
 The response time of our hello handler is very low. To show that requests are not processed in parallel, we need to ensure a longer response time, which we can exploit in our tests.
 :::
 
-Because we've made changes, run `wash build` again to compile the updated Wasm component.
+Because we've made changes, run `wash build` to compile the updated Wasm component.
 
 ```bash
 wash build
 ```
 
-If you stopped your local wasmCloud environment and Redis server in the previous tutorial, start them up again: 
+Start a local wasmCloud environment (using the `-d`/`--detached` flag to run in the background):
 
 ```shell
 wash up -d
 ```
+
+If you stopped the Redis server in the previous tutorial, start it up again: 
+
 <Tabs groupId="env" queryString>
   <TabItem value="local" label="Local Redis Server" default>
 
@@ -230,7 +303,7 @@ docker run -d --name redis -p 6379:6379 redis
   </TabItem>
 </Tabs>
 
-Deploy the latest version of our application:
+Manually deploy the application:
 
 ```shell
 wash app deploy wadm.yaml

--- a/netlify.toml
+++ b/netlify.toml
@@ -173,6 +173,8 @@ redirects = [
   { from = "/docs/tour/adding-capabilities", to = "/docs/tour/add-features", status = 301 },
   { from = "/docs/tour/hello_world", to = "/docs/tour/hello-world", status = 301 },
   { from = "/docs/tour/why_wasmcloud", to = "/docs/tour/why-wasmcloud", status = 301 },
+  { from = "/docs/tour/extend-and-deploy", to = "/docs/tour/customize-and-extend", status = 301 },
+  { from = "/docs/tour/scale-and-distribute", to = "/docs/tour/deploy-and-scale", status = 301 },
 
   # blog
   { from = "/blog/wasi-p2-comes-to-tinygo", to = "/blog/compile-go-directly-to-webassembly-components-with-tinygo-and-wasi-p2", status = 301 },


### PR DESCRIPTION
## Feature or Problem
This PR uses interface level overrides to override the keyvalue dependency in the quickstart.

Will depend on wash 0.38 being released, and a newer keyvalue provider version.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
