### PR TITLE
chore(docs): add advisory on HTTP server provider on K8s

### DIFF
--- a/docs/deployment/k8s/akamai.mdx
+++ b/docs/deployment/k8s/akamai.mdx
@@ -192,7 +192,7 @@ kubectl get services
 ```
 ```text
 NAME             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                        AGE
-hello-world      ClusterIP   10.96.199.43    <none>        8080/TCP                                       11s
+hello-world      ClusterIP   10.96.199.43    <none>        8000/TCP                                       11s
 kubernetes       ClusterIP   10.96.0.1       <none>        443/TCP                                        6m29s
 nats             ClusterIP   10.96.104.180   <none>        4222/TCP,7422/TCP,4223/TCP                     5m36s
 nats-headless    ClusterIP   None            <none>        4222/TCP,7422/TCP,4223/TCP,6222/TCP,8222/TCP   5m36s
@@ -209,10 +209,10 @@ Assign the wasmCloud host pod name to an environment variable:
 ```shell
 WASMCLOUD_HOST_POD=$(kubectl get pods -o jsonpath="{.items[*].metadata.name}" -l app.kubernetes.io/instance=wasmcloud-host)
 ```
-Port-forward the wasmCloud host's port 8080:
+Port-forward the wasmCloud host's port 8000:
 
 ```shell
-kubectl port-forward pods/$WASMCLOUD_HOST_POD 4040:8080
+kubectl port-forward pods/$WASMCLOUD_HOST_POD 4040:8000
 ```
 `curl` the application:
 
@@ -227,10 +227,24 @@ You can use `kubectl` to get logs from the wasmCloud host running on your LKE cl
 ```shell
 kubectl logs -l app.kubernetes.io/instance=wasmcloud-host -c wasmcloud-host
 ```
-#### Common mistakes
+
+You can use a debug pod to test connections to an HTTP application's service from within the cluster:
+
+```shell
+kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- sh
+```
+
+Once the command prompt appears, you can try running `curl` against the service name and port of your application. For the `hello-world` application in the guide above, this would look like:
+
+```shell
+curl hello-world:8000
+```
+
+##### Common mistakes
 
 * If you're having trouble deploying an application, make sure your wadm application manifest references an OCI image and not a local file.
 * If a service is not automatically generated for an application using the httpserver provider, check to ensure that the provider uses `daemonscaler` in the application manifest. (You can see an example of this in the [`hello-world-application` manifest](https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/hello-world-application.yaml).)
+* If you're having trouble connecting to an application that uses the HTTP Server provider, make sure it is configured to use the address `0.0.0.0`. 
 
 ### Manage applications with wash
 

--- a/docs/deployment/k8s/index.mdx
+++ b/docs/deployment/k8s/index.mdx
@@ -145,6 +145,30 @@ hello-world   v0.0.1             v0.0.1           Deployed
 
 When you run a wasmCloud application that uses the `httpserver` provider with a daemonscaler, as this one does, the operator automatically creates a Kubernetes service for the application. 
 
+:::warning[HTTP Server Address]
+When you're using the HTTP Server provider in an application that will run on Kubernetes with the wasmCloud operator, make sure the application manifest configures the provider to use the address `0.0.0.0`, for example:
+
+```yaml {15-15}
+- name: httpserver
+  type: capability
+  properties:
+    image: ghcr.io/wasmcloud/http-server:0.21.0
+  traits:
+    - type: link
+      properties:
+        target: http-component
+        namespace: wasi
+        package: http
+        interfaces: [incoming-handler]
+        source_config:
+          - name: default-http
+            properties:
+              address: 0.0.0.0:8000
+```
+
+Because of the way the application runs within a wasmCloud host pod, using `127.0.0.1` results in networking errors when running on Kubernetes. 
+:::
+
 View services:
 
 ```shell
@@ -152,7 +176,7 @@ kubectl get services
 ```
 ```text
 NAME                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                        AGE
-hello-world          ClusterIP   10.105.170.131   <none>        8080/TCP                                       2m53s
+hello-world          ClusterIP   10.105.170.131   <none>        8000/TCP                                       2m53s
 kubernetes           ClusterIP   10.96.0.1        <none>        443/TCP                                        9m39s
 nats                 ClusterIP   10.102.201.180   <none>        4222/TCP,7422/TCP,4223/TCP                     7m54s
 nats-headless        ClusterIP   None             <none>        4222/TCP,7422/TCP,4223/TCP,6222/TCP,8222/TCP   7m54s
@@ -170,15 +194,15 @@ Assign the wasmCloud host pod name to an environment variable:
 ```shell
 WASMCLOUD_HOST_POD=$(kubectl get pods -o jsonpath="{.items[*].metadata.name}" -l app.kubernetes.io/instance=wasmcloud-host)
 ```
-Port-forward the wasmCloud host's port 8080:
+Port-forward the wasmCloud host's port 8000:
 
 ```shell
