### PR TITLE
docs: update application yaml across site

### DIFF
--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -96,9 +96,9 @@ Add logging to the project's `world.wit` file in the `wit` directory:
 package wasmcloud:hello;
 
 world hello {
-  import wasi:logging/logging; // [!code ++]
+  import wasi:logging/logging@0.1.0-draft; // [!code ++]
 
-  export wasi:http/incoming-handler@0.2.0;
+  export wasi:http/incoming-handler@0.2.2;
 }
 ```
 
@@ -243,7 +243,7 @@ A provider only ever dispatches messages to&mdash;or receives messages from&mdas
 
 The wasmCloud Quickstart (running through the "Adding capabilities" section) provides a great example of a component using two different providers. The component you build in the tutorial exports on the **wasi-http** interface (linking with the `http-server` provider) and imports on the **wasi-keyvalue** interface (linking with the `kvredis` provider).
 
-Here's the manifest for the completed Quickstart example:
+Here's the manifest for the [Extend and Deploy](/docs/tour/extend-and-deploy.mdx) step of the [Quickstart](/docs/tour/hello-world.mdx) example:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
@@ -251,7 +251,6 @@ kind: Application
 metadata:
   name: hello-world
   annotations:
-    version: v0.0.1
     description: 'HTTP hello world demo'
 spec:
   components:
@@ -259,7 +258,8 @@ spec:
     - name: http-component
       type: component
       properties:
-        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+        # This field can also point to artifacts in OCI registries
+        image: file://./build/http_hello_world_s.wasm
       traits:
         - type: spreadscaler
           properties:
@@ -279,12 +279,12 @@ spec:
     - name: kvredis
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
     # The httpserver provider
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.25.0
       traits:
         # Link definition for httpserver -> http-component
         - type: link
@@ -296,7 +296,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 127.0.0.1:8000
 ```
 
 - The http-component is **importing functions on the keyvalue interface**. It is the **importer** in relation to **kvredis**, meaning that it is the source for the link definition: the link is defined as a trait of http-component.

--- a/docs/ecosystem/wadm/model.md
+++ b/docs/ecosystem/wadm/model.md
@@ -7,96 +7,127 @@ type: 'docs'
 sidebar_position: 2
 ---
 
