### PR TITLE
fix: add wasi logging import

### DIFF
--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -187,6 +187,7 @@ package wasmcloud:hello;
 
 world hello {
   include wasmcloud:component-go/imports@0.1.0;
+  import wasi:logging/logging@0.1.0-draft; // [!code ++]
   import wasi:keyvalue/atomics@0.2.0-draft; // [!code ++]
   import wasi:keyvalue/store@0.2.0-draft; // [!code ++]
 


### PR DESCRIPTION
This commit adds the missing wasi logging import to the Golang quickstart

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
