### PR TITLE
blog: fix sched link in contribfest blog

### DIFF
--- a/blog/2024-11-13-join-us-for-contribfest/index.mdx
+++ b/blog/2024-11-13-join-us-for-contribfest/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Join us for Contribfest at KubeCon NA 2024!"
+title: "Join us for Contribfest at KubeCon NA 2024 in Salt Lake City!"
 authors: [ericgregory]
 image: './images/contribfest-2024.webp'
 slug: 2024-11-13-join-us-for-contribfest
@@ -9,7 +9,7 @@ description: "Learn about Contribfest, good first issues for new wasmCloud contr
 
 ![Header remixes original photo at https://commons.wikimedia.org/wiki/File:Saltlakecity_winter2009.jpg](./images/contribfest-2024.webp)
 
-We're thrilled to be hosting a [**Contribfest**](https://kccnceu2024.sched.com/event/1YkTW) session on **Thursday, November 14**, at KubeCon North America 2024 in Salt Lake City, Utah. Check it out from **11:00am to 12:30pm MST** in the Salt Palace, Level 3, 355 D!
+We're thrilled to be hosting a [**Contribfest**](https://sched.co/1howS) session on **Thursday, November 14**, at KubeCon North America 2024 in Salt Lake City, Utah. Check it out from **11:00am to 12:30pm MST** in the Salt Palace, Level 3, 355 D!
 
 As a [newly Incubating CNCF project](https://www.cncf.io/blog/2024/11/12/cncf-welcomes-wasmcloud-to-the-cncf-incubator/), there's never been a better time to jump on board and become an open source contributor. In this post, we'll explain exactly what Contribfest is, highlight some good first issues for new contributors, and show you how you can get involved, whether you're in Salt Lake City or anywhere around the world.
 


### PR DESCRIPTION
Fix sched link (and extend title to look nicer as formatted on blog)