### PR TITLE
docs: Consistency and correctness fixes on quickstart

### DIFF
--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -49,7 +49,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
     name = r.FormValue("name") // [!code ++]
   } // [!code ++]
   fmt.Fprintf(w, "Hello, %s!\n", name) // [!code ++]
-  fmt.Fprintf(w, "Hello from Go!\n") // [!code --]
+  fmt.Fprintf(w, "Hello from Wasm!\n") // [!code --]
 }
 
 // Since we don't run this program like a CLI, the `main` function is empty. Instead,
@@ -120,7 +120,7 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
     const name = getNameFromPath(req.pathWithQuery() || "") // [!code ++]
     // Write "hello [name]" to the response stream // [!code ++]
     outputStream.blockingWriteAndFlush(
-      new Uint8Array(new TextEncoder().encode("hello from Typescript")) // [!code --]
+      new Uint8Array(new TextEncoder().encode("Hello from Wasm!\n")) // [!code --]
       new Uint8Array(new TextEncoder().encode(`Hello ${name}!\n`)) // [!code ++]
     );
     // @ts-ignore: This is required in order to dispose the stream before we return

--- a/docs/tour/extend-and-deploy.mdx
+++ b/docs/tour/extend-and-deploy.mdx
@@ -64,7 +64,7 @@ For our manual deployment, let's **swap out a different key-value storage provid
 <Tabs groupId="env" queryString>
   <TabItem value="local" label="Local Redis Server" default>
 
