### PR TITLE
docs: remove Fedora 41 note

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -269,10 +269,6 @@ curl -s https://packagecloud.io/install/repositories/wasmcloud/core/script.rpm.s
 sudo dnf install wash
 ```
 
-:::warning[Note on Fedora 41]
-Users attempting to install on Fedora 41 will encounter errors because https://packagecloud.io/wasmCloud/core is currently missing `fedora/41` packages. A [fix](https://github.com/wasmCloud/wasmCloud/pull/3589) is in progress; in the meantime, users may manually edit `/etc/yum.repos.d/wasmCloud_core.repo` and point to `fedora/40` as a workaround.
-:::
-
 <details>
 <summary>What's in that install script?</summary>
 It is always a good idea to inspect scripts before piping them directly into `sudo bash`. Below are the contents of `script.rpm.sh` for your verification.


### PR DESCRIPTION
Remove warning note on Fedora 41 installation now that wasmcloud/wasmcloud#3589 is merged.