### PR TITLE
docs: add extra emphasis to wasm-tools dependency

### DIFF
--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -114,7 +114,7 @@ brew install go
 brew install tinygo-org/tools/tinygo
 ```
 
-You will also need the `wasm-tools` utility. You can use `brew`:
+**You will also need the `wasm-tools` utility.** You can use `brew`:
 
 ```shell
 brew install wasm-tools
@@ -200,7 +200,7 @@ Validate the installation:
 tinygo version
 ```
 
-You will also need the `wasm-tools` utility. 
+**You will also need the `wasm-tools` utility.** 
   </TabItem>
 
 </Tabs>


### PR DESCRIPTION
Adds emphasis to the `wasm-tools` dependency for the Go toolchain in the quickstart to ensure that users do not miss it. Resolves #760 
