### PR TITLE
chore(docs): update manual build steps for Go components

### DIFF
--- a/docs/developer/components/build.mdx
+++ b/docs/developer/components/build.mdx
@@ -60,18 +60,10 @@ The `wash build` subcommand performs the same tasks as the following commands us
 ```console
 # Fetch wit dependencies
 wkg wit fetch
-# Generate the types and bindings for the Wasm module
+# Generate the Go types and bindings
 go generate
-# Build the Wasm module
-tinygo build -o ./build/module.wasm -target wasm32-wasi -scheduler none -no-debug .
-# Embed the component wit metadata into the module
-wasm-tools component embed wit ./build/module.wasm > ./build/embed.wasm
-# Create a Wasm component from the embedded Wasm module by using the wasmtime adapter
-wasm-tools component new ./build/embed.wasm -o ./build/component.wasm --adapt ./wasi_snapshot_preview1.wasm
-# Sign the Wasm component with your generated keys, using information in wasmcloud.toml
-wash claims sign ./build/component.wasm --destination ./build/component_s.wasm
-# Remove temporarily created files
-rm ./build/embed.wasm ./build/module.wasm
+# Build the Wasm component
+tinygo build --target=wasip2 --wit-package ./wit --wit-world component
 ```
 
 With native support for Go implemented in `wash build`, the above simplifies to:


### PR DESCRIPTION
Updates the manual steps for building a Go component on `/docs/developer/components/build/?lang=tinygo#language-support`.