-[Install](https://redis.io/docs/getting-started/) and launch the local redis server in the background
+[Install](https://redis.io/docs/getting-started/) and launch a local Redis server in the background:
 
 ```bash
 redis-server &
@@ -89,7 +89,7 @@ ghcr.io/wasmcloud/keyvalue-redis:0.28.1
 ```
 
 :::note[What are those images?]
-The wasmCloud ecosystem uses the [OCI image specification](https://github.com/opencontainers/image-spec) to package components and providers&mdash;these component and provider images are not container images, but conform to OCI standards and may be stored on any OCI-compatible registry.
+The wasmCloud ecosystem uses the [OCI image specification](https://github.com/opencontainers/image-spec) to package components and providers&mdash;these component and provider images are not container images, but conform to OCI standards and may be stored on any OCI-compatible registry. You can learn more about wasmCloud packaging on the [**Packaging**](/docs/concepts/packaging.mdx) page.
 :::
 
 ### Deploying the application with a key-value provider
@@ -124,7 +124,7 @@ spec:
     - name: http-component
       type: component
       properties:
-        # Your manifest will point to the path of the built component, you can also
+        # Your manifest will point to the path of the built component; you can also
         # start published components from OCI registries
         image: file://./build/http_hello_world_s.wasm
       traits:
@@ -146,11 +146,11 @@ spec:
     - name: kvredis
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.1
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.25.0
       traits:
         - type: link
           properties:
@@ -161,7 +161,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 ```
 
 Once you save `wadm.yaml`, we can deploy from the project directory:
@@ -215,6 +215,28 @@ Shut down the environment:
 ```shell
 wash down
 ```
+
+Stop your Redis server:
+
+<Tabs groupId="env" queryString>
+  <TabItem value="local" label="Local Redis Server" default>
+
+Enter CTRL+C.
+
+```shell
+redis-cli shutdown
+```
+
+  </TabItem>
+  <TabItem value="docker" label="Docker">
+
+```shell
+docker stop redis
+```
+
+  </TabItem>
+</Tabs>
+
 
 ## Log files
 

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -98,7 +98,7 @@ wasmCloud supports building WebAssembly components from any language that suppor
 Requirements:
 
 - [Go](https://go.dev/doc/install) 1.23.0+
-- [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+:
+- [TinyGo](https://tinygo.org/getting-started/install/) (always use the latest version):
 - [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) 1.219+
 
 <Tabs groupId="os" queryString>
@@ -167,7 +167,7 @@ Finally, move the `go` directory to `/usr/local`:
 mv -v go /usr/local
 ```
 
-On Ubuntu/Debian, you can download TinyGo similarly. Refer to the [TinyGo GitHub releases page](https://github.com/tinygo-org/tinygo/releases/) to find the correct version and architecture and set environment variables accordingly. (The values below are examples.) 
+On Ubuntu/Debian, you can download TinyGo similarly. Refer to the [TinyGo GitHub releases page](https://github.com/tinygo-org/tinygo/releases/) to find the correct version and architecture and set environment variables accordingly. (The values below are examples&mdash;**remember to always use the latest version of TinyGo**.) 
 
 ```shell
 export TINYGO_VERSION="0.34.0"
@@ -220,7 +220,7 @@ Otherwise, [download the binary for the latest version of `wasm-tools` for your 
 
 Requirements:
 
-- [The Rust toolchain](https://www.rust-lang.org/tools/install)
+- [The Rust toolchain](https://www.rust-lang.org/tools/install) (always use the latest version)
 - The `wasm32-wasip2` target for Rust
 
 On macOS or Ubuntu/Debian, you can use the official install script to download `rustup`, which will automatically install the Rust toolchain:

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -7,11 +7,45 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import washboard_hello from '../images/washboard_hello.png';
 
+In the previous steps, we started a developer loop, added two [**interfaces**](/docs/concepts/interfaces.mdx) (`wasi:logging` and `wasi:keyvalue`), and extended our application with pluggable [**capabilities**](/docs/concepts/capabilities.mdx).
+
+Now we'll learn how to:
+
+- Scale our application to handle multiple parallel requests
+- Distribute an application globally
+- Use the wasmCloud dashboard
+
+:::info[Prerequisites]
+This tutorial assumes you're following directly from the previous steps. Make sure to complete [**Quickstart**](/docs/tour/hello-world.mdx), [**Add Features**](/docs/tour/add-features.mdx), and [**Extend and Deploy**](/docs/tour/extend-and-deploy.mdx) first.
+:::
+
 ## Scaling up 📈
 
-So far, our hello world application can only handle a single request at a time. This is because a dedicated instance of our hello component is instantiated for each request received, but currently only a single replica is defined for it in `wadm.yaml`. Accordingly, wasmCloud instructs [wasmtime](https://wasmtime.dev/) to instantiate only a single instance for our component at any time to process incoming requests. As a result, requests received at the same time are processed sequentially, one after the other. Let's check this quickly.
+So far, our application can only handle a single request at a time. This is because only a single **instance** is defined for it in the application manifest (`wadm.yaml`), as a property of the `spreadscaler`:
 
-For test and demonstration purposes, we add a simple `sleep` to the handler to simulate a longer processing time:
+```yaml {14-16}
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: hello-world
+  annotations:
+    description: 'HTTP hello world demo'
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        - type: spreadscaler
+          properties:
+            instances: 1
+...
+```
+
+Following the specification in the manifest, wasmCloud instructs the [host](/docs/concepts/hosts.mdx)'s WebAssembly runtime ([wasmtime](/docs/ecosystem/wasmtime/)) to instantiate **only a single instance of our component** at any time to process incoming requests. As a result, requests received at the same time are processed sequentially, one after the other. 
+
+Let's try adding a simple `sleep` to the handler to simulate a longer processing time:
 
 <Tabs groupId="lang" queryString>
   <TabItem value="tinygo" label="Go">
@@ -164,14 +198,43 @@ Because we've made changes, run `wash build` again to compile the updated Wasm c
 wash build
 ```
 
-Deploy the latest version of our component and try to send multiple requests in parallel.
+If you stopped your local wasmCloud environment and Redis server in the previous tutorial, start them up again: 
+
+```shell
+wash up -d
+```
+<Tabs groupId="env" queryString>
+  <TabItem value="local" label="Local Redis Server" default>
+
+```shell
+redis-server &
+```
+
+  </TabItem>
+  <TabItem value="docker" label="Docker">
+
+```shell
+docker run -d --name redis -p 6379:6379 redis
+```
+
+  </TabItem>
+</Tabs>
+
+Deploy the latest version of our application:
+
+```shell
+wash app deploy wadm.yaml
+```
+
+Now we'll try to send multiple requests in parallel.
 
 <Tabs groupId="lang" queryString>
   <TabItem value="Linux/macOS" label="Linux/macOS">
 
-```bash
-> wash app deploy wadm.yaml
-> seq 1 10 | xargs -P0 -I {} curl --max-time 3 "localhost:8080?name=Alice"
+```shell
+seq 1 10 | xargs -P0 -I {} curl --max-time 3 "localhost:8000?name=Alice"
+```
+```text
 Hello x1, Alice!
 curl: (28) Operation timed out after 3002 milliseconds with 0 bytes received
 curl: (28) Operation timed out after 3006 milliseconds with 0 bytes received
@@ -187,8 +250,9 @@ curl: (28) Operation timed out after 3001 milliseconds with 0 bytes received
   <TabItem value="Windows" label="Windows">
 
 ```powershell
-> wash app deploy wadm.yaml
-> 1..10 | ForEach-Object -Parallel { curl --max-time 3 'localhost:8080?name=Alice' }
+1..10 | ForEach-Object -Parallel { curl --max-time 3 'localhost:8000?name=Alice' }
+```
+```text
 Hello x1, Alice!
 curl: (28) Operation timed out after 3002 milliseconds with 0 bytes received
 curl: (28) Operation timed out after 3006 milliseconds with 0 bytes received
@@ -206,7 +270,7 @@ curl: (28) Operation timed out after 3001 milliseconds with 0 bytes received
 
 As you can see, only the first `curl` command receives the expected response in time, while all the others run into a timeout. However, if you check the logs of the wasmCloud host, you will see that multiple requests have been received and forwarded to our component one after the other.
 
-```txt
+```text
 2024-10-20T19:29:30.897232Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Bob component_id="rust_hello_world-http_component" level=Level::Info context=""
 2024-10-20T19:29:30.897253Z  INFO log: wasmcloud_host::wasmbus::handler: Sleep for 2 to simulate longer processing time component_id="rust_hello_world-http_component" level=Level::Info context=""
 2024-10-20T19:29:32.905355Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x1, Bob!' component_id="rust_hello_world-http_component" level=Level::Info context=""
@@ -225,53 +289,35 @@ As you can see, only the first `curl` command receives the expected response in 
 You can also check the wasmCloud host's `DEBUG` or `TRACE` logs for more detailed information (e.g. using `wash up --log-level=debug`). In these logs, you can clearly see that for received requests, our hello component is instantiated sequentially.
 :::
 
-If you wish, you can also use `wash spy` to check which messages the capability providers and the hello component have received and sent
-
-
-<Tabs groupId="lang" queryString>
-  <TabItem value="tinygo" label="Go">
+If you wish, you can also use `wash spy` to check which messages the capability providers and the hello component have received and sent.
 
 ```bash
-wash spy --experimental tinygo_hello_world-http_component
+wash spy --experimental hello_world-http_component
 ```
-
-  </TabItem>
-  <TabItem value="rust" label="Rust">
-
-```bash
-wash spy --experimental rust_hello_world-http_component
-```
-
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
-
-```bash
-wash spy --experimental typescript_hello_world-http_component
-```
-
-  </TabItem>
-</Tabs>
 
 :::note[Requests are not forwarded to our component anymore]
 After multiple requests were received but timed out, it is no longer possible to send further requests to our hello application. The reason for this is that the httpserver capability provider is no longer able to invoke the hello component via NATS. To continue, we must first delete and redeploy our application.
 :::
 
-To receive multiple requests in parallel, we need to instruct wasmCloud to scale our component according to the incoming load.
-WebAssembly can be easily scaled due to its small size, portability, and [wasmtime](https://wasmtime.dev/)'s ability to efficiently instantiate multiple instances of a single WebAssembly component. We leverage these aspects to make it simple to scale your applications with wasmCloud. Components only use resources when they're actively processing requests, so you can specify the number of replicas you want to run and wasmCloud will automatically scale up and down to meet demand. Let's allow our hello world application to scale up to 100 instances simultaneously by editing `wadm.yaml`:
+To receive multiple requests in parallel, we need to instruct wasmCloud to scale our component according to the incoming load. WebAssembly components can be easily scaled due to the small size and portability of the binaries as well as [wasmtime](https://wasmtime.dev/)'s ability to efficiently instantiate multiple instances of a given component. 
 
-```yaml {15-17}
+We leverage these aspects to make it simple to scale your applications with wasmCloud. Components only use resources when they're actively processing requests, so you can **specify the number of instances you want to run** and **wasmCloud will automatically scale up and down to meet demand**. 
+
+Let's allow our application to scale up to 100 instances simultaneously by editing the application manifest in `wadm.yaml`:
+
+```yaml {14-17}
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
   name: hello-world
   annotations:
-    description: 'HTTP hello world demo using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    description: 'HTTP hello world demo'
 spec:
   components:
     - name: http-component
       type: component
       properties:
-        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+        image: file://./build/http_hello_world_s.wasm
       traits:
         - type: spreadscaler
           properties:
@@ -281,14 +327,23 @@ spec:
 ...
 ```
 
-Now our hello component is ready to be deployed as version 0.0.3 with up to 100 instances, meaning it can handle up to 100 simultaneous incoming HTTP requests. Just run `wash app deploy wadm.yaml` again and wasmCloud will be able to automatically scale the component according to the incoming load. Let's deploy the component and try again to send multiple requests in parallel.
+Our application is ready to be deployed again with up to 100 instances, meaning it can handle up to 100 simultaneous incoming HTTP requests. 
+
+Deploy the application again:
+
+```shell
+wash app deploy wadm.yaml
+```
+
+Now wasmCloud will be able to automatically scale the component according to the incoming load. Let's try sending multiple requests in parallel again.
 
 <Tabs groupId="lang" queryString>
   <TabItem value="Linux/macOS" label="Linux/macOS">
 
-```bash
-> wash app deploy wadm.yaml
-> seq 1 10 | xargs -P0 -I {} curl --max-time 3 "localhost:8080?name=Bob"
+```shell
+seq 1 10 | xargs -P0 -I {} curl --max-time 3 "localhost:8000?name=Bob"
+```
+```text
 Hello x1, Bob!
 Hello x2, Bob!
 Hello x3, Bob!
@@ -305,8 +360,9 @@ Hello x10, Bob!
   <TabItem value="Windows" label="Windows">
 
 ```powershell
-> wash app deploy wadm.yaml
-> 1..10 | ForEach-Object -Parallel { curl --max-time 3 'localhost:8080?name=Bob' }
+> 1..10 | ForEach-Object -Parallel { curl --max-time 3 'localhost:8000?name=Bob' }
+```
+```text
 Hello x1, Bob!
 Hello x2, Bob!
 Hello x3, Bob!
@@ -323,8 +379,41 @@ Hello x10, Bob!
 </Tabs>
 
 :::note[Utilization planning is important]
-As you have seen, if a component receives too many requests in parallel, it may break down and wasmCloud will not be able to forward further requests. Therefore, it is important to plan and manage the specified maximum number of concurrent instances for Spreadscaler components according to the expected load.
+As we've seen, if a component receives too many requests in parallel, it may break down and wasmCloud will not be able to forward further requests. Therefore, it is important to plan and manage the specified maximum number of concurrent instances for Spreadscaler components according to the expected load.
 :::
+
+When you're done with the application, delete it from the wasmCloud environment:
+
+```shell
+wash app delete hello-world
+```
+
+Shut down the environment:
+
+```shell
+wash down
+```
+
+Stop your Redis server:
+
+<Tabs groupId="env" queryString>
+  <TabItem value="local" label="Local Redis Server" default>
+
+Enter CTRL+C.
+
+```shell
+redis-cli shutdown
+```
+
+  </TabItem>
+  <TabItem value="docker" label="Docker">
+
+```shell
+docker stop redis
+```
+
+  </TabItem>
+</Tabs>
 
 ## Distribute Globally 🌍
 
@@ -338,13 +427,13 @@ kind: Application
 metadata:
   name: hello-world
   annotations:
-    description: 'HTTP hello world demo using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    description: 'HTTP hello world demo'
 spec:
   components:
     - name: http-component
       type: component
       properties:
-        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+        image: file://./build/http_hello_world_s.wasm
       traits:
         - type: spreadscaler
           properties:


### PR DESCRIPTION
A set of consistency and correctness fixes for the quickstart including:

- Consistently use `localhost:8000` for `curl`s throughout all sections. (Resolves #771)
- Align "Scale and Distribute" page with structure and style of other sections.
- Specify latest version of TinyGo and Rust on Quickstart page.
- Update manifests to use latest versions of relevant providers.
- Align application name across sections and languages for simplicity and accuracy when using commands that target application and component names (i.e. `wash spy` on "Scale and Distribute" page).
- Add comprehensive clean-up instructions everywhere it is relevant.