### PR TITLE
docs: fix persistent storage for go

### DIFF
--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -180,6 +180,21 @@ We'll use the **key-value capability** for this. We don't need to pick a library
 
 We can use the `wasi:keyvalue` interface for interacting with a key value store, and the `wasi:logging` interface to log the name of each person we greet. Before we can use those interfaces, we'll need to add them to our `wit/world.wit` file:
 
+<Tabs groupId="lang" queryString>
+  <TabItem value="tinygo" label="Go">
+```wit
+package wasmcloud:hello;
+
+world hello {
+  include wasmcloud:component-go/imports@0.1.0;
+  import wasi:keyvalue/atomics@0.2.0-draft; // [!code ++]
+  import wasi:keyvalue/store@0.2.0-draft; // [!code ++]
+
+  export wasi:http/incoming-handler@0.2.0;
+}
+```
+  </TabItem>
+  <TabItem value="rust" label="Rust">
 ```wit
 package wasmcloud:hello;
 
@@ -191,7 +206,21 @@ world hello {
   export wasi:http/incoming-handler@0.2.0;
 }
 ```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```wit
+package wasmcloud:hello;
 
+world hello {
+  import wasi:keyvalue/atomics@0.2.0-draft; // [!code ++]
+  import wasi:keyvalue/store@0.2.0-draft; // [!code ++]
+  import wasi:logging/logging@0.1.0-draft; // [!code ++]
+
+  export wasi:http/incoming-handler@0.2.0;
+}
+```
+  </TabItem>
+</Tabs>
 We've given our application the ability to perform atomic incrementation and storage operations via the `wasi:keyvalue` interface and general logging operations via `wasi:logging`.
 
 <Tabs groupId="lang" queryString>


### PR DESCRIPTION
## Feature or Problem
The quickstart guide is not aligned with generated component sdk go.

### Manual Verification
Looking to use the netlify preview to see the mdx renders correctly.