### PR TITLE
docs: update go repos and packages

### DIFF
--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -374,21 +374,19 @@ let y = wasi::keyvalue::store::function(args);
   <TabItem value="tinygo" label="TinyGo">
 
 ```go
-yourInterface := world.WasmcloudBus1_0_0_LatticeCallTargetInterface().new(
-	"wasi",
-	"keyvalue",
-	"store",
-);
+// Specifies wasi keyvalue store as target interface
+yourInterface := lattice.NewCallTargetInterface("wasi", "keyvalue", "store")
+yourInterfaceSlice := []lattice.CallTargetInterface{yourInterface}
+yourInterfaceList := cm.ToList(yourInterfaceSlice)
 
 // Sets the operative link for interface to the named link foo
-world.WasmcloudBus1_0_0_LatticeSetLinkName("foo", yourInterface);
-// Calls over link foo to perform a keyvalue operation
-let x = world.WasiKeyvalue0_2_0_draft_StoreFunction
+lattice.SetLinkName("foo", yourInterfaceList)
+kvStore := store.Open("default")
 
 // Sets the operative link for interface to the named link bar
-world.WasmcloudBus1_0_0_LatticeSetLinkName("bar", yourInterface);
+lattice.SetLinkName("bar", yourInterfaceList);
 // Calls over link bar to perform a keyvalue operation
-let y = world.WasiKeyvalue0_2_0_draft_StoreFunction
+kvStore := store.Open("default")
 ```
 
   </TabItem>

--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -129,11 +129,6 @@ wasm_target = "wasm32-wasi-preview2"
 wit_world = "hello"
 ```
 
-We also need a folder where the generated bindings will be stored:
-```shell
-mkdir gen
-```
-
 When we run `wash build`, we will generate bindings and compile a component:
 
 ```shell

--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -9,28 +9,30 @@ description: 'How to develop WebAssembly components with Go'
 
 The Go ecosystem provides developers with powerful options for building WebAssembly components. Go and the TinyGo fork provide a strong foundation for development:
 
-* **TinyGo**: The fast-moving implementation of Go for embedded environments includes native compilation to components with WASI 0.2 support as of TinyGo 0.33. 
+* **TinyGo**: The fast-moving implementation of Go for embedded environments includes native compilation to components with WASI 0.2 support as of TinyGo 0.33. Since the project moves quickly, we always recommend using the latest version of TinyGo.
 * **Go** has supported compilation to WebAssembly for years; we expect native WASI 0.2 support like that in TinyGo to land in the near future.
