### PR TITLE
fix(ci): Give more permissions for the sync job

### DIFF
--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -6,12 +6,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   sync-docs:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout docs repo


### PR DESCRIPTION
The job was failing when run as a workflow dispatch. Looking at other jobs we have it seems like we need contents: write as well