-kubectl port-forward pods/$WASMCLOUD_HOST_POD 8080
+kubectl port-forward pods/$WASMCLOUD_HOST_POD 8000
 ```
 `curl` the application:
 
 ```shell
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 You should get the response:
@@ -189,15 +213,29 @@ Hello from Rust!
 
 #### Debugging
 
-You can use `kubectl` to get logs from the wasmCloud host running on your kind cluster:
+You can use `kubectl` to get logs from the wasmCloud host running on your cluster:
 
 ```shell
 kubectl logs -l app.kubernetes.io/instance=wasmcloud-host -c wasmcloud-host
 ```
+
+You can use a debug pod to test connections to an HTTP application's service from within the cluster:
+
+```shell
+kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- sh
+```
+
+Once the command prompt appears, you can try running `curl` against the service name and port of your application. For the `hello-world` application in the guide above, this would look like:
+
+```shell
+curl hello-world:8000
+```
+
 ##### Common mistakes
 
 * If you're having trouble deploying an application, make sure your wadm application manifest references an OCI image and not a local file.
 * If a service is not automatically generated for an application using the httpserver provider, check to ensure that the provider uses `daemonscaler` in the application manifest. (You can see an example of this in the [`hello-world-application` manifest](https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/hello-world-application.yaml).)
+* If you're having trouble connecting to an application that uses the HTTP Server provider, make sure it is configured to use the address `0.0.0.0`. 
 
 #### Manage applications with `wash`
 

--- a/docs/deployment/k8s/kind.mdx
+++ b/docs/deployment/k8s/kind.mdx
@@ -171,7 +171,7 @@ kubectl get services
 ```
 ```text
 NAME             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                        AGE
-hello-world      ClusterIP   10.96.199.43    <none>        8080/TCP                                       11s
+hello-world      ClusterIP   10.96.199.43    <none>        8000/TCP                                       11s
 kubernetes       ClusterIP   10.96.0.1       <none>        443/TCP                                        6m29s
 nats             ClusterIP   10.96.104.180   <none>        4222/TCP,7422/TCP,4223/TCP                     5m36s
 nats-headless    ClusterIP   None            <none>        4222/TCP,7422/TCP,4223/TCP,6222/TCP,8222/TCP   5m36s
@@ -188,15 +188,15 @@ Assign the wasmCloud host pod name to an environment variable:
 ```shell
 WASMCLOUD_HOST_POD=$(kubectl get pods -o jsonpath="{.items[*].metadata.name}" -l app.kubernetes.io/instance=wasmcloud-host)
 ```
-Port-forward the wasmCloud host's port 8080:
+Port-forward the wasmCloud host's port 8000:
 
 ```shell
-kubectl port-forward pods/$WASMCLOUD_HOST_POD 8080
+kubectl port-forward pods/$WASMCLOUD_HOST_POD 8000
 ```
 `curl` the application:
 
 ```shell
-curl http://localhost:8080
+curl http://localhost:8000
 ```
 
 ### Debugging
@@ -206,10 +206,24 @@ You can use `kubectl` to get logs from the wasmCloud host running on your kind c
 ```shell
 kubectl logs -l app.kubernetes.io/instance=wasmcloud-host -c wasmcloud-host
 ```
-#### Common mistakes
+
+You can use a debug pod to test connections to an HTTP application's service from within the cluster:
+
+```shell
+kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- sh
+```
+
+Once the command prompt appears, you can try running `curl` against the service name and port of your application. For the `hello-world` application in the guide above, this would look like:
+
+```shell
+curl hello-world:8000
+```
+
+##### Common mistakes
 
 * If you're having trouble deploying an application, make sure your wadm application manifest references an OCI image and not a local file.
 * If a service is not automatically generated for an application using the httpserver provider, check to ensure that the provider uses `daemonscaler` in the application manifest. (You can see an example of this in the [`hello-world-application` manifest](https://raw.githubusercontent.com/wasmCloud/wasmcloud-operator/main/examples/quickstart/hello-world-application.yaml).)
+* If you're having trouble connecting to an application that uses the HTTP Server provider, make sure it is configured to use the address `0.0.0.0`. 
 
 ### Manage applications with wash
 


### PR DESCRIPTION
Updates for consistency with wasmcloud-operator's [hello-world](https://github.com/wasmCloud/wasmcloud-operator/blob/main/examples/quickstart/hello-world-application.yaml) and emphasizes the requirement to use 0.0.0.0 in HTTP server provider config.
