### PR TITLE
chore: clarify wit-bindgen-wrpc dependency for providers

### DIFF
--- a/docs/developer/languages/go/providers.mdx
+++ b/docs/developer/languages/go/providers.mdx
@@ -23,7 +23,7 @@ To build a capability provider in Go, you'll need...
 * [Go](https://go.dev/doc/install) 1.23.0+
 * [The Rust toolchain](https://www.rust-lang.org/tools/install)
 * [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) for Go binding generation
-* [`wrpc`](https://github.com/wrpc/wrpc/) 0.9+ installed with `cargo install wrpc`
+* [`wit-bindgen-wrpc`](https://github.com/wrpc/wrpc/) 0.9+ (may install with `cargo install wrpc` or [release binary](https://github.com/bytecodealliance/wrpc/releases))
 * [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.32.1+ for building and deploying components
 
 Additionally, for the purposes of the "testing" section of this example, you'll want:

--- a/docs/developer/providers/create.md
+++ b/docs/developer/providers/create.md
@@ -8,7 +8,7 @@ draft: false
 The first step in creating our new provider is to generate a new project from a template. We provide an example template to generate a capability provider that has scaffolding to implement the `wasmcloud:messaging` interface. This page will walk you through generating this capability provider and then implementing the functionality using [NATS](https://nats.io).
 
 :::info[Dependencies]
-To create this capability provider you'll need to install [wash](/docs/installation.mdx) and the [Rust toolchain](https://www.rust-lang.org/tools/install). After implementing, you'll also want the [nats CLI](https://github.com/nats-io/natscli) to send your provider messages.
+To create this capability provider you'll need to install [wash](/docs/installation.mdx), the [Rust toolchain](https://www.rust-lang.org/tools/install), and `wit-bindgen-wrpc` (available by running `cargo install wrpc` or as a [release binary](https://github.com/bytecodealliance/wrpc/releases) in the `wrpc` repo). After implementing, you'll also want the [nats CLI](https://github.com/nats-io/natscli) to send your provider messages.
 :::
 
 ## The messaging interface


### PR DESCRIPTION
Make dependency and installation clearer on relevant pages.