### PR TITLE
docs: improve lang toolchain installs in quickstart

### DIFF
--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -104,7 +104,7 @@ Requirements:
 <Tabs groupId="os" queryString>
   <TabItem value="macos" label="macOS">
 
-On macOS, you can use [Homebrew](https://brew.sh/) to install the Go toolchain:
+On macOS, you can use [Homebrew](https://brew.sh/) to install the Go toolchain. (See the [official Go documentation](https://go.dev/doc/install) for other options.)
 
 ```shell
 brew install go
@@ -124,21 +124,17 @@ brew install wasm-tools
 
 <TabItem value="ubuntu" label="Ubuntu/Debian">
 
-On Ubuntu/Debian, Go 1.23+ isn't currently available via major package managers, but you can use `curl` or `wget` to download the Go toolchain from the [official Go download page](https://go.dev/dl/).
+On Ubuntu/Debian, Go 1.23+ isn't currently available via major package managers, but you can use `curl` or `wget` to download the Go toolchain from the [official Go download page](https://go.dev/dl/). (See the [official Go documentation](https://go.dev/doc/install) for other options.)
 
-Before downloading, ensure that you do not have a previous version of Go installed:
-
-```shell
-sudo rm -rf /usr/local/go
-```
+Before downloading, ensure that you do not have a previous version of Go installed. You can find an existing installation in the `/usr/local/go` directory.
 
 Consult the [download page](https://go.dev/dl/) and set environment variables specifying the appropriate version and architecture for your system. (The values below are examples.)
 
 ```shell
-GO_VERSION="1.23.4"
+export GO_VERSION="1.23.4"
 ```
 ```shell
-GO_ARCH="arm64"
+export GO_ARCH="amd64"
 ```
 
 Download your file:
@@ -147,10 +143,10 @@ Download your file:
 curl -O -L "https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
 ```
 
-Find the appropriate checksum value for your file on the [download page](https://go.dev/dl/) and validate the file:
+Find the appropriate checksum value for your file on the [download page](https://go.dev/dl/) and validate the file. (The example below uses the checksum value for the v1.23.4 on `amd64` download.)
 
 ```shell
-echo -n "CHECKSUMVALUEHERE *go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | shasum -a 256 --check
+echo -n "6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971 *go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | shasum -a 256 --check
 ```
 
 Extract the file:
@@ -174,10 +170,10 @@ mv -v go /usr/local
 On Ubuntu/Debian, you can download TinyGo similarly. Refer to the [TinyGo GitHub releases page](https://github.com/tinygo-org/tinygo/releases/) to find the correct version and architecture and set environment variables accordingly. (The values below are examples.) 
 
 ```shell
-TINYGO_VERSION="0.34.0"
+export TINYGO_VERSION="0.34.0"
 ```
 ```shell
-TINYGO_ARCH="arm64"
+export TINYGO_ARCH="amd64"
 ```
 
 Now download the `.deb` file:
@@ -252,7 +248,7 @@ Requirements:
 <Tabs groupId="os" queryString>
   <TabItem value="macos" label="macOS">
 
-On macOS, you can use [Homebrew](https://brew.sh/) to install `npm` (and Node.js):
+On macOS, you can use [Homebrew](https://brew.sh/) to install `npm` and Node.js. (See the [official Node.js documentation](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) for other options.)
 
 ```shell
 brew install node
@@ -261,10 +257,17 @@ brew install node
   </TabItem>
     <TabItem value="ubuntu" label="Ubuntu/Debian">
 
-On Ubuntu, you can use `snap` to install `npm` (and Node.js):
+On Ubuntu, you can install `npm` (and Node.js) using the [Node Version Manager (`nvm`)](https://github.com/nvm-sh/nvm). (See the [official Node.js documentation](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) for other options.) You can download and install `nvm` using the official installation script:
 
 ```shell
-sudo snap install node --classic --channel=14
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+```
+Once the script completes, you may need to start a new shell session. 
+
+You can use `nvm` to install the latest Long-Term Service version of `node`:
+
+```shell
+nvm install --lts
 ```
 
   </TabItem>

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -101,7 +101,10 @@ Requirements:
 - [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+:
 - [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) 1.219+
 
-You can use [Homebrew](https://brew.sh/) to install the Go toolchain:
+<Tabs groupId="os" queryString>
+  <TabItem value="macos" label="macOS">
+
+On macOS, you can use [Homebrew](https://brew.sh/) to install the Go toolchain:
 
 ```shell
 brew install go
@@ -116,6 +119,95 @@ You will also need the `wasm-tools` utility. You can use `brew`:
 ```shell
 brew install wasm-tools
 ```
+
+  </TabItem>
+
+<TabItem value="ubuntu" label="Ubuntu/Debian">
+
+On Ubuntu/Debian, Go 1.23+ isn't currently available via major package managers, but you can use `curl` or `wget` to download the Go toolchain from the [official Go download page](https://go.dev/dl/).
+
+Before downloading, ensure that you do not have a previous version of Go installed:
+
+```shell
+sudo rm -rf /usr/local/go
+```
+
+Consult the [download page](https://go.dev/dl/) and set environment variables specifying the appropriate version and architecture for your system. (The values below are examples.)
+
+```shell
+GO_VERSION="1.23.4"
+```
+```shell
+GO_ARCH="arm64"
+```
+
+Download your file:
+
+```shell
+curl -O -L "https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+```
+
+Find the appropriate checksum value for your file on the [download page](https://go.dev/dl/) and validate the file:
+
+```shell
+echo -n "CHECKSUMVALUEHERE *go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | shasum -a 256 --check
+```
+
+Extract the file:
+
+```shell
+tar -xf "go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+```
+
+You may need to change ownership on the new `go` directory:
+
+```shell
+sudo chown -R root:root ./go
+```
+
+Finally, move the `go` directory to `/usr/local`:
+
+```shell
+mv -v go /usr/local
+```
+
+On Ubuntu/Debian, you can download TinyGo similarly. Refer to the [TinyGo GitHub releases page](https://github.com/tinygo-org/tinygo/releases/) to find the correct version and architecture and set environment variables accordingly. (The values below are examples.) 
+
+```shell
+TINYGO_VERSION="0.34.0"
+```
+```shell
+TINYGO_ARCH="arm64"
+```
+
+Now download the `.deb` file:
+
+```shell
+curl -O -L "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_${TINYGO_ARCH}.deb"
+```
+
+Install TinyGo from the `.deb` file:
+
+```shell
+sudo dpkg -i tinygo_${TINYGO_VERSION}_${TINYGO_ARCH}.deb
+```
+
+Add TinyGo to your PATH:
+
+```shell
+export PATH=$PATH:/usr/local/bin
+```
+
+Validate the installation:
+
+```shell
+tinygo version
+```
+
+You will also need the `wasm-tools` utility. 
+  </TabItem>
+
+</Tabs>
 
 If you have the [Rust toolchain](https://www.rust-lang.org/tools/install), you can use `cargo` to install `wasm-tools`:
 
@@ -135,7 +227,7 @@ Requirements:
 - [The Rust toolchain](https://www.rust-lang.org/tools/install)
 - The `wasm32-wasip2` target for Rust
 
-You can use the official install script to download `rustup`, which will automatically install the Rust toolchain:
+On macOS or Ubuntu/Debian, you can use the official install script to download `rustup`, which will automatically install the Rust toolchain:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -154,14 +246,29 @@ rustup target add wasm32-wasip2
 
 Requirements:
 
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) v10.8+
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) v14.17+
 - [TypeScript](https://www.typescriptlang.org/) v5.6+
 
-You can use [Homebrew](https://brew.sh/) to install `npm` (and Node.js):
+<Tabs groupId="os" queryString>
+  <TabItem value="macos" label="macOS">
+
+On macOS, you can use [Homebrew](https://brew.sh/) to install `npm` (and Node.js):
 
 ```shell
 brew install node
 ```
+
+  </TabItem>
+    <TabItem value="ubuntu" label="Ubuntu/Debian">
+
+On Ubuntu, you can use `snap` to install `npm` (and Node.js):
+
+```shell
+sudo snap install node --classic --channel=14
+```
+
+  </TabItem>
+</Tabs>
 
 Once you've installed Node.js and `npm`, you can use `npm` to install TypeScript:
 


### PR DESCRIPTION
Adds OS tabs for language toolchain installation instructions in quickstart and provides corrected or expanded instructions in several instances, particularly for Go on Ubuntu/Debian.