### PR TITLE
chore(docs): update http server artifact version

### DIFF
--- a/docs/concepts/applications.mdx
+++ b/docs/concepts/applications.mdx
@@ -57,7 +57,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         # Link the HTTP server and set it to listen on the local machine's port 8080
         - type: link
@@ -69,7 +69,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  ADDRESS: 127.0.0.1:8080
+                  ADDRESS: 0.0.0.0:8000
 ```
 
 :::info[Write less YAML]

--- a/docs/concepts/linking-components/linking-at-runtime.mdx
+++ b/docs/concepts/linking-components/linking-at-runtime.mdx
@@ -206,10 +206,10 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         - type: link
           properties:
             target: http-component
@@ -219,7 +219,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 0.0.0.0:8000
 ```
 
 - The http-component is **exporting on the wasi-http interface** and **importing on a custom "pingpong" interface**. It is the importer in relation to the pong-component, so it is the source for that link.
@@ -284,7 +284,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.25.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         # Link definition for httpserver -> http-component
         - type: link
@@ -296,7 +296,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8000
+                  address: 0.0.0.0:8000
 ```
 
 - The http-component is **importing functions on the keyvalue interface**. It is the **importer** in relation to **kvredis**, meaning that it is the source for the link definition: the link is defined as a trait of http-component.

--- a/docs/concepts/packaging.mdx
+++ b/docs/concepts/packaging.mdx
@@ -49,7 +49,7 @@ Once a component or provider is published to a registry, you can include it in a
 - name: http-server
   type: capability
   properties:
-    image: ghcr.io/wasmcloud/http-server:0.23.2
+    image: ghcr.io/wasmcloud/http-server:0.26.0
 ```
 
 In the manifest excerpt above, the `http-server` capability provider is included in an application via an artifact (or "image") stored on a GitHub Packages registry. You can learn more about application manifests on the [Defining Applications](/docs/ecosystem/wadm/model) page.

--- a/docs/concepts/secrets.mdx
+++ b/docs/concepts/secrets.mdx
@@ -190,11 +190,11 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.23.1
+        image: ghcr.io/wasmcloud/http-server:0.26.0
         id: auth-http-server
       traits:
         # Link the httpserver to the component, and configure the HTTP server
-        # to listen on port 8080 for incoming requests
+        # to listen on port 8000 for incoming requests
         #
         # Since the HTTP server calls the `counter` component, we establish
         # a unidirectional link from this `httpserver` provider (the "source")
@@ -211,7 +211,7 @@ spec:
               config:
                 - name: default-http
                   properties:
-                    address: 0.0.0.0:8080
+                    address: 0.0.0.0:8000
 ```
 
 ## Defining secrets on the command line
@@ -469,21 +469,21 @@ You can first verify that unauthenticated requests to Redis and the component ar
 ➜ redis-cli -u redis://127.0.0.1:6379 keys '*'
 (error) NOAUTH Authentication required.
 
-➜ curl 127.0.0.1:8080/counter
+➜ curl 127.0.0.1:8000/counter
 Unauthorized
 ```
 
 Then, authenticating passes the check in the component:
 
 ```bash
-➜ curl -H "password: opensesame" 127.0.0.1:8080/counter
+➜ curl -H "password: opensesame" 127.0.0.1:8000/counter
 Counter /counter: 1
 ```
 
 Passing in an invalid password will still fail the authentication check:
 
 ```bash
-➜ curl -H "password: letmein" 127.0.0.1:8080/counter
+➜ curl -H "password: letmein" 127.0.0.1:8000/counter
 Unauthorized
 ```
 

--- a/docs/deployment/k8s/index.mdx
+++ b/docs/deployment/k8s/index.mdx
@@ -152,7 +152,7 @@ When you're using the HTTP Server provider in an application that will run on Ku
 - name: httpserver
   type: capability
   properties:
-    image: ghcr.io/wasmcloud/http-server:0.21.0
+    image: ghcr.io/wasmcloud/http-server:0.26.0
   traits:
     - type: link
       properties:

--- a/docs/developer/components/configure.mdx
+++ b/docs/developer/components/configure.mdx
@@ -198,7 +198,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         - type: link
           properties:

--- a/docs/developer/providers/configure.mdx
+++ b/docs/developer/providers/configure.mdx
@@ -195,7 +195,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         - type: link
           properties:

--- a/docs/ecosystem/wadm/model.md
+++ b/docs/ecosystem/wadm/model.md
@@ -259,7 +259,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.25.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         # Link definition for httpserver -> http-component
         - type: link
@@ -271,7 +271,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8000
+                  address: 0.0.0.0:8000
 ```
 
 ## Further reading

--- a/docs/examples/rust/providers/http-server/index.md
+++ b/docs/examples/rust/providers/http-server/index.md
@@ -75,7 +75,7 @@ components:
   - name: httpserver
     type: capability
     properties:
-      image: ghcr.io/wasmcloud/http-server:0.25.0
+      image: ghcr.io/wasmcloud/http-server:0.26.0
       config:
         - name: http-config
           properties:

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -69,7 +69,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.25.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         - type: link
           properties:
@@ -80,7 +80,7 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8000
+                  address: 0.0.0.0:8000
 ```
 
 * `kvredis` is defined as a `capability` provider and fetched from an OCI image.


### PR DESCRIPTION
Update HTTP server provider artifact version to 0.26 across docs. (Also updates address to 0.0.0.0:8000 consistently where relevant.)