### PR TITLE
fix: update quickstart on wasilog and delete

### DIFF
--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -221,10 +221,11 @@ world hello {
 ```
   </TabItem>
 </Tabs>
-We've given our application the ability to perform atomic incrementation and storage operations via the `wasi:keyvalue` interface and general logging operations via `wasi:logging`.
 
 <Tabs groupId="lang" queryString>
   <TabItem value="tinygo" label="Go">
+
+We've given our application the ability to perform atomic incrementation and storage operations via the `wasi:keyvalue` interface.
 
 Now let's use the atomic increment function to keep track of how many times we've greeted each person.
 
@@ -275,8 +276,16 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 func main() {}
 ```
 
+Download the `wasilog` module for idiomatic Go logging that compiles to a component:
+
+```shell
+go get go.wasmcloud.dev/component/log/wasilog
+```
+
   </TabItem>
     <TabItem value="rust" label="Rust">
+
+We've given our application the ability to perform atomic incrementation and storage operations via the `wasi:keyvalue` interface and general logging operations via `wasi:logging`.
 
 Now let's use the atomic increment function to keep track of how many times we've greeted each person.
 
@@ -321,6 +330,8 @@ impl http::Server for Component {
 
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
+
+We've given our application the ability to perform atomic incrementation and storage operations via the `wasi:keyvalue` interface and general logging operations via `wasi:logging`.
 
 Now let's use the atomic increment function to keep track of how many times we've greeted each person.
 

--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -116,7 +116,7 @@ Open `wadm.yaml` in your code editor and make the changes below.
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: hello-world
+  name: hello-world # [!code ++:3]
   annotations:
     description: 'HTTP hello world demo'
 spec:


### PR DESCRIPTION
Makes a few small fixes to the quickstart: 

Adds line to download wasilog module for Go on "Add features" page. (This is a stopgap to get the instructions working before a larger update to the template.) 

Places the instruction text for that section within the tab because Go differs from the other languages in not using wasi:logging directly. 

Adds highlight text to updated wadm manifest on "Extend and deploy" page to emphasize that user should update the application name to `hello-world`.

* Resolves #717 
* Resolves #718 
* Resolves #719 