+
+[`wasmCloud/Go`](https://github.com/wasmCloud/go/tree/main) is a repository containing Go ecosystem libraries and examples for wasmCloud. This repo serves as a centralized home for resources including the Component SDK package, component templates, component examples, and more.
 
 ## Go-native tooling
 
 There are a number of useful tools available as Go packages that streamline and simplify the Go development experience:
 
-### `wasm-tools-go`
+### `go.bytecodealliance.org`
 
-[`wasm-tools-go`](https://github.com/bytecodealliance/wasm-tools-go) is a project hosted by the Bytecode Alliance that collects utilities such as `wit-bindgen-go`, which generates Go bindings for WebAssembly Interface Type (WIT) interfaces. 
+**`go.bytecodealliance.org`** ([GitHub](https://github.com/bytecodealliance/go-modules) | [go.pkg.dev](https://pkg.go.dev/go.bytecodealliance.org)) is a Go package hosted by the Bytecode Alliance that collects utilities such as `wit-bindgen-go`, which generates Go bindings for WebAssembly Interface Type (WIT) interfaces. 
 
-### `component-sdk-go`
+### `go.wasmcloud.dev/component`
 
-[The Go Component SDK](https://github.com/wasmCloud/component-sdk-go) is an optional, open source framework that simplifies the development of WebAssembly components targeting the wasmCloud host runtime. The SDK aims to provide a more idiomatic Go development experience for developers using WASI interfaces such as `wasi:http` or `wasi:logging`.
+**The Go Component SDK** ([GitHub](https://github.com/wasmCloud/go/tree/main/component) | [go.pkg.dev](https://pkg.go.dev/go.wasmcloud.dev/component)) is an optional, open source framework that simplifies the development of WebAssembly components targeting the wasmCloud host runtime. The SDK aims to provide a more idiomatic Go development experience for developers using WASI interfaces such as `wasi:http` or `wasi:logging`.
 
-### `wadge`
+### `go.wasmcloud.dev/wadge`
 
-[`wadge`](https://github.com/wasmCloud/wadge) is a "bridging" framework that enables your native code to interact with WebAssembly component interfaces for purposes such as testing. `wadge` acts as a bridge between your Go toolchain and a WebAssembly runtime that makes interfaces “just work” when it's time to test your code. 
+**`wadge`** ([GitHub](https://github.com/wasmCloud/wadge) | [go.pkg.dev](https://pkg.go.dev/go.wasmcloud.dev/wadge)) is a "bridging" framework that enables your native code to interact with WebAssembly component interfaces for purposes such as testing. `wadge` acts as a bridge between your Go toolchain and a WebAssembly runtime that makes interfaces “just work” when it's time to test your code. 
 
 ## Get started
 
-In this walkthrough, we will create an HTTP server from scratch using the [Go component SDK](https://github.com/wasmCloud/component-sdk-go/), write a test for the application, and use `wadge` to run the test. This walkthrough requires:
+In this walkthrough, we will create an HTTP server from scratch using the [Go Component SDK](https://github.com/wasmCloud/go/tree/main/component), write a test for the application, and use `wadge` to run the test. This walkthrough requires:
 
 * [Go](https://go.dev/doc/install) 1.23.0+
 * [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+
@@ -66,7 +68,7 @@ Finally, we'll delete the contents of `main.go` and write our HTTP server, which
 Using the Component SDK, this looks like a fairly standard server using the HTTP standard library, with only a handful of exceptions where we use methods of `wasihttp` or `wasilog`.
 
 ```go
-//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world hello --out gen ./wit
+//go:generate go run go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 
 package main
 
@@ -105,7 +107,7 @@ touch tools.go
 package main
 
 import (
-	_ "github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go"
+	_ "go.bytecodealliance.org/cmd/wit-bindgen-go"
 )
 ```
 
@@ -198,7 +200,7 @@ touch tools.go
 package main
 
 import (
-	_ "github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go"
+	_ "go.bytecodealliance.org/cmd/wit-bindgen-go"
 	_ "go.wasmcloud.dev/wadge/cmd/wadge-bindgen-go" // [!code ++]
 )
 ```
@@ -332,7 +334,7 @@ world hello {
 }
 ```
 
-Add the `wasm-tools-go` package to a `tools.go` file in your project:
+Add the `go.bytecodealliance.org` package to a `tools.go` file in your project:
 
 ```shell
 touch tools.go
@@ -344,7 +346,7 @@ touch tools.go
 package main
 
 import (
-	_ "github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go"
+	_ "go.bytecodealliance.org/cmd/wit-bindgen-go"
 )
 ```
 
@@ -365,7 +367,7 @@ Finally, we'll write our HTTP server in a new `hello.go` file. Using the Compone
 touch hello.go
 ```
 ```go
-//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world hello --out gen ./wit
+//go:generate go run go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 
 package main
 

--- a/docs/developer/languages/go/providers.mdx
+++ b/docs/developer/languages/go/providers.mdx
@@ -8,9 +8,11 @@ description: 'How to develop WebAssembly providers with Go'
 
 # Building providers with Go
 
-wasmCloud provides a complete [SDK for building capability providers in Go](https://github.com/wasmCloud/provider-sdk-go), meaning that Go developers can write every part of a wasmCloud application. 
+wasmCloud provides a complete [SDK for building capability providers in Go](https://github.com/wasmCloud/go/tree/main/provider) (available as the Go package [`go.wasmcloud.dev/provider`](https://pkg.go.dev/go.wasmcloud.dev/provider)), meaning that Go developers can write every part of a wasmCloud application. 
 
-For a listing of WebAssembly+Go tooling, see [**Building components with Go**](/docs/developer/languages/go/components.mdx). 
+[`wasmCloud/Go`](https://github.com/wasmCloud/go/tree/main) is a repository containing Go ecosystem libraries and examples for wasmCloud. This repo serves as a centralized home for resources including the Provider SDK package, provider templates, provider examples, and more.
+
+For a listing of Go component tooling, see [**Building components with Go**](/docs/developer/languages/go/components.mdx). 
 
 ## Get started
 

--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -31,7 +31,7 @@ Let's extend this application to do more than just say "Hello!"
 Using the [FormValue](https://pkg.go.dev/net/http#Request.FormValue) method on the incoming request, we can check the request for a name provided in a query string, and then return a greeting with that name. If there isn't one or the path isn't in the format we expect, we'll default to saying "Hello, World!"
 
 ```go
-//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world hello --out gen ./wit
+//go:generate go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 import (
   "fmt"
   "net/http"
@@ -231,7 +231,7 @@ We've given our application the ability to perform atomic incrementation and sto
 Now let's use the atomic increment function to keep track of how many times we've greeted each person.
 
 ```go
-//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world hello --out gen ./wit
+//go:generate go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 package main
 
 import (

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -51,7 +51,7 @@ Let's try adding a simple `sleep` to the handler to simulate a longer processing
   <TabItem value="tinygo" label="Go">
 
 ```go
-//go:generate go run github.com/bytecodealliance/wasm-tools-go/cmd/wit-bindgen-go generate --world hello --out gen ./wit
+//go:generate go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 package main
 
 import (


### PR DESCRIPTION
* Adds links to the centralized repository for Go + wasmCloud libraries, templates, and examples at https://github.com/wasmcloud/go
* Updates references to `wasm-tools-go` to refer to `go.bytecodealliance.org` package
* Updates references to Go component and provider SDKs to refer to `wasmCloud/go` repository
* Updates bus excerpt on "Linking at Runtime" page to use current Go bindings (more complete example forthcoming in a separate PR
