### PR TITLE
docs: update curl commands to use the default port when app is deployed

### DIFF
--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -176,10 +176,12 @@ Check the status of the app:
 wash app list
 ```
 
+**Note**: When deploying the application, it uses port **8080** as defined in `wadm.yaml`.
+
 Once the application status is `Deployed`, we can `curl` the application like before:
 
 ```shell
-curl 'localhost:8000?name=Bob'
+curl 'localhost:8080?name=Bob'
 ```
 
 ```text
@@ -187,7 +189,7 @@ Hello x1, Bob!
 ```
 
 ```shell
-curl 'localhost:8000?name=Bob'
+curl 'localhost:8080?name=Bob'
 ```
 
 ```text
@@ -195,7 +197,7 @@ Hello x2, Bob!
 ```
 
 ```shell
-curl 'localhost:8000?name=Alice'
+curl 'localhost:8080?name=Alice'
 ```
 
 ```text


### PR DESCRIPTION
## Feature or Problem
`wash dev` start the application with port 8000. However, when deploying the app with `wash app deploy` it'll take the port from `wadm.yaml` which is set to 8080 by default. This commit makes sure the `curl` commands in the documentation uses the default port in `wadm.yaml`