### PR TITLE
fix(getting started): type-script errors

### DIFF
--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -156,7 +156,16 @@ impl http::Server for Component {
   <TabItem value="typescript" label="TypeScript">
 
   ```typescript
-  ...
+async function handle(req: IncomingRequest, resp: ResponseOutparam) {
+  // Start building an outgoing response
+  const outgoingResponse = new OutgoingResponse(new Fields());
+
+  // Access the outgoing response body
+  let outgoingBody = outgoingResponse.body();
+  {
+    // Create a stream for the response body
+    let outputStream = outgoingBody.write();
+
     // Write to the response stream
     const name = getNameFromPath(req.pathWithQuery() || '');
 
@@ -164,7 +173,7 @@ impl http::Server for Component {
 
     const sleep = 2000; // [!code ++:3]
     log('info', '', `Sleep for ${sleep} to simulate longer processing time`);
-    await new Proise(resolve => setTimeout(resolve, sleep));
+    await new Promise(resolve => setTimeout(resolve, sleep));
 
     // Increment the bucket's count
     const bucket = open('default');

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -156,7 +156,8 @@ impl http::Server for Component {
   <TabItem value="typescript" label="TypeScript">
 
   ```typescript
-async function handle(req: IncomingRequest, resp: ResponseOutparam) {
+function handle(req: IncomingRequest, resp: ResponseOutparam) { // [!code --]
+async function handle(req: IncomingRequest, resp: ResponseOutparam) { // [!code ++]
   // Start building an outgoing response
   const outgoingResponse = new OutgoingResponse(new Fields());
 


### PR DESCRIPTION
the typescript code in the getting started documentation defined for adding a sleep does not compile. It misses the `async` keyword in front of the `function` definition and there is a typo on the Promise.