-The **w**asmCloud **A**pplication **D**eployment **M**anager uses the [Open Application Model](https://oam.dev/) to define application specifications. Because this specification is extensible and platform agnostic, it makes for an ideal way to represent applications with metadata specific to wasmCloud. Don't worry if OAM seems overwhelming, you don't need to know much about it. We're using it as a way of defining application components in a flexible way that's familiar to a lot of people who have been working in the cloud space.
+The **wasmCloud Application Deployment Manager** (`wadm`) uses the [Open Application Model](https://oam.dev/) to define application specifications. Because the OAM specification is extensible and platform-agnostic, it makes for an ideal way to represent applications with metadata specific to wasmCloud. 
 
-In this model, an application `specification` is a set of metadata about the app, as well as a list of `components`. Each component within an application is decorated with various `traits`. These core building blocks allow us to make it very easy to define incredibly powerful deployments. wasmCloud defines a number of traits that are specific to our hosts, but let's go through the model from top to bottom.
+:::note[OAM expertise not required]
+You don't need to know much about OAM to use wasmCloud&mdash;we've adopted the spec as a way of defining applications in a flexible way that is familiar to many people who work with cloud native technologies.
+:::
+
+In this model, an application `specification` is a set of metadata about the application, as well as a list of `components`. In this context, we are following the OAM spec in using the term "component" to refer to **any entity that makes up an application**, and not specifically a WebAssembly component. (As we will see, the `type` field will help us distinguish WebAssembly components from other entities.)
+
+Each component within an application is decorated with various `traits`. These core building blocks allow us to make it very easy to define incredibly powerful deployments. wasmCloud defines a number of traits that are specific to our hosts, but let's go through the model from top to bottom.
 
 ## Application
 
-The application is the top-most definition in an OAM specification. The metadata about the application that we're mostly concerned with are the name and version:
+The application is the top-most definition in an OAM specification. The metadata about the application that we're most concerned with is the name:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: my-example-app
+  name: hello-world
   annotations:
+    description: 'HTTP hello world demo'
+    # The version field is optional
     version: v0.0.1
-    description: 'This is my app'
 spec: ...
 ```
 
-wadm considers the `name` field to be a _globally unique value_, and the version number to follow [semantic versioning](https://semver.org/) conventions, though we only enforce that it looks like a semantic version - _we have no way to detect if you've produced a breaking change in a patch release_.
+`wadm` considers the `name` field to be a _globally unique value_.
 
-When application specifications are stored, they are keyed by name and a history of all versions is maintained, with the _most recently pushed_ version being considered the newest. We do not make assumptions about whether one version string (e.g. is `v1.10` is newer than `v1.1`?) is newer or older than any other. Version history is based purely on time of storage.
+The `version` field is optional&mdash;if not specified, the version will be assigned a unique alphanumeric value (for example, `01JGMAQX707A6FSGR7DC24RTD3`). 
+
+When application specifications are stored, they are keyed by name and a history of all versions is maintained, with the _most recently pushed_ version being considered the newest. `wadm` does not make assumptions about whether one version string is newer or older than any other (e.g. is `v1.10` is newer than `v1.1`?). Version history is based purely on time of storage.
 
 ## Components
 
-While OAM allows us to define any component in a specification, there are only a few components with which wadm is concerned:
+While OAM allows us to define any component in a specification, there are only a few components with which `wadm` is concerned:
 
-- `component` - represents a specification of a component
+- `component` - represents a specification of a WebAssembly component
 - `capability` - represents a specification of a capability provider
 
-Within the `components` field of a specification, you define an application component as follows:
+### WebAssembly components
+
+Within the `components` field of a specification, you define a WebAssembly component as follows:
 
 ```yaml
 spec:
   components:
-    - name: echo
+    - name: http-component
       type: component
       properties:
-        image: wasmcloud.azurecr.io/echo:0.3.8
-        id: echo
+        # The image field may point to the path of a local .wasm binary
+        # or an OCI artifact in an OCI registry
+        image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+        # The id field is optional
+        id: hello
+        # The config field is optional
         config:
-          - name: default-language
-            properties:
-              lang: en-US
+          - name: custom-config
+            properties: 
+              foo: bar
+              log-level: debug
       traits: ...
 ```
 
-The `image` property of the `component` component contains a file reference, an OCI image reference URL, or a Bindle image reference. The `id` property is an optional unique identifier you can assign your component. Generally, unless you have a reason to, it's recommended to omit the `id` property and let wadm assign a generated identifier for you which is a combination of the manifest name and the component name. Configuration specified here for the component will be available to the component at runtime via the [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) interface.
+The `image` property of the `component` component contains either a `.wasm` file reference or an OCI image reference URL. You can learn more about wasmCloud and packaging with OCI on the [Packaging](/docs/concepts/packaging.mdx) page.
+
+:::info[Launching WebAssembly components from local files]
 
 To launch a component from a local file, you should prefix the path with `file://`, as follows:
 
 ```yaml
 spec:
   components:
-    - name: echo
+    - name: http-component
       type: component
       properties:
-        image: file:///Users/wasmcloud/echo/build/echo_s.wasm
+        image: file://./build/http_hello_world_s.wasm
       traits: ...
 ```
-
-:::info
-When launching a component from a local file, ensure that the environment variable `WASMCLOUD_ALLOW_FILE_LOAD=true` is set when you launch wasmCloud. This is the default for hosts running with `wash up`. Only absolute paths are supported, since clients cannot reliably assume which directory the target host was started from. When running hosts locally with `wash up` for development, however, it is possible to use relative paths (which is converted to an absolute path) for convenience.
+When launching a WebAssembly component from a local file, ensure that the environment variable `WASMCLOUD_ALLOW_FILE_LOAD=true` is set when you launch wasmCloud. This is the default for hosts running with `wash up`. Only absolute paths are supported, since clients cannot reliably assume which directory the target host was started from. When running hosts locally with `wash up` for development, however, it is possible to use relative paths (which is converted to an absolute path) for convenience.
 :::
 
-To define a **capability provider**, we include a `capability` component, as follows:
+The `id` property is an optional unique identifier you can assign your component. Generally, we recommend omitting the `id` property&mdash;if no value is provided, `wadm` will assign a generated identifier, which is a combination of the manifest name and the component name. 
+
+Configuration specified in the `config` property will be available to the component at runtime. The `config` property is generally most useful for making arbitrary data available at runtime via the [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) interface.
+
+⚠️ **NOTE**: Essential configuration options (like specifying ports for an HTTP or Redis server) are typically passed to components and providers through the `source_config` and `target_config` properties of the `link` trait. These properties are covered in the [Traits](#traits) section below, and you can read more about links, sources, and targets on the [Linking at Runtime](/docs/concepts/linking-components/linking-at-runtime.mdx) page.
+
+### Capability providers
+
+To define a **capability provider**, we use a `capability` component, as follows:
 
 ```yaml
-- name: keyvalue
+- name: kvredis
   type: capability
   properties:
-    image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
-    id: kvredis
+    image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
+    # The id field is optional
+    id: keyvalue
+    # The config field is optional
     config:
-      - name: url
-        properties:
-        url: redis://127.0.0.1:6379
+      - name: custom-capability-config
+        properties: 
+          foo: bar
+          log-level: debug
 ```
 
-Just like when manipulating a lattice _imperatively_, the thing that differentiate one capability provider from another is its `id`, which can be specified here or ommitted in favor of wadm generating an identifier (recommended.). Configuration can be specified here for the provider and it will be accessible at runtime via the data passed to the provider, see the [keyvalue-redis](https://github.com/wasmCloud/wasmCloud/blob/main/crates/provider-keyvalue-redis/src/lib.rs#L64) provider for example usage.
+The `id` property is an optional unique identifier you can assign your capability provider. Generally, we recommend omitting the `id` property&mdash;if no value is provided, `wadm` will assign a generated identifier, which is a combination of the manifest name and the component name. This ID differentiates one capability provider from another on the lattice.
+
+Configuration specified in the `config` property will be available at runtime via the data passed to the provider&mdash;see the [keyvalue-redis](https://github.com/wasmCloud/wasmCloud/blob/main/crates/provider-keyvalue-redis/src/lib.rs#L64) provider for example usage. The `config` property is generally most useful for making arbitrary data available at runtime according to the [wasi-runtime-config](https://github.com/WebAssembly/wasi-runtime-config) interface.
+
+⚠️ **NOTE**: Essential configuration options (like specifying ports for an HTTP or Redis server) are typically passed to components and providers through the `source_config` and `target_config` properties of the `link` trait. These properties are covered in the [Traits](#traits) section below, and you can read more about links, sources, and targets on the [Linking at Runtime](/docs/concepts/linking-components/linking-at-runtime.mdx) page.
 
 ## Traits
 
-Traits are, as their name applies, metadata associated with a `component`. The OAM trait system is completely extensible, so as wadm gains more functionality, it can support more traits. Right now, the following traits are supported:
+Traits are metadata associated with a `component`. The following traits are supported:
 
 - `spreadscaler`
 - `daemonscaler`
 - `link`
 
-### Spread Scaler
+### Spreadscaler
 
 The `spreadscaler` trait contains a specification for how you would like to scale a set number of instances of a component. We call it a _spread_ scaler because you declare how you would like the instances of that component spread across the hosts within your lattice by specifying targets with host _labels_. You can think of this like affinity and anti-affinity rules combined with a scale specification.
 
@@ -118,7 +149,7 @@ traits:
         zone: us-west-1
 ```
 
-This definition states that, for this component (a spread scaler can apply to a `component` or `capability`), you want a total of 4 instances, with 80% of them going to hosts with the `zone` label set to `us-east-1` and 20% of them going to hosts with the `zone` label set to `us-west-1`. Because this system uses labels as selectors, and you can set any arbitrary label on your hosts, you can define practically any conditions for the spread rules.
+This definition states that, for this component (a spreadscaler can apply to a `component` or `capability`), you want a total of 4 instances, with 80% of them going to hosts with the `zone` label set to `us-east-1` and 20% of them going to hosts with the `zone` label set to `us-west-1`. Because this system uses labels as selectors, and you can set any arbitrary label on your hosts, you can define practically any conditions for the spread rules.
 
 If you leave the `requirements` section blank then all hosts will be considered possible targets for that component. You can also leave the `spread` definition off so you can simply state that you would like `n` replicas and you don't care where or how you get them:
 
@@ -129,9 +160,9 @@ traits:
     instances: 4
 ```
 
-⚠️ _NOTE_: if you define a label/value pair requirement and wadm is unable to find hosts that match this constraint, it will consider this a deployment failure and will _not_ fall back to arbitrary placement.
+⚠️ **NOTE**: If you define a label/value pair requirement and `wadm` is unable to find hosts that match this constraint, it will consider this a deployment failure and will _not_ fall back to arbitrary placement.
 
-### Daemon Scaler
+### Daemonscaler
 
 The `daemonscaler` trait is an alternative to the `spreadscaler` trait. It is a trait that deploys a certain number of instances of a component on every host in your lattice that matches specified labels. Take a look at the following sample `daemonscaler` spec:
 
@@ -149,7 +180,7 @@ traits:
         zone: us-west-1
 ```
 
-Note that this looks similar to the above `spreadscaler` spec, but the `daemonscaler` is responsible for running a certain number of instances of a component on _every host_ that matches the label requirements. So, instead of running **4** total instances, it will run **4** instances on every host that either has the `zone` label set to `us-east-1` or `us-west-1`. If you leave off the `spread` key entirely, it will run the specified number of instances on _every host_ in your lattice.
+Note that this looks similar to the above `spreadscaler` spec, but the `daemonscaler` is responsible for running a certain number of instances of a component on _every host_ that matches the label requirements. Instead of running four **total** instances, it will run four instances on **every host** that either has the `zone` label set to `us-east-1` or `us-west-1`. If you leave off the `spread` key entirely, it will run the specified number of instances on _every host_ in your lattice.
 
 :::info[For the Kubernetes developer]
 The `daemonscaler` works just like a Kubernetes DaemonSet, spreading components across all hosts that match the label requirements.
@@ -157,89 +188,93 @@ The `daemonscaler` works just like a Kubernetes DaemonSet, spreading components 
 
 ### Links
 
-The `link` trait links two components together with a set of configuration values.
+The `link` trait links two entities together with a set of configuration values.
 
 ```yaml
 # Link to KVredis with local connection
 - type: link
   properties:
-    target: keyvalue
+    target: kvredis
     namespace: wasi
     package: keyvalue
-    interfaces:
-      - atomics
-      - store
+    interfaces: [atomics, store]
     target_config:
-      - name: redis-connect-local
+      - name: redis-url
         properties:
-          URL: redis://127.0.0.1:6379
+          url: redis://127.0.0.1:6379
 ```
 
-The value of the `target` field is a _component_ whose `name` field matches that. The `values` is a simple key-value map that will be passed as link definition configuration data at deployment time. Note that the value here **must be a string**, so if you're passing a value like "false" or "125" ensure that you wrap it in single or double quotes.
+The value of the `target` field is the `name` of the entity (in this case, the `kvredis` capability provider) to which this component is linking. 
+
+The `namespace`, `package`, and `interfaces` fields are used to identify the [interface(s)](/docs/concepts/interfaces.mdx) over which the component and the linked entity will communicate. In the example above, a WebAssembly component is linking to the `kvredis` capability provider over the `wasi:keyvalue/atomics` and `wasi:keyvalue/store` interfaces.
+
+The `target_config` field provides essential configuration data to pass on to the provider&mdash;in the example above, that means the address and port of a local Redis server. This link uses a **`target_config`** (rather than a `source_config`) because the WebAssembly component _imports_ on the `keyvalue` interface. For more information on how to understand and use sources and targets, see the [Linking at Runtime](/docs/concepts/linking-components/linking-at-runtime.mdx) page.
 
 :::info[Target vs source configuration]
 Links include both a `target_config` and a `source_config` field for providing configuration. This can be used to provide configuration values to just the component that needs them. For example, in the above snippet, the _target_ of the link is the Redis provider which needs to know what URL to connect to, and the _source_ of the link is a component that doesn't need that configuration. This is very important for security sensitive configuration that you don't want to expose unnecessarily to additional components.
 :::
 
-### Putting it All Together
+The values in these fields are a simple key-value map that will be passed as link definition configuration data at deployment time. Note that the values here **must be strings**, so if you're passing a value like "false" or "125" ensure that you wrap it in single or double quotes.
 
-So far we've seen bits and pieces of the application specification YAML. The following is an example of a complete manifest:
+## Putting it all together
+
+So far we've seen bits and pieces of the application specification YAML. Here's the complete manifest for the [Extend and Deploy](/docs/tour/extend-and-deploy.mdx) step of the [Quickstart](/docs/tour/hello-world.mdx) example:
 
 ```yaml
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
-  name: kvcounter-rust
+  name: hello-world
   annotations:
-    version: v0.0.1
-    description: 'Kvcounter demo'
+    description: 'HTTP hello world demo'
 spec:
   components:
-    - name: kvcounter
+    # The component with our business logic
+    - name: http-component
       type: component
       properties:
+        # This field can also point to artifacts in OCI registries
         image: file://./build/http_hello_world_s.wasm
       traits:
-        # Govern the spread/scheduling of the component
         - type: spreadscaler
           properties:
             instances: 1
-        # Link to KVredis with local connection
+        # Link definition for http-component -> kvredis
         - type: link
           properties:
-            target: keyvalue
+            target: kvredis
             namespace: wasi
             package: keyvalue
-            interfaces:
-              - atomics
-              - store
+            interfaces: [atomics, store]
             target_config:
-              - name: redis-connect-local
+              - name: redis-url
                 properties:
-                  URL: redis://127.0.0.1:6379
-
-    # Add a capability provider that mediates HTTP access
+                  url: redis://127.0.0.1:6379
+    # The kvredis provider
+    - name: kvredis
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/keyvalue-redis:0.28.2
+    # The httpserver provider
     - name: httpserver
       type: capability
       properties:
-        image: wasmcloud.azurecr.io/httpserver:0.19.1
+        image: ghcr.io/wasmcloud/http-server:0.25.0
       traits:
-        # Link the HTTP server, and inform it to listen on port 8080
-        # on the local machine
+        # Link definition for httpserver -> http-component
         - type: link
           properties:
-            target: http-hello-world
+            target: http-component
             namespace: wasi
             package: http
-            interfaces:
-              - incoming-handler
+            interfaces: [incoming-handler]
             source_config:
-              - name: listen-config
+              - name: default-http
                 properties:
-                  ADDRESS: 127.0.0.1:8080
-    # Add a capability provider that interfaces with the Redis key-value store
-    - name: keyvalue
-      type: capability
-      properties:
-        image: ghcr.io/wasmcloud/keyvalue-redis:0.27.0
+                  address: 127.0.0.1:8000
 ```
+
+## Further reading
+
+* You can find a step-by-step explanation of the source and target linking in the Quickstart manifest on the [Linking at Runtime](/docs/concepts/linking-components/linking-at-runtime#providers) page. 
+* For examples of other application manifests, see the `wadm.yaml` files for the projects in the [**examples** directory of the wasmCloud repository](https://github.com/wasmCloud/wasmCloud/tree/main/examples).


### PR DESCRIPTION
Brings application manifest examples (and explanations of examples) on **Linking at Runtime** and **wadm -> Defining Applications** pages up-to-date.
