### PR TITLE
fix: correct link and version on interface page

### DIFF
--- a/docs/concepts/interfaces.mdx
+++ b/docs/concepts/interfaces.mdx
@@ -134,7 +134,7 @@ Additionally, wasmCloud supports proposed WASI APIs that are in the process of i
 | --------------------------------------------- | ----------- |
 | https://github.com/WebAssembly/wasi-blobstore | 0.2.0-draft |
 | https://github.com/WebAssembly/wasi-keyvalue  | 0.2.0-draft |
-| https://github.com/WebAssembly/wasi-logging   | [proposal]  |
+| https://github.com/WebAssembly/wasi-logging   | 0.1.0-draft |
 
 ### wasmCloud interfaces
 
@@ -142,7 +142,7 @@ Well-known interfaces include two APIs built specifically for wasmCloud:
 
 | API                                                                              | Versions    |
 | -------------------------------------------------------------------------------- | ----------- |
-| [wasmcloud:bus](https://github.com/wasmCloud/wasmCloud/blob/main/wit/bus.wit)    | 1.0.0       |
+| [wasmcloud:bus](https://github.com/wasmCloud/wasmCloud/tree/main/wit/bus)        | 1.0.0       |
 | [wasmcloud:messaging](https://github.com/wasmCloud/messaging)                    | 1.0.0       |
 
 * **`wasmcloud:bus`** provides advanced link configuration only available in wasmCloud.


### PR DESCRIPTION
Two small fixes on the **Platform Overview -> Interfaces** page: updating the URL for `wasmcloud:bus` and the version for `wasi:logging`.
