### PR TITLE
chore: tabbed wash install in quickstart per feedback

### DIFF
--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -20,12 +20,15 @@ In this tutorial:
 
 First, we need to install the latest version of `wash`.
 
+<Tabs groupId="os" queryString>
+<TabItem value="macos" label="macOS">
 On macOS, you can use [Homebrew](https://brew.sh/) to install `wash`:
 
 ```shell
 brew install wasmcloud/wasmcloud/wash
 ```
-
+</TabItem>
+<TabItem value="debian" label="Ubuntu and Debian">
 On Ubuntu and Debian Linux, you can use `apt` to install `wash`:
 
 ```shell
@@ -35,12 +38,15 @@ curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.deb.s
 ```shell
 sudo apt install wash
 ```
-
+</TabItem>
+<TabItem value="windows" label="Windows">
 On Windows, you can use [Chocolatey](https://chocolatey.org/) to install `wash`:
 
 ```shell
 choco install wash
 ```
+</TabItem>
+</Tabs>
 
 We support other package managers and the option to install from source. If you'd like to use a different installation method, see the [**Installation**](/docs/installation) page.
 


### PR DESCRIPTION
Add OS tabs for wash installation in the quickstart per feedback from @ricochet.