### PR TITLE
Update components.mdx hello.go to main.go

### DIFF
--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -61,7 +61,7 @@ world hello {
 }
 ```
 
-Finally, we'll delete the contents of `hello.go` and write our HTTP server, which will return a simple "hello world."
+Finally, we'll delete the contents of `main.go` and write our HTTP server, which will return a simple "hello world."
 
 Using the Component SDK, this looks like a fairly standard server using the HTTP standard library, with only a handful of exceptions where we use methods of `wasihttp` or `wasilog`.
 


### PR DESCRIPTION
The template project generates main.go.  The guide references  'hello.go'.  change 'hello.go' to 'main.go'.

## Feature or Problem
Developer Guide referred to a 'hello.go' where it should be 'main.go' from the template project


