### PR TITLE
feat(docs): add robots.txt and noindex 0.82 docs

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /docs/0.82/
+
+Sitemap: https://wasmcloud.com/sitemap.xml

--- a/versioned_docs/version-0.82/cli/app.md
+++ b/versioned_docs/version-0.82/cli/app.md
@@ -6,7 +6,7 @@ description: "wash app command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 When deploying apps using [wadm](../ecosystem/wadm/index.md), the easiest way to manage these apps is using `wash app`. `wash app` provides us with all the tools needed to add, remove and get the necessary details of your deployed as well as undeployed applications. Following are the subcommands available under `wash app`.

--- a/versioned_docs/version-0.82/cli/app.md
+++ b/versioned_docs/version-0.82/cli/app.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 description: "wash app command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 When deploying apps using [wadm](../ecosystem/wadm/index.md), the easiest way to manage these apps is using `wash app`. `wash app` provides us with all the tools needed to add, remove and get the necessary details of your deployed as well as undeployed applications. Following are the subcommands available under `wash app`.
 
 - `list`

--- a/versioned_docs/version-0.82/cli/build.md
+++ b/versioned_docs/version-0.82/cli/build.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 description: "wash build command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash build` enables you to build and sign custom wasmCloud entities like actors, providers, or interfaces. You can bring in your own project containing some business logic and build these entities by simply providing the path to the project or its associated `wasmcloud.toml` file. The built artifact is signed using automatically generated keys. Alternatively, you may use your own keys to sign the build.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/build.md
+++ b/versioned_docs/version-0.82/cli/build.md
@@ -6,7 +6,7 @@ description: "wash build command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash build` enables you to build and sign custom wasmCloud entities like actors, providers, or interfaces. You can bring in your own project containing some business logic and build these entities by simply providing the path to the project or its associated `wasmcloud.toml` file. The built artifact is signed using automatically generated keys. Alternatively, you may use your own keys to sign the build.

--- a/versioned_docs/version-0.82/cli/call.md
+++ b/versioned_docs/version-0.82/cli/call.md
@@ -6,7 +6,7 @@ description: "wash call command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Wash call can be used to directly invoke an actor. This can be useful when debugging, especially when the actor isn't directly accessible via external channels such as HTTP. It is not recommended to use wash call in production environments.

--- a/versioned_docs/version-0.82/cli/call.md
+++ b/versioned_docs/version-0.82/cli/call.md
@@ -5,6 +5,10 @@ sidebar_position: 3
 description: "wash call command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Wash call can be used to directly invoke an actor. This can be useful when debugging, especially when the actor isn't directly accessible via external channels such as HTTP. It is not recommended to use wash call in production environments.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/capture.md
+++ b/versioned_docs/version-0.82/cli/capture.md
@@ -5,7 +5,9 @@ sidebar_position: 4
 description: "wash capture command reference"
 --- 
 
-v
+<head>
+  <meta name="robots" content="noindex" />
+</head>
 
 Wash capture helps in capturing snapshots of the state of a lattice and assists in debugging cluster invocations using operations like replay. This is currently an experimental feature and you would have to pass the `--experimental` flag or set the `WASH_EXPERIMENTAL` environment variable to true. This tool provides three options - enable capture mode, disable capture mode or replay a captured file. A user must first enable capture mode by passing the `--enable` flag. Once capture mode is enabled, a user can capture snapshots at any time by running `wash capture --experimental`, which will download the snapshot file to the current directory. The snapshot files can be viewed by passing the file path to the `replay` subcommand. To disable capture mode, pass the `--disable` flag. 
 

--- a/versioned_docs/version-0.82/cli/capture.md
+++ b/versioned_docs/version-0.82/cli/capture.md
@@ -5,6 +5,10 @@ sidebar_position: 4
 description: "wash capture command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Wash capture helps in capturing snapshots of the state of a lattice and assists in debugging cluster invocations using operations like replay. This is currently an experimental feature and you would have to pass the `--experimental` flag or set the `WASH_EXPERIMENTAL` environment variable to true. This tool provides three options - enable capture mode, disable capture mode or replay a captured file. A user must first enable capture mode by passing the `--enable` flag. Once capture mode is enabled, a user can capture snapshots at any time by running `wash capture --experimental`, which will download the snapshot file to the current directory. The snapshot files can be viewed by passing the file path to the `replay` subcommand. To disable capture mode, pass the `--disable` flag. 
 
 :::info

--- a/versioned_docs/version-0.82/cli/capture.md
+++ b/versioned_docs/version-0.82/cli/capture.md
@@ -5,9 +5,7 @@ sidebar_position: 4
 description: "wash capture command reference"
 --- 
 
-<head>
-  <meta name="robots" content="noindex">
-</head>
+v
 
 Wash capture helps in capturing snapshots of the state of a lattice and assists in debugging cluster invocations using operations like replay. This is currently an experimental feature and you would have to pass the `--experimental` flag or set the `WASH_EXPERIMENTAL` environment variable to true. This tool provides three options - enable capture mode, disable capture mode or replay a captured file. A user must first enable capture mode by passing the `--enable` flag. Once capture mode is enabled, a user can capture snapshots at any time by running `wash capture --experimental`, which will download the snapshot file to the current directory. The snapshot files can be viewed by passing the file path to the `replay` subcommand. To disable capture mode, pass the `--disable` flag. 
 

--- a/versioned_docs/version-0.82/cli/claims.md
+++ b/versioned_docs/version-0.82/cli/claims.md
@@ -6,7 +6,7 @@ description: "wash claims command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Every actor in a wasmCloud environment claims its capabilities or the features it can interact with to supplement its current behavior. These capabilities are claimed in the form of JSON Web Tokens (JWTs). `wash claims` will assist you to generate, manage and view these JWTs for wasmCloud actors. Following are the subcommands available under `wash claims`.

--- a/versioned_docs/version-0.82/cli/claims.md
+++ b/versioned_docs/version-0.82/cli/claims.md
@@ -5,6 +5,10 @@ sidebar_position: 5
 description: "wash claims command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Every actor in a wasmCloud environment claims its capabilities or the features it can interact with to supplement its current behavior. These capabilities are claimed in the form of JSON Web Tokens (JWTs). `wash claims` will assist you to generate, manage and view these JWTs for wasmCloud actors. Following are the subcommands available under `wash claims`.
 
 - `inspect`

--- a/versioned_docs/version-0.82/cli/completions.md
+++ b/versioned_docs/version-0.82/cli/completions.md
@@ -6,7 +6,7 @@ description: "wash completions command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Shell completions for wash commands can be enabled with the use of `wash completions`. This feature will help you to easily navigate the CLI interface as it will recommend auto-completions for wash subcommands. Currently, shell completions can be generated for the following supported shell types:

--- a/versioned_docs/version-0.82/cli/completions.md
+++ b/versioned_docs/version-0.82/cli/completions.md
@@ -5,6 +5,10 @@ sidebar_position: 6
 description: "wash completions command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Shell completions for wash commands can be enabled with the use of `wash completions`. This feature will help you to easily navigate the CLI interface as it will recommend auto-completions for wash subcommands. Currently, shell completions can be generated for the following supported shell types:
 
 - `zsh`

--- a/versioned_docs/version-0.82/cli/ctx.md
+++ b/versioned_docs/version-0.82/cli/ctx.md
@@ -6,7 +6,7 @@ description: "wash ctx command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash ctx` provides a user with tools to interact with wasmCloud host configuration contexts. By default, the host configuration context is stored in a `host_config.json` file in your `$HOME/.wash/contexts` directory. This command will help you to interactively manage host contexts by performing operations such as addition, removal and editing of contexts. Following are the available subcommands under `wash ctx`:

--- a/versioned_docs/version-0.82/cli/ctx.md
+++ b/versioned_docs/version-0.82/cli/ctx.md
@@ -5,6 +5,10 @@ sidebar_position: 7
 description: "wash ctx command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash ctx` provides a user with tools to interact with wasmCloud host configuration contexts. By default, the host configuration context is stored in a `host_config.json` file in your `$HOME/.wash/contexts` directory. This command will help you to interactively manage host contexts by performing operations such as addition, removal and editing of contexts. Following are the available subcommands under `wash ctx`:
 
 - `list`

--- a/versioned_docs/version-0.82/cli/dev.md
+++ b/versioned_docs/version-0.82/cli/dev.md
@@ -6,7 +6,7 @@ description: "wash dev command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Starts a local dev loop for an actor. Takes a local `wasmcloud.toml` file to deploy the specified actor and accepts a host ID to specify the host to deploy on. This is an experimental feature and needs `--experimental` flag to run.

--- a/versioned_docs/version-0.82/cli/dev.md
+++ b/versioned_docs/version-0.82/cli/dev.md
@@ -5,6 +5,10 @@ sidebar_position: 8
 description: "wash dev command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Starts a local dev loop for an actor. Takes a local `wasmcloud.toml` file to deploy the specified actor and accepts a host ID to specify the host to deploy on. This is an experimental feature and needs `--experimental` flag to run.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/down.md
+++ b/versioned_docs/version-0.82/cli/down.md
@@ -5,6 +5,10 @@ sidebar_position: 9
 description: "wash down command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command will stop all the resources started by `wash up`. Primarily, it will stop the wasmCloud host and NATS leaf that were started on your local machine. If there is a single host running on your machine, `wash down` will stop that singular host. In case of multiple hosts, the user gets a choice to stop a specific host or all the running hosts on the system. To stop a specific host in a multiple host scenario, pass the `--host-id` flag to the command. To stop currently running hosts, pass the `--all` flag.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/down.md
+++ b/versioned_docs/version-0.82/cli/down.md
@@ -6,7 +6,7 @@ description: "wash down command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command will stop all the resources started by `wash up`. Primarily, it will stop the wasmCloud host and NATS leaf that were started on your local machine. If there is a single host running on your machine, `wash down` will stop that singular host. In case of multiple hosts, the user gets a choice to stop a specific host or all the running hosts on the system. To stop a specific host in a multiple host scenario, pass the `--host-id` flag to the command. To stop currently running hosts, pass the `--all` flag.

--- a/versioned_docs/version-0.82/cli/drain.md
+++ b/versioned_docs/version-0.82/cli/drain.md
@@ -5,6 +5,10 @@ sidebar_position: 10
 description: "wash drain command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Wash drain helps you in managing contents of local wasmCloud caches. This command allows you to clear caches selectively for various items downloaded while working on a wasmCloud environment. Following are the subcommands available under `wash drain`:
 
 - `all`

--- a/versioned_docs/version-0.82/cli/drain.md
+++ b/versioned_docs/version-0.82/cli/drain.md
@@ -6,7 +6,7 @@ description: "wash drain command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Wash drain helps you in managing contents of local wasmCloud caches. This command allows you to clear caches selectively for various items downloaded while working on a wasmCloud environment. Following are the subcommands available under `wash drain`:

--- a/versioned_docs/version-0.82/cli/get.md
+++ b/versioned_docs/version-0.82/cli/get.md
@@ -6,7 +6,7 @@ description: "wash get command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Wash get helps you in retrieving information about your lattice. It can help you retrieve all the links in the lattice, hosts, their inventories and claims. Following are the subcommands available under `wash get`:

--- a/versioned_docs/version-0.82/cli/get.md
+++ b/versioned_docs/version-0.82/cli/get.md
@@ -5,6 +5,10 @@ sidebar_position: 11
 description: "wash get command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Wash get helps you in retrieving information about your lattice. It can help you retrieve all the links in the lattice, hosts, their inventories and claims. Following are the subcommands available under `wash get`:
 
 - `links`

--- a/versioned_docs/version-0.82/cli/index.md
+++ b/versioned_docs/version-0.82/cli/index.md
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 **_wash_** (the _wasmCloud Shell_) is a single command-line interface (CLI) to handle all of your wasmCloud tooling needs. This CLI has a number of sub-commands that help you interact with the wasmCloud ecosystem.

--- a/versioned_docs/version-0.82/cli/index.md
+++ b/versioned_docs/version-0.82/cli/index.md
@@ -6,6 +6,10 @@ description: 'The wasmCloud Shell (wash) CLI'
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 **_wash_** (the _wasmCloud Shell_) is a single command-line interface (CLI) to handle all of your wasmCloud tooling needs. This CLI has a number of sub-commands that help you interact with the wasmCloud ecosystem.
 
 ```

--- a/versioned_docs/version-0.82/cli/inspect.md
+++ b/versioned_docs/version-0.82/cli/inspect.md
@@ -6,7 +6,7 @@ description: "wash inspect command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Inspect helps you to examine the capabilities of a wasmCloud component. It accepts the path to the wasmCloud actor or provider and prints out the properties of that component.

--- a/versioned_docs/version-0.82/cli/inspect.md
+++ b/versioned_docs/version-0.82/cli/inspect.md
@@ -5,6 +5,10 @@ sidebar_position: 12
 description: "wash inspect command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Inspect helps you to examine the capabilities of a wasmCloud component. It accepts the path to the wasmCloud actor or provider and prints out the properties of that component.
 
 #### Usage

--- a/versioned_docs/version-0.82/cli/keys.md
+++ b/versioned_docs/version-0.82/cli/keys.md
@@ -6,7 +6,7 @@ description: "wash keys command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command helps a user to generate NATS keys and manage them. Following are the subcommands available under `wash keys`.

--- a/versioned_docs/version-0.82/cli/keys.md
+++ b/versioned_docs/version-0.82/cli/keys.md
@@ -5,6 +5,10 @@ sidebar_position: 13
 description: "wash keys command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command helps a user to generate NATS keys and manage them. Following are the subcommands available under `wash keys`.
 
 - `gen`

--- a/versioned_docs/version-0.82/cli/link.md
+++ b/versioned_docs/version-0.82/cli/link.md
@@ -5,6 +5,10 @@ sidebar_position: 15
 description: "wash link command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command will assist you to add remove and query all the links in the lattice. Following are the subcommands available in `wash link`:
 
 - `query`

--- a/versioned_docs/version-0.82/cli/link.md
+++ b/versioned_docs/version-0.82/cli/link.md
@@ -6,7 +6,7 @@ description: "wash link command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command will assist you to add remove and query all the links in the lattice. Following are the subcommands available in `wash link`:

--- a/versioned_docs/version-0.82/cli/new.md
+++ b/versioned_docs/version-0.82/cli/new.md
@@ -5,6 +5,10 @@ sidebar_position: 16
 description: "wash new command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command creates a new project from an existing template. A user may create an actor, provider or an interface project. This command takes you through the process in an interactive way. Following are the subcommands available under `wash new`:
 
 - `actor`

--- a/versioned_docs/version-0.82/cli/new.md
+++ b/versioned_docs/version-0.82/cli/new.md
@@ -6,7 +6,7 @@ description: "wash new command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command creates a new project from an existing template. A user may create an actor, provider or an interface project. This command takes you through the process in an interactive way. Following are the subcommands available under `wash new`:

--- a/versioned_docs/version-0.82/cli/par.md
+++ b/versioned_docs/version-0.82/cli/par.md
@@ -5,6 +5,10 @@ sidebar_position: 17
 description: "wash par command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash par` gives a user the capacity to interact with provider archives. A user may create, inspect or modify provider archive files. Following are the subcommands available under `wash par`.
 
 - `create`

--- a/versioned_docs/version-0.82/cli/par.md
+++ b/versioned_docs/version-0.82/cli/par.md
@@ -6,7 +6,7 @@ description: "wash par command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash par` gives a user the capacity to interact with provider archives. A user may create, inspect or modify provider archive files. Following are the subcommands available under `wash par`.

--- a/versioned_docs/version-0.82/cli/pull.md
+++ b/versioned_docs/version-0.82/cli/pull.md
@@ -5,6 +5,10 @@ sidebar_position: 19
 description: "wash pull command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command pulls an artifact from an OCI compliant registry.
 
 #### Usage

--- a/versioned_docs/version-0.82/cli/pull.md
+++ b/versioned_docs/version-0.82/cli/pull.md
@@ -6,7 +6,7 @@ description: "wash pull command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command pulls an artifact from an OCI compliant registry.

--- a/versioned_docs/version-0.82/cli/push.md
+++ b/versioned_docs/version-0.82/cli/push.md
@@ -6,7 +6,7 @@ description: "wash push command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Push an artifact to an OCI compliant registry. A user needs to provide a registry URL and the path to the artifact that needs to be pushed.

--- a/versioned_docs/version-0.82/cli/push.md
+++ b/versioned_docs/version-0.82/cli/push.md
@@ -5,6 +5,10 @@ sidebar_position: 20
 description: "wash push command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Push an artifact to an OCI compliant registry. A user needs to provide a registry URL and the path to the artifact that needs to be pushed.
 
 #### Usage

--- a/versioned_docs/version-0.82/cli/reg.md
+++ b/versioned_docs/version-0.82/cli/reg.md
@@ -6,7 +6,7 @@ description: "wash reg command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash reg` allows users to interact with OCI compliant registries and their artifacts. A user may pull artifacts from the registry to use in their projects. They may also push their own projects to registries to use in various lattices. Following are the subcommands available under `wash reg`.

--- a/versioned_docs/version-0.82/cli/reg.md
+++ b/versioned_docs/version-0.82/cli/reg.md
@@ -5,6 +5,10 @@ sidebar_position: 18
 description: "wash reg command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash reg` allows users to interact with OCI compliant registries and their artifacts. A user may pull artifacts from the registry to use in their projects. They may also push their own projects to registries to use in various lattices. Following are the subcommands available under `wash reg`.
 
 - `push`

--- a/versioned_docs/version-0.82/cli/scale.md
+++ b/versioned_docs/version-0.82/cli/scale.md
@@ -5,6 +5,10 @@ sidebar_position: 22
 description: 'wash scale command reference'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash scale` supports scaling the actors in your lattice to handle concurrent requests. It accepts the host ID on which the actor is running and the reference of the actor to scale as required arguments. It also accepts a `--max-concurrent` value that specifies the maximum number of instances this actor can run concurrently. By default, the value is an unbounded level of concurrency. A value of zero is equivalent to stopping the actor.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/scale.md
+++ b/versioned_docs/version-0.82/cli/scale.md
@@ -6,7 +6,7 @@ description: 'wash scale command reference'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash scale` supports scaling the actors in your lattice to handle concurrent requests. It accepts the host ID on which the actor is running and the reference of the actor to scale as required arguments. It also accepts a `--max-concurrent` value that specifies the maximum number of instances this actor can run concurrently. By default, the value is an unbounded level of concurrency. A value of zero is equivalent to stopping the actor.

--- a/versioned_docs/version-0.82/cli/spy.md
+++ b/versioned_docs/version-0.82/cli/spy.md
@@ -6,7 +6,7 @@ description: "wash spy command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command will spy on all invocations between an actor and its linked providers. This is an experimental command and needs the `--experimental` flag passed to it. The user will pass the actor ID or actor name to this command to spy on. If an actor name is passed, it will be resolved to an ID. If multiple actors have the same name, the user will be prompted to pick the desired one.

--- a/versioned_docs/version-0.82/cli/spy.md
+++ b/versioned_docs/version-0.82/cli/spy.md
@@ -5,6 +5,10 @@ sidebar_position: 21
 description: "wash spy command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command will spy on all invocations between an actor and its linked providers. This is an experimental command and needs the `--experimental` flag passed to it. The user will pass the actor ID or actor name to this command to spy on. If an actor name is passed, it will be resolved to an ID. If multiple actors have the same name, the user will be prompted to pick the desired one.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/start.md
+++ b/versioned_docs/version-0.82/cli/start.md
@@ -5,6 +5,10 @@ sidebar_position: 23
 description: "wash start command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash start` assists in launching an actor or a provider from an OCI reference on a host. The user may specify if they want to start an actor or a provider and pass the OCI reference of that entity to the command. By default, the actor or provider are auctioned in the lattice for a suitable host. To specify a host to launch the actor or provider, pass the host ID using the `--host-id` flag. Actors or providers can also be started from local files using the prefix `file://` followed by the file path. By default, loading from files is permitted when you start the host using `wash up` and can be disabled using the `WASMCLOUD_ALLOW_FILE_LOAD` environment variable. If the host is started from the binary instead of `wash up`, loading from files is disabled. Following are the available subcommads under `wash start`:
 
 - `actor`

--- a/versioned_docs/version-0.82/cli/start.md
+++ b/versioned_docs/version-0.82/cli/start.md
@@ -6,7 +6,7 @@ description: "wash start command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash start` assists in launching an actor or a provider from an OCI reference on a host. The user may specify if they want to start an actor or a provider and pass the OCI reference of that entity to the command. By default, the actor or provider are auctioned in the lattice for a suitable host. To specify a host to launch the actor or provider, pass the host ID using the `--host-id` flag. Actors or providers can also be started from local files using the prefix `file://` followed by the file path. By default, loading from files is permitted when you start the host using `wash up` and can be disabled using the `WASMCLOUD_ALLOW_FILE_LOAD` environment variable. If the host is started from the binary instead of `wash up`, loading from files is disabled. Following are the available subcommads under `wash start`:

--- a/versioned_docs/version-0.82/cli/stop.md
+++ b/versioned_docs/version-0.82/cli/stop.md
@@ -5,6 +5,10 @@ sidebar_position: 24
 description: "wash stop command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash stop` allows you to stop an actor, provider or a host. The user may specify if they want to stop an actor or a provider and pass the OCI reference of that entity to the command. To specify a host to stop the actor or provider, pass the host ID using the `--host-id` flag. Following are the available subcommads:
 
 - `actor`

--- a/versioned_docs/version-0.82/cli/stop.md
+++ b/versioned_docs/version-0.82/cli/stop.md
@@ -6,7 +6,7 @@ description: "wash stop command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash stop` allows you to stop an actor, provider or a host. The user may specify if they want to stop an actor or a provider and pass the OCI reference of that entity to the command. To specify a host to stop the actor or provider, pass the host ID using the `--host-id` flag. Following are the available subcommads:

--- a/versioned_docs/version-0.82/cli/ui.md
+++ b/versioned_docs/version-0.82/cli/ui.md
@@ -6,7 +6,7 @@ description: "wash ui command reference"
 --- 
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This command starts a wasmCloud web UI called the washboard. This is an experimental feature and needs the `--experimental` flag passed to the command in order to be run. By default the UI runs on port 3030. To run on a different port, pass the port number to the `--port` flag.

--- a/versioned_docs/version-0.82/cli/ui.md
+++ b/versioned_docs/version-0.82/cli/ui.md
@@ -5,6 +5,10 @@ sidebar_position: 25
 description: "wash ui command reference"
 --- 
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This command starts a wasmCloud web UI called the washboard. This is an experimental feature and needs the `--experimental` flag passed to the command in order to be run. By default the UI runs on port 3030. To run on a different port, pass the port number to the `--port` flag.
 
 ### Usage

--- a/versioned_docs/version-0.82/cli/up.md
+++ b/versioned_docs/version-0.82/cli/up.md
@@ -6,7 +6,7 @@ description: "wash up command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash up` lets you easily start a wasmCloud host to play around or develop with. To start off, it spins up a NATS Server (if you don't have one running) on port `4222` and along with it a wasmCloud host. It also starts wadm to manage your declarative deployments. If you successively run `wash up` it will spawn multiple wasmCloud hosts that will connect to the originally created NATS server. By default, the host runs in an interactive mode in your terminal. If you add a `-d` flag to this command, the host will run in a detached mode.

--- a/versioned_docs/version-0.82/cli/up.md
+++ b/versioned_docs/version-0.82/cli/up.md
@@ -5,6 +5,10 @@ sidebar_position: 26
 description: "wash up command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash up` lets you easily start a wasmCloud host to play around or develop with. To start off, it spins up a NATS Server (if you don't have one running) on port `4222` and along with it a wasmCloud host. It also starts wadm to manage your declarative deployments. If you successively run `wash up` it will spawn multiple wasmCloud hosts that will connect to the originally created NATS server. By default, the host runs in an interactive mode in your terminal. If you add a `-d` flag to this command, the host will run in a detached mode.
 
 Usage:

--- a/versioned_docs/version-0.82/cli/update.md
+++ b/versioned_docs/version-0.82/cli/update.md
@@ -6,7 +6,7 @@ description: "wash update command reference"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wash update` updates an actor running in a host to a new reference. The user may supply the actor ID, its host ID and the new OCI reference of the actor that needs to replace the actor in this actor ID.

--- a/versioned_docs/version-0.82/cli/update.md
+++ b/versioned_docs/version-0.82/cli/update.md
@@ -5,6 +5,10 @@ sidebar_position: 27
 description: "wash update command reference"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wash update` updates an actor running in a host to a new reference. The user may supply the actor ID, its host ID and the new OCI reference of the actor that needs to replace the actor in this actor ID.
 
 #### Usage

--- a/versioned_docs/version-0.82/concepts/actors.mdx
+++ b/versioned_docs/version-0.82/concepts/actors.mdx
@@ -8,7 +8,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/concepts/actors.mdx
+++ b/versioned_docs/version-0.82/concepts/actors.mdx
@@ -7,6 +7,10 @@ sidebar_position: 3
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/concepts/applications.mdx
+++ b/versioned_docs/version-0.82/concepts/applications.mdx
@@ -6,6 +6,10 @@ sidebar_position: 7
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 Applications combine all of the previous concepts into a declarative, deployable unit. wasmCloud supports the imperative management of [actors](/docs/0.82/concepts/actors), [providers](/docs/0.82/concepts/capabilities), and [links](/docs/0.82/concepts/runtime-linking), which can be useful for experimentation or debugging. However, these are generally considered low-level operations. wasmCloud supports complex distributed applications that can be dynamically adjusted at runtime, and managing a combination of actors, providers, links, and configuration one command at a time quickly becomes unwieldy.

--- a/versioned_docs/version-0.82/concepts/applications.mdx
+++ b/versioned_docs/version-0.82/concepts/applications.mdx
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/capabilities.mdx
+++ b/versioned_docs/version-0.82/concepts/capabilities.mdx
@@ -7,6 +7,10 @@ sidebar_position: 4
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 A **_capability_** is an abstraction over a non-functional requirement, some functionality that is not considered part of the core business logic. Actors depend on capabilities to fulfill their business logic, and these capabilities are provided by — you guessed it — **_capability providers_**.

--- a/versioned_docs/version-0.82/concepts/capabilities.mdx
+++ b/versioned_docs/version-0.82/concepts/capabilities.mdx
@@ -8,7 +8,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/hosts.mdx
+++ b/versioned_docs/version-0.82/concepts/hosts.mdx
@@ -6,6 +6,10 @@ sidebar_position: 2
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 The wasmCloud **host** is an application runtime. The host is responsible for loading, instantiating, and communicating among WebAssembly components and capability providers, in a secure, distributed way.

--- a/versioned_docs/version-0.82/concepts/hosts.mdx
+++ b/versioned_docs/version-0.82/concepts/hosts.mdx
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/interface-driven-development.mdx
+++ b/versioned_docs/version-0.82/concepts/interface-driven-development.mdx
@@ -8,7 +8,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/interface-driven-development.mdx
+++ b/versioned_docs/version-0.82/concepts/interface-driven-development.mdx
@@ -7,6 +7,10 @@ sidebar_position: 5
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 Interface Driven Development (**IDD**), aka contract-driven development, is a development approach that _focuses on defining **what** components need before **how** to meet those needs_.

--- a/versioned_docs/version-0.82/concepts/lattice.mdx
+++ b/versioned_docs/version-0.82/concepts/lattice.mdx
@@ -6,6 +6,10 @@ sidebar_position: 1
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 The lattice is a self-forming, self-healing mesh network that provides a unified, flat topology across any number of environments, clouds, browsers, or even hardware. A lattice allows [actors](/docs/0.82/concepts/actors), [capability providers](/docs/0.82/concepts/capabilities), and [hosts](/docs/0.82/concepts/hosts) to communicate with each other across any number of infrastructure barriers. A network in wasmCloud should "just work", which enables short developer feedback loops as well as production performance and resilience.

--- a/versioned_docs/version-0.82/concepts/lattice.mdx
+++ b/versioned_docs/version-0.82/concepts/lattice.mdx
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/runtime-linking.mdx
+++ b/versioned_docs/version-0.82/concepts/runtime-linking.mdx
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/runtime-linking.mdx
+++ b/versioned_docs/version-0.82/concepts/runtime-linking.mdx
@@ -5,6 +5,10 @@ sidebar_position: 6
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 A **_runtime link_** is a declared connection between a specific actor and a specific capability provider. Link definitions are a tuple composed of the actor's identity, the provider's identity, and a link name. (If not provided, link names default to `default`.) There are 3 different consumers of this relationship:

--- a/versioned_docs/version-0.82/concepts/webassembly-components.mdx
+++ b/versioned_docs/version-0.82/concepts/webassembly-components.mdx
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Overview

--- a/versioned_docs/version-0.82/concepts/webassembly-components.mdx
+++ b/versioned_docs/version-0.82/concepts/webassembly-components.mdx
@@ -6,6 +6,10 @@ sidebar_position: 0
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Overview
 
 [WebAssembly components](https://github.com/WebAssembly/component-model) are the unit of compute for wasmCloud. Components are containers for WebAssembly modules (or other sub-components), which can depend on and expose interfaces. This aligns well with wasmCloud's approach to building distributed applications via the [actor model](/docs/0.82/concepts/actors) and [interface-driven development](/docs/0.82/concepts/interface-driven-development).

--- a/versioned_docs/version-0.82/deployment/docker/index.mdx
+++ b/versioned_docs/version-0.82/deployment/docker/index.mdx
@@ -4,6 +4,10 @@ description: "Starting wasmCloud with Docker"
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ### Release Artifacts
 
 wasmCloud host and CLI releases are published to:

--- a/versioned_docs/version-0.82/deployment/docker/index.mdx
+++ b/versioned_docs/version-0.82/deployment/docker/index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ### Release Artifacts

--- a/versioned_docs/version-0.82/deployment/hosts/auctions.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/auctions.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 All hosts within a lattice participate in _**auctions**_. An auction is performed when a client of the lattice control interface (e.g. the `wash` CLI, `wadm`, or another application) publishes a set of _requirements_ to all hosts within the lattice.

--- a/versioned_docs/version-0.82/deployment/hosts/auctions.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/auctions.mdx
@@ -4,6 +4,10 @@ description: 'Finding hosts eligible for a workload'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 All hosts within a lattice participate in _**auctions**_. An auction is performed when a client of the lattice control interface (e.g. the `wash` CLI, `wadm`, or another application) publishes a set of _requirements_ to all hosts within the lattice.
 
 Each host in the lattice will determine whether or not it meets those requirements. If it does, the host will respond to the auction. The primary reason to hold an auction is to use the results for scheduling workloads. A target host for an actor or capability provider can be chosen from among the auction responders.

--- a/versioned_docs/version-0.82/deployment/hosts/config-service.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/config-service.mdx
@@ -4,6 +4,10 @@ description: 'Starting hosts with supplemental configuration'
 sidebar_position: 2
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud hosts can be configured at start time with a variety of [host config](/docs/0.82/reference/host-config) options. However, in some production deploys, it is useful to provide supplemental configuration to a host from an external source.
 
 For example, wasmCloud hosts can be configured to pull artifacts from private OCI registries. The host can be started with credentials to a single registry, but in cases where multiple registries are used to host artifacts, a config service can be used to provide credentials for multiple registries to hosts.

--- a/versioned_docs/version-0.82/deployment/hosts/config-service.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/config-service.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud hosts can be configured at start time with a variety of [host config](/docs/0.82/reference/host-config) options. However, in some production deploys, it is useful to provide supplemental configuration to a host from an external source.

--- a/versioned_docs/version-0.82/deployment/hosts/labels.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/labels.mdx
@@ -4,6 +4,10 @@ description: 'Key-value pairs to distinguish hosts'
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud hosts are associated with a set of label key-value pairs. Labels are used to distinguish hosts in [auctions](/docs/0.82/deployment/hosts/auctions) and schedule workloads with [`wadm`](/docs/0.82/category/declarative-application-deployment-wadm).
 
 ### Built-in Labels

--- a/versioned_docs/version-0.82/deployment/hosts/labels.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/labels.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud hosts are associated with a set of label key-value pairs. Labels are used to distinguish hosts in [auctions](/docs/0.82/deployment/hosts/auctions) and schedule workloads with [`wadm`](/docs/0.82/category/declarative-application-deployment-wadm).

--- a/versioned_docs/version-0.82/deployment/hosts/local-artifacts.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/local-artifacts.mdx
@@ -4,6 +4,10 @@ description: 'A quick note on best practices for starting applications from loca
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 When running wasmCloud locally using `wash up`, it's simple to deploy applications using local file references. This enables rapid iteration and testing of applications during development, by not having to push and pull artifacts to a registry. In a production environment, however, deploying artifacts from a filesystem is not always wise, as local artifacts are not immutable and may be tampered with.
 
 Fortunately, **the wasmCloud host denies requests to start actors and providers from local artifacts** by default.

--- a/versioned_docs/version-0.82/deployment/hosts/local-artifacts.mdx
+++ b/versioned_docs/version-0.82/deployment/hosts/local-artifacts.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 When running wasmCloud locally using `wash up`, it's simple to deploy applications using local file references. This enables rapid iteration and testing of applications during development, by not having to push and pull artifacts to a registry. In a production environment, however, deploying artifacts from a filesystem is not always wise, as local artifacts are not immutable and may be tampered with.

--- a/versioned_docs/version-0.82/deployment/k8s/index.mdx
+++ b/versioned_docs/version-0.82/deployment/k8s/index.mdx
@@ -4,6 +4,10 @@ description: 'Integrating wasmCloud with Kubernetes'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud is **compatible with, but not dependent on**, Kubernetes. We think the future of WebAssembly is bright, _and_ we also know there are plenty of systems already running in Kubernetes. For this reason, we provide the wasmCloud operator to help users run wasmCloud hosts on a Kubernetes cluster&mdash;and thereby run WebAssembly components on Kubernetes.
 
 For high-level discussion of our approach to Kubernetes and compatibility with common cloud native tooling, see [wasmCloud on Kubernetes](/docs/0.82/kubernetes/).

--- a/versioned_docs/version-0.82/deployment/k8s/index.mdx
+++ b/versioned_docs/version-0.82/deployment/k8s/index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud is **compatible with, but not dependent on**, Kubernetes. We think the future of WebAssembly is bright, _and_ we also know there are plenty of systems already running in Kubernetes. For this reason, we provide the wasmCloud operator to help users run wasmCloud hosts on a Kubernetes cluster&mdash;and thereby run WebAssembly components on Kubernetes.

--- a/versioned_docs/version-0.82/deployment/lattice/generating-creds.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/generating-creds.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud hosts use a set of public and private keypairs to [sign and verify](/docs/0.82/deployment/security/zero-trust-invocations) invocations. Each host is started with:

--- a/versioned_docs/version-0.82/deployment/lattice/generating-creds.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/generating-creds.mdx
@@ -4,6 +4,10 @@ description: 'How to generate credentials for a lattice'
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud hosts use a set of public and private keypairs to [sign and verify](/docs/0.82/deployment/security/zero-trust-invocations) invocations. Each host is started with:
 
 - a single "cluster seed" (private key)

--- a/versioned_docs/version-0.82/deployment/lattice/index.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/index.mdx
@@ -4,6 +4,10 @@ description: 'Provisioning a lattice'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 All wasmCloud hosts are segmented into distinct namespaces called [lattices](/docs/0.82/concepts/lattice).
 
 When running locally with `wash up`, the lattice name defaults to `default`. In production, it's common to run multiple lattices on the same NATS cluster, where each lattice gets its own name.

--- a/versioned_docs/version-0.82/deployment/lattice/index.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 All wasmCloud hosts are segmented into distinct namespaces called [lattices](/docs/0.82/concepts/lattice).

--- a/versioned_docs/version-0.82/deployment/lattice/metadata.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/metadata.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The wasmCloud lattice makes use of a _distributed cache_ for lattice-wide metadata. The information in this cache is required to allow a lattice to function properly. It contains the following information:

--- a/versioned_docs/version-0.82/deployment/lattice/metadata.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/metadata.mdx
@@ -4,6 +4,10 @@ description: 'How to ensure redundancy of lattice metadata'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The wasmCloud lattice makes use of a _distributed cache_ for lattice-wide metadata. The information in this cache is required to allow a lattice to function properly. It contains the following information:
 
 - Claims - JWTs are stored for both providers and actors

--- a/versioned_docs/version-0.82/deployment/lattice/starting-hosts.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/starting-hosts.mdx
@@ -4,6 +4,10 @@ description: 'How to dynamically start hosts in a lattice'
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 When a wasmCloud host starts with no additional parameters or configuration, it creates a new "lattice of one"; the host starts with an _ad hoc_ generated seed key and uses the corresponding public key for the issuers list, which means it will not be able to communicate with other hosts.
 
 To ensure that any set of hosts are able to join the same lattice and securely communicate with each other, specify the following [host config](/docs/0.82/reference/host-config) options:

--- a/versioned_docs/version-0.82/deployment/lattice/starting-hosts.mdx
+++ b/versioned_docs/version-0.82/deployment/lattice/starting-hosts.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 When a wasmCloud host starts with no additional parameters or configuration, it creates a new "lattice of one"; the host starts with an _ad hoc_ generated seed key and uses the corresponding public key for the issuers list, which means it will not be able to communicate with other hosts.

--- a/versioned_docs/version-0.82/deployment/nats/cluster-config.mdx
+++ b/versioned_docs/version-0.82/deployment/nats/cluster-config.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 A wasmCloud deployment requires at least one NATS server configured to use [JetStream](https://docs.nats.io/nats-concepts/jetstream). A production deployment should use at least one NATS [_cluster_](https://docs.nats.io/running-a-nats-service/configuration/clustering) with three or five servers depending on your reliability requirements.

--- a/versioned_docs/version-0.82/deployment/nats/cluster-config.mdx
+++ b/versioned_docs/version-0.82/deployment/nats/cluster-config.mdx
@@ -4,6 +4,10 @@ description: 'How to set up a NATS server/cluster'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 A wasmCloud deployment requires at least one NATS server configured to use [JetStream](https://docs.nats.io/nats-concepts/jetstream). A production deployment should use at least one NATS [_cluster_](https://docs.nats.io/running-a-nats-service/configuration/clustering) with three or five servers depending on your reliability requirements.
 
 :::info

--- a/versioned_docs/version-0.82/deployment/nats/js-leaf.md
+++ b/versioned_docs/version-0.82/deployment/nats/js-leaf.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 NATS leaf nodes are a simple concept but they enable an incredible amount of power, flexibility, and use cases. A leaf node allows NATS servers to bridge or join security domains. On any given server, you can set up [leaf node remotes](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) that tether one account space on one side of the node to a different account space on the other side of the node.

--- a/versioned_docs/version-0.82/deployment/nats/js-leaf.md
+++ b/versioned_docs/version-0.82/deployment/nats/js-leaf.md
@@ -3,6 +3,10 @@ title: 'Leaf Node Config (JetStream)'
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 NATS leaf nodes are a simple concept but they enable an incredible amount of power, flexibility, and use cases. A leaf node allows NATS servers to bridge or join security domains. On any given server, you can set up [leaf node remotes](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) that tether one account space on one side of the node to a different account space on the other side of the node.
 
 This simplicity and power makes leaf nodes work like a universal connector for stitching together disparate infrastructures and they are part of the magic sauce that makes wasmCloud lattices so powerful.

--- a/versioned_docs/version-0.82/deployment/nats/leaf-nodes.mdx
+++ b/versioned_docs/version-0.82/deployment/nats/leaf-nodes.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 [NATS leaf nodes](https://docs.nats.io/nats-server/configuration/leafnodes) are a flexible way to extend NATS infrastructure. Leaf nodes enable segmentation or isolation of traffic and/or security boundaries.

--- a/versioned_docs/version-0.82/deployment/nats/leaf-nodes.mdx
+++ b/versioned_docs/version-0.82/deployment/nats/leaf-nodes.mdx
@@ -4,6 +4,10 @@ description: 'A common way to for hosts to connect securely to a lattice'
 sidebar_position: 2
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 [NATS leaf nodes](https://docs.nats.io/nats-server/configuration/leafnodes) are a flexible way to extend NATS infrastructure. Leaf nodes enable segmentation or isolation of traffic and/or security boundaries.
 
 wasmCloud can use leaf nodes to simplify lattice configuration. A common pattern involves starting a NATS leaf node alongside a wasmCloud host on a system (virtual or otherwise). The leaf node is configured with credentials for authenticating with an external NATS cluster. By delegating the NATS authentication to the leaf node, the wasmCloud host can connect to the leaf node anonymously.

--- a/versioned_docs/version-0.82/deployment/observability/logs.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/logs.mdx
@@ -4,6 +4,10 @@ description: 'How to get the most out of logs in a distributed system'
 sidebar_position: 2
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 In addition to host-level logging, wasmCloud supports log exports using the [OpenTelemetry (OTEL)](https://opentelemetry.io/) specification.
 
 For more information on wasmCloud's implementation of OpenTelemetry, including advanced configuration options, see [Observability with OpenTelemetry](/docs/deployment/observability/observability-with-opentelemetry.mdx).

--- a/versioned_docs/version-0.82/deployment/observability/logs.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/logs.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 In addition to host-level logging, wasmCloud supports log exports using the [OpenTelemetry (OTEL)](https://opentelemetry.io/) specification.

--- a/versioned_docs/version-0.82/deployment/observability/metrics.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/metrics.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/deployment/observability/metrics.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/metrics.mdx
@@ -4,6 +4,10 @@ description: "How to get aggregate data on the availability and performance of a
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 
 🚧 Under construction 🚧

--- a/versioned_docs/version-0.82/deployment/observability/observability-with-opentelemetry.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/observability-with-opentelemetry.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud is designed to support cloud native observability standards using [OpenTelemetry (OTEL)](https://opentelemetry.io/). OpenTelemetry is an open source project defining common APIs and standards for telemetry in cloud native systems. As of v0.82.0, wasmCloud emits **traces** and **logs** as OTEL [**signals**](https://opentelemetry.io/docs/concepts/signals/), with **metrics** support slated for v1.0.

--- a/versioned_docs/version-0.82/deployment/observability/observability-with-opentelemetry.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/observability-with-opentelemetry.mdx
@@ -4,6 +4,10 @@ description: 'Using OpenTelemetry for wasmCloud observability'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud is designed to support cloud native observability standards using [OpenTelemetry (OTEL)](https://opentelemetry.io/). OpenTelemetry is an open source project defining common APIs and standards for telemetry in cloud native systems. As of v0.82.0, wasmCloud emits **traces** and **logs** as OTEL [**signals**](https://opentelemetry.io/docs/concepts/signals/), with **metrics** support slated for v1.0.
 
 ### Data flow

--- a/versioned_docs/version-0.82/deployment/observability/tracing.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/tracing.mdx
@@ -4,6 +4,10 @@ description: 'How to enable end-to-end visibility of messages through wasmCloud'
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Traces are essential for understanding the flow of messages through a distributed system. The wasmCloud host is instrumented to record traces for all control interface and RPC messages.
 
 The wasmCloud host can record and export distributed traces using the [OpenTelemetry](https://opentelemetry.io/) (OTEL) specification. If you haven't worked with distributed traces before, [this primer](https://opentelemetry.io/docs/concepts/observability-primer/#distributed-traces) is a great place to start.

--- a/versioned_docs/version-0.82/deployment/observability/tracing.mdx
+++ b/versioned_docs/version-0.82/deployment/observability/tracing.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Traces are essential for understanding the flow of messages through a distributed system. The wasmCloud host is instrumented to record traces for all control interface and RPC messages.

--- a/versioned_docs/version-0.82/deployment/oci/index.mdx
+++ b/versioned_docs/version-0.82/deployment/oci/index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The wasmCloud host supports pulling images for [actor components](/docs/0.82/concepts/actors) and [capability providers](/docs/0.82/concepts/capabilities) from [OCI](https://opencontainers.org/) (Open Container Initiative) registries.

--- a/versioned_docs/version-0.82/deployment/oci/index.mdx
+++ b/versioned_docs/version-0.82/deployment/oci/index.mdx
@@ -4,6 +4,10 @@ description: 'Working with and managing registries'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The wasmCloud host supports pulling images for [actor components](/docs/0.82/concepts/actors) and [capability providers](/docs/0.82/concepts/capabilities) from [OCI](https://opencontainers.org/) (Open Container Initiative) registries.
 
 ### Configuring Access to a Private registry

--- a/versioned_docs/version-0.82/deployment/security/env.mdx
+++ b/versioned_docs/version-0.82/deployment/security/env.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The wasmCloud host can obtain configuration via environment variables. (For a list of the environment variables supported by the host, check out the [host configuration](/docs/0.82/reference/host-config) section.)

--- a/versioned_docs/version-0.82/deployment/security/env.mdx
+++ b/versioned_docs/version-0.82/deployment/security/env.mdx
@@ -4,6 +4,10 @@ description: 'A quick note on best practices related to environment variables'
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The wasmCloud host can obtain configuration via environment variables. (For a list of the environment variables supported by the host, check out the [host configuration](/docs/0.82/reference/host-config) section.)
 
 However, there are security pitfalls related to environment variables. For example, consider setting environment variables on the command line along with invoking the script, e.g.

--- a/versioned_docs/version-0.82/deployment/security/nats-segmentation.mdx
+++ b/versioned_docs/version-0.82/deployment/security/nats-segmentation.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 NATS forms the connective tissue that stitches together all of the wasmCloud hosts within a lattice. Each host requires two connections:

--- a/versioned_docs/version-0.82/deployment/security/nats-segmentation.mdx
+++ b/versioned_docs/version-0.82/deployment/security/nats-segmentation.mdx
@@ -4,6 +4,10 @@ description: 'How to partition and secure the control interface and RPC protocol
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 NATS forms the connective tissue that stitches together all of the wasmCloud hosts within a lattice. Each host requires two connections:
 
 - A [control plane](/docs/0.82/hosts/lattice-protocols/control-interface) connection

--- a/versioned_docs/version-0.82/deployment/security/policy-service.mdx
+++ b/versioned_docs/version-0.82/deployment/security/policy-service.mdx
@@ -4,6 +4,10 @@ description: 'Deploying and managing a policy service'
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud hosts will always enforce a certain level of security by default that _cannot be loosened_. For example, hosts will always validate [invocations](/docs/0.82/deployment/security/zero-trust-invocations) and [runtime links](/docs/0.82/developer/debugging/actors#missing-runtime-links).
 
 A _policy service_ can be used to restrict starting/communicating with untrusted actors and providers on particular hosts.

--- a/versioned_docs/version-0.82/deployment/security/policy-service.mdx
+++ b/versioned_docs/version-0.82/deployment/security/policy-service.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud hosts will always enforce a certain level of security by default that _cannot be loosened_. For example, hosts will always validate [invocations](/docs/0.82/deployment/security/zero-trust-invocations) and [runtime links](/docs/0.82/developer/debugging/actors#missing-runtime-links).

--- a/versioned_docs/version-0.82/deployment/security/zero-trust-invocations.mdx
+++ b/versioned_docs/version-0.82/deployment/security/zero-trust-invocations.mdx
@@ -4,6 +4,10 @@ description: 'Cluster keys and issuers'
 sidebar_position: 2
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The concept of cluster **keys** and **issuers** is a classic example of an architectural pattern based on [zero trust](https://www.crowdstrike.com/cybersecurity-101/zero-trust-security/) environments. Once a wasmCloud host has authenticated with its two NATS connections (discussed next), that host is open to sending and receiving both [control signals](/docs/0.82/hosts/lattice-protocols/control-interface) and [Remote Procedure Call](/docs/0.82/hosts/lattice-protocols/rpc) (RPC) traffic.
 
 wasmCloud assumes a zero-trust environment, so even with compromised access to a NATS cluster, an attacker cannot communicate with actors and providers.

--- a/versioned_docs/version-0.82/deployment/security/zero-trust-invocations.mdx
+++ b/versioned_docs/version-0.82/deployment/security/zero-trust-invocations.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The concept of cluster **keys** and **issuers** is a classic example of an architectural pattern based on [zero trust](https://www.crowdstrike.com/cybersecurity-101/zero-trust-security/) environments. Once a wasmCloud host has authenticated with its two NATS connections (discussed next), that host is open to sending and receiving both [control signals](/docs/0.82/hosts/lattice-protocols/control-interface) and [Remote Procedure Call](/docs/0.82/hosts/lattice-protocols/rpc) (RPC) traffic.

--- a/versioned_docs/version-0.82/deployment/wadm/configuration.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/configuration.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/deployment/wadm/configuration.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/configuration.mdx
@@ -4,6 +4,10 @@ description: 'A reference for configuration options for wadm'
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/0.82/category/declarative-application-deployment-wadm).
 :::

--- a/versioned_docs/version-0.82/deployment/wadm/deploy-architecture.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/deploy-architecture.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/deployment/wadm/deploy-architecture.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/deploy-architecture.mdx
@@ -4,6 +4,10 @@ description: 'How to set up wadm for high availability and performance'
 sidebar_position: 2
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/0.82/category/declarative-application-deployment-wadm).
 :::

--- a/versioned_docs/version-0.82/deployment/wadm/index.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/index.mdx
@@ -3,6 +3,10 @@ title: 'Deploying Wadm'
 description: 'Deploying and operating Wadm'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/0.82/category/declarative-application-deployment-wadm).
 :::

--- a/versioned_docs/version-0.82/deployment/wadm/index.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/index.mdx
@@ -4,7 +4,7 @@ description: 'Deploying and operating Wadm'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/deployment/wadm/installing.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/installing.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 `wadm` releases include a standalone binary and Docker image.

--- a/versioned_docs/version-0.82/deployment/wadm/installing.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/installing.mdx
@@ -4,6 +4,10 @@ description: "Installing wadm from releases or with Docker"
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 `wadm` releases include a standalone binary and Docker image.
 
 ### Standalone Binary

--- a/versioned_docs/version-0.82/deployment/wadm/nats-credentials.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/nats-credentials.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/deployment/wadm/nats-credentials.mdx
+++ b/versioned_docs/version-0.82/deployment/wadm/nats-credentials.mdx
@@ -4,6 +4,10 @@ description: 'How to configure NATS credentials for wadm'
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/0.82/category/declarative-application-deployment-wadm).
 :::

--- a/versioned_docs/version-0.82/developer/actors/build.mdx
+++ b/versioned_docs/version-0.82/developer/actors/build.mdx
@@ -8,6 +8,10 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/developer/actors/build.mdx
+++ b/versioned_docs/version-0.82/developer/actors/build.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/developer/actors/generate.mdx
+++ b/versioned_docs/version-0.82/developer/actors/generate.mdx
@@ -9,6 +9,10 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HubspotForm from 'react-hubspot-form';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/developer/actors/generate.mdx
+++ b/versioned_docs/version-0.82/developer/actors/generate.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 import HubspotForm from 'react-hubspot-form';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/developer/actors/index.md
+++ b/versioned_docs/version-0.82/developer/actors/index.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/developer/actors/index.md
+++ b/versioned_docs/version-0.82/developer/actors/index.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/developer/actors/publish.mdx
+++ b/versioned_docs/version-0.82/developer/actors/publish.mdx
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/developer/actors/publish.mdx
+++ b/versioned_docs/version-0.82/developer/actors/publish.mdx
@@ -5,6 +5,10 @@ sidebar_position: 6
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/developer/actors/run.mdx
+++ b/versioned_docs/version-0.82/developer/actors/run.mdx
@@ -8,6 +8,10 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/developer/actors/run.mdx
+++ b/versioned_docs/version-0.82/developer/actors/run.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/developer/actors/update.mdx
+++ b/versioned_docs/version-0.82/developer/actors/update.mdx
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning[Changing in 1.0+]

--- a/versioned_docs/version-0.82/developer/actors/update.mdx
+++ b/versioned_docs/version-0.82/developer/actors/update.mdx
@@ -5,6 +5,10 @@ sidebar_position: 3
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning[Changing in 1.0+]
 The term "actor" is deprecated. wasmCloud 1.0 and later simply refer to this entity as a **component**, reflecting wasmCloud's standardization around WebAssembly components. You can learn more [here](/docs/concepts/components).
 :::

--- a/versioned_docs/version-0.82/developer/communication/actor-to-actor-calls.md
+++ b/versioned_docs/version-0.82/developer/communication/actor-to-actor-calls.md
@@ -7,7 +7,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The ability for one actor to call another actor is critical to being able to create _composable_ actor systems. wasmCloud supports RPC-style communication between actors, even if those actors are running in hosts scattered across disparate infrastructure, connected only via the [lattice](/docs/0.82/reference/glossary#lattice).

--- a/versioned_docs/version-0.82/developer/communication/actor-to-actor-calls.md
+++ b/versioned_docs/version-0.82/developer/communication/actor-to-actor-calls.md
@@ -6,6 +6,10 @@ description: 'Actor to Actor RPC'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The ability for one actor to call another actor is critical to being able to create _composable_ actor systems. wasmCloud supports RPC-style communication between actors, even if those actors are running in hosts scattered across disparate infrastructure, connected only via the [lattice](/docs/0.82/reference/glossary#lattice).
 
 ### Identifying actors

--- a/versioned_docs/version-0.82/developer/debugging/actors.mdx
+++ b/versioned_docs/version-0.82/developer/debugging/actors.mdx
@@ -5,6 +5,10 @@ sidebar_position: 3
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 
 Before you follow this section, consider [configuring the log level](/docs/0.82/developer/debugging/host#changing-the-log-level) to `debug` for more information when debugging.

--- a/versioned_docs/version-0.82/developer/debugging/actors.mdx
+++ b/versioned_docs/version-0.82/developer/debugging/actors.mdx
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/developer/debugging/host.mdx
+++ b/versioned_docs/version-0.82/developer/debugging/host.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::info

--- a/versioned_docs/version-0.82/developer/debugging/host.mdx
+++ b/versioned_docs/version-0.82/developer/debugging/host.mdx
@@ -8,6 +8,10 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::info
 
 The primary wasmCloud host runtime is the [`wasmcloud-host`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/host), which you'll be using if you're running the host from wash, a released binary, or with the [wasmcloud](https://hub.docker.com/r/wasmcloud/wasmcloud) docker image.

--- a/versioned_docs/version-0.82/developer/debugging/index.md
+++ b/versioned_docs/version-0.82/developer/debugging/index.md
@@ -6,6 +6,10 @@ draft: false
 description: 'Troubleshooting and Diagnosing problems with wasmCloud'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The following sections detail ways to track down errors with specific wasmCloud components, as well as some of the most common issues we see when getting started with wasmCloud applications. It's recommended to start with the [Host Troubleshooting](./host) guide first, as it details how to find wasmCloud's logs.
 
 - [Host Troubleshooting](./host)

--- a/versioned_docs/version-0.82/developer/debugging/index.md
+++ b/versioned_docs/version-0.82/developer/debugging/index.md
@@ -7,7 +7,7 @@ description: 'Troubleshooting and Diagnosing problems with wasmCloud'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The following sections detail ways to track down errors with specific wasmCloud components, as well as some of the most common issues we see when getting started with wasmCloud applications. It's recommended to start with the [Host Troubleshooting](./host) guide first, as it details how to find wasmCloud's logs.

--- a/versioned_docs/version-0.82/developer/debugging/providers.md
+++ b/versioned_docs/version-0.82/developer/debugging/providers.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This section is still under construction. If there is specific content you'd like to see here, please [file an issue for this site](https://github.com/wasmCloud/wasmCloud.com/issues/new).

--- a/versioned_docs/version-0.82/developer/debugging/providers.md
+++ b/versioned_docs/version-0.82/developer/debugging/providers.md
@@ -5,4 +5,8 @@ sidebar_position: 4
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This section is still under construction. If there is specific content you'd like to see here, please [file an issue for this site](https://github.com/wasmCloud/wasmCloud.com/issues/new).

--- a/versioned_docs/version-0.82/developer/interfaces/creating-an-interface.md
+++ b/versioned_docs/version-0.82/developer/interfaces/creating-an-interface.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The first thing we're going to need for our _payments service_ sample capability provider is an **interface**. An interface describes the data types that actors and providers exchange, as well as the supported operations that can be invoked, and the relative directions of those operations.

--- a/versioned_docs/version-0.82/developer/interfaces/creating-an-interface.md
+++ b/versioned_docs/version-0.82/developer/interfaces/creating-an-interface.md
@@ -5,6 +5,10 @@ sidebar_position: 6
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The first thing we're going to need for our _payments service_ sample capability provider is an **interface**. An interface describes the data types that actors and providers exchange, as well as the supported operations that can be invoked, and the relative directions of those operations.
 
 [Contract-driven](https://en.wikipedia.org/wiki/Design_by_contract) design and development (CDD) has been a long-favored technique for developers building microservices and other types of composable systems. Earlier in our documentation we also referred to it as [interface-driven development](/docs/0.82/concepts/interface-driven-development). Not only does CDD/IDD make our initial design experience easier, but it continues to pay dividends throughout the life cycle of our application.

--- a/versioned_docs/version-0.82/developer/providers/consuming.md
+++ b/versioned_docs/version-0.82/developer/providers/consuming.md
@@ -5,6 +5,10 @@ sidebar_position: 9
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 It's a fairly easy matter to declare a dependency on the Payments interface crate for a new actor project. However, the difficult question isn't _how_ can an actor utilize this new payments provider, but _why_ and _when_?
 
 There are a couple of different approaches here, with their own pros and cons.

--- a/versioned_docs/version-0.82/developer/providers/consuming.md
+++ b/versioned_docs/version-0.82/developer/providers/consuming.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 It's a fairly easy matter to declare a dependency on the Payments interface crate for a new actor project. However, the difficult question isn't _how_ can an actor utilize this new payments provider, but _why_ and _when_?

--- a/versioned_docs/version-0.82/developer/providers/create-par.md
+++ b/versioned_docs/version-0.82/developer/providers/create-par.md
@@ -5,6 +5,10 @@ sidebar_position: 8
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 A [provider archive](/docs/0.82/reference/glossary#provider-archive) (also called a _par file_) is an archive file (in unix 'tar' format) containing platform-specific executable files for a variety of CPU and OS combinations. A typical provider archive file contains executables for 64-bit linux, x86_64 macos, aarch64 macos, and other supported platforms. The par file includes a cryptographically signed JSON Web Token (JWT) that contains a set of claims attestations for the capability provider.
 
 A provider archive can be uploaded to, or downloaded from, OCI registries.

--- a/versioned_docs/version-0.82/developer/providers/create-par.md
+++ b/versioned_docs/version-0.82/developer/providers/create-par.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 A [provider archive](/docs/0.82/reference/glossary#provider-archive) (also called a _par file_) is an archive file (in unix 'tar' format) containing platform-specific executable files for a variety of CPU and OS combinations. A typical provider archive file contains executables for 64-bit linux, x86_64 macos, aarch64 macos, and other supported platforms. The par file includes a cryptographically signed JSON Web Token (JWT) that contains a set of claims attestations for the capability provider.

--- a/versioned_docs/version-0.82/developer/providers/index.md
+++ b/versioned_docs/version-0.82/developer/providers/index.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 When you decide to create a new capability provider, you have two options:

--- a/versioned_docs/version-0.82/developer/providers/index.md
+++ b/versioned_docs/version-0.82/developer/providers/index.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 When you decide to create a new capability provider, you have two options:
 
 - Create a provider for a brand new interface contract.

--- a/versioned_docs/version-0.82/developer/providers/rust.md
+++ b/versioned_docs/version-0.82/developer/providers/rust.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Creating a capability provider involves creating a native executable. All capability provider executables have the same basic requirements:

--- a/versioned_docs/version-0.82/developer/providers/rust.md
+++ b/versioned_docs/version-0.82/developer/providers/rust.md
@@ -5,6 +5,10 @@ sidebar_position: 7
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Creating a capability provider involves creating a native executable. All capability provider executables have the same basic requirements:
 
 - Accept a [Host Data](https://wasmcloud.github.io/interfaces/html/org_wasmcloud_core.html#host_data) object from `stdin` immediately upon starting the executable. The host data is a base64 encoded JSON object with a trailing newline making it easy to pull from the `stdin` pipe.

--- a/versioned_docs/version-0.82/developer/providers/testing.md
+++ b/versioned_docs/version-0.82/developer/providers/testing.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 There are two ways to test a capability provider.

--- a/versioned_docs/version-0.82/developer/providers/testing.md
+++ b/versioned_docs/version-0.82/developer/providers/testing.md
@@ -5,6 +5,10 @@ sidebar_position: 10
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 There are two ways to test a capability provider.
 
 The first method loads the provider into a test harness, and issues rpc calls to it to verify responses. This type of testing can be useful for "unit" tests - evaluating the provider in an isolated, controlled context. For examples of providers that use this kind of testing, look in the `tests` folder of [kvredis](https://github.com/wasmCloud/capability-providers/tree/main/kvredis) and [httpserver](https://github.com/wasmCloud/capability-providers/tree/main/httpserver-rs). These two capability providers exhibit different directions for rpc: kvredis, an example of a [`providerReceive`](/docs/0.82/hosts/abis/wasmbus/interfaces/traits#wasmbus) service, receives commands from actors, and httpserver, an example of an [`actorReceive`](/docs/0.82/hosts/abis/wasmbus/interfaces/traits#wasmbus) service, sends messages to actors.

--- a/versioned_docs/version-0.82/developer/workflow.md
+++ b/versioned_docs/version-0.82/developer/workflow.md
@@ -7,7 +7,7 @@ description: 'Common development loops'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 As a developer using wasmCloud, there are a number of common day-to-day workflows that you will experience.

--- a/versioned_docs/version-0.82/developer/workflow.md
+++ b/versioned_docs/version-0.82/developer/workflow.md
@@ -6,6 +6,10 @@ draft: false
 description: 'Common development loops'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 As a developer using wasmCloud, there are a number of common day-to-day workflows that you will experience.
 
 The following is a list of developer workflows _sorted_ from **_most to least common_**.

--- a/versioned_docs/version-0.82/ecosystem/useful-webassembly-tools/index.mdx
+++ b/versioned_docs/version-0.82/ecosystem/useful-webassembly-tools/index.mdx
@@ -8,7 +8,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Beyond the wasmCloud toolchain, the WebAssembly community maintains many open source projects that are invaluable for Wasm users. This is a non-comprehensive list of tools we've found particularly useful.

--- a/versioned_docs/version-0.82/ecosystem/useful-webassembly-tools/index.mdx
+++ b/versioned_docs/version-0.82/ecosystem/useful-webassembly-tools/index.mdx
@@ -7,6 +7,10 @@ type: "docs"
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Beyond the wasmCloud toolchain, the WebAssembly community maintains many open source projects that are invaluable for Wasm users. This is a non-comprehensive list of tools we've found particularly useful.
 
 ## WIT syntax highlighting (VSCode)

--- a/versioned_docs/version-0.82/ecosystem/wadm/api.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/api.md
@@ -7,6 +7,10 @@ type: 'docs'
 sidebar_position: 4
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The normal way to interact with a `wadm` installation (which could be a single server or a cluster)
 is through the [wash](./usage.md) command-line tool. However, if you are planning on
 creating your own integration or writing a non-Rust language binding, then this reference will help.

--- a/versioned_docs/version-0.82/ecosystem/wadm/api.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/api.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The normal way to interact with a `wadm` installation (which could be a single server or a cluster)

--- a/versioned_docs/version-0.82/ecosystem/wadm/index.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/index.md
@@ -8,7 +8,7 @@ sidebar_position: 0
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ![wadm logo](https://raw.githubusercontent.com/wasmCloud/wadm/main/wadm.png)

--- a/versioned_docs/version-0.82/ecosystem/wadm/index.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/index.md
@@ -7,6 +7,10 @@ type: "docs"
 sidebar_position: 0
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ![wadm logo](https://raw.githubusercontent.com/wasmCloud/wadm/main/wadm.png)
 
 If you've been reading the tutorials or going through the reference guide in order, then by now you should be pretty familiar with what we call _imperative deployment_. This involves using the `wash` tool (or invoking the control interface directly) to send imperatives or _commands_ to a lattice. These commands are things like telling a host to start or stop an actor, start or stop a provider, etc.

--- a/versioned_docs/version-0.82/ecosystem/wadm/model.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/model.md
@@ -7,6 +7,10 @@ type: 'docs'
 sidebar_position: 2
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The **w**asmCloud **A**pplication **D**eployment **M**anager uses the [Open Application Model](https://oam.dev/) to define application specifications. Because this specification is extensible and platform agnostic, it makes for an ideal way to represent applications with metadata specific to wasmCloud. Don't worry if OAM seems overwhelming, you don't need to know much about it. We're using it as a way of defining application components in a flexible way that's familiar to a lot of people who have been working in the cloud space.
 
 In this model, an application `specification` is a set of metadata about the app, as well as a list of `components`. Each component within an application is decorated with various `traits`. These core building blocks allow us to make it very easy to define incredibly powerful deployments. wasmCloud defines a number of traits that are specific to our hosts, but let's go through the model from top to bottom.

--- a/versioned_docs/version-0.82/ecosystem/wadm/model.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/model.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The **w**asmCloud **A**pplication **D**eployment **M**anager uses the [Open Application Model](https://oam.dev/) to define application specifications. Because this specification is extensible and platform agnostic, it makes for an ideal way to represent applications with metadata specific to wasmCloud. Don't worry if OAM seems overwhelming, you don't need to know much about it. We're using it as a way of defining application components in a flexible way that's familiar to a lot of people who have been working in the cloud space.

--- a/versioned_docs/version-0.82/ecosystem/wadm/usage.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/usage.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Using `wadm` typically involves using the `wash` command line tool. However, you can also use wash's supporting library in your Rust application or, if you continue to the next section, you'll see the API reference if you want to interact with wadm directly over a NATS connection.

--- a/versioned_docs/version-0.82/ecosystem/wadm/usage.md
+++ b/versioned_docs/version-0.82/ecosystem/wadm/usage.md
@@ -6,6 +6,10 @@ type: "docs"
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Using `wadm` typically involves using the `wash` command line tool. However, you can also use wash's supporting library in your Rust application or, if you continue to the next section, you'll see the API reference if you want to interact with wadm directly over a NATS connection.
 
 The following is an overview of the high level functionality exposed by `wadm`. To see the corresponding commands in the `wash` CLI, issue the following command:

--- a/versioned_docs/version-0.82/ecosystem/wash/contexts.mdx
+++ b/versioned_docs/version-0.82/ecosystem/wash/contexts.mdx
@@ -8,6 +8,10 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ✨New in `wash` `v0.7.0`
 
 `wash` communicates to a wasmCloud host over 2 different NATS connections: the remote procedure call (RPC) connection and the control interface connection.

--- a/versioned_docs/version-0.82/ecosystem/wash/contexts.mdx
+++ b/versioned_docs/version-0.82/ecosystem/wash/contexts.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ✨New in `wash` `v0.7.0`

--- a/versioned_docs/version-0.82/ecosystem/wash/index.md
+++ b/versioned_docs/version-0.82/ecosystem/wash/index.md
@@ -7,7 +7,7 @@ description: 'The wasmCloud Shell (wash)'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 **_wash_** (the _wasmCloud Shell_) is a single command-line interface (CLI) to handle all of your wasmCloud tooling needs. This CLI has a number of sub-commands that help you interact with the wasmCloud ecosystem.

--- a/versioned_docs/version-0.82/ecosystem/wash/index.md
+++ b/versioned_docs/version-0.82/ecosystem/wash/index.md
@@ -6,6 +6,10 @@ sidebar_position: 1
 description: 'The wasmCloud Shell (wash)'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 **_wash_** (the _wasmCloud Shell_) is a single command-line interface (CLI) to handle all of your wasmCloud tooling needs. This CLI has a number of sub-commands that help you interact with the wasmCloud ecosystem.
 
 ```

--- a/versioned_docs/version-0.82/examples/cruddy.mdx
+++ b/versioned_docs/version-0.82/examples/cruddy.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 <h3>Build and deploy a CRUDdy Wasm component</h3>

--- a/versioned_docs/version-0.82/examples/cruddy.mdx
+++ b/versioned_docs/version-0.82/examples/cruddy.mdx
@@ -8,6 +8,10 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 <h3>Build and deploy a CRUDdy Wasm component</h3>
 
 This tutorial will show you how to create and deploy a distributed WebAssembly application with wasmCloud, using Python, Rust, Go, or TypeScript. Building on what you've learned in the [Quickstart](/docs/0.82/tour/hello-world), we'll explore the fundamentals of wasmCloud development by making a simple guestbook that performs [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations using several **capabilities**&mdash;abstracted requirements like HTTP handling or key-value storage, fulfilled by [WebAssembly components](/docs/0.82/concepts/webassembly-components).

--- a/versioned_docs/version-0.82/hosts/abis/components/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/components/index.md
@@ -7,7 +7,7 @@ description: 'Support for wit-defined WebAssembly components'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The [WebAssembly component model](https://github.com/WebAssembly/component-model) holds the promise of ushering in an even more powerful programming paradigm than WebAssembly modules. With components, we can bolt together incredible new forms of compute from small building blocks. For more information on our thoughts on the component model's future, check out the blog post [For the wit!](https://cosmonic.com/blog/engineering/for-the-wit-my-first-day-with-components)

--- a/versioned_docs/version-0.82/hosts/abis/components/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/components/index.md
@@ -6,6 +6,10 @@ draft: false
 description: 'Support for wit-defined WebAssembly components'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The [WebAssembly component model](https://github.com/WebAssembly/component-model) holds the promise of ushering in an even more powerful programming paradigm than WebAssembly modules. With components, we can bolt together incredible new forms of compute from small building blocks. For more information on our thoughts on the component model's future, check out the blog post [For the wit!](https://cosmonic.com/blog/engineering/for-the-wit-my-first-day-with-components)
 
 The wasmCloud host has added **_experimental_** support for WebAssembly components. As the specification and tooling around components and the component model stabilize, we will gradually improve our support for components. Until then, we recommend that you utilize our [Stable ABI](/docs/0.82/hosts/abis/wasmbus), which will still be supported even after components are the default.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/ffi.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/ffi.md
@@ -5,6 +5,10 @@ sidebar_position: 6
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 For the curious, here is the exact list of the wasmbus protocol's functions. The guest always imports from a module called `wasmbus`, and all function names are preceded by two underscores to avoid accidental collisions with other exported functions.
 
 | Function                | Owner | Description                                                                                                                                                         |

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/ffi.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/ffi.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 For the curious, here is the exact list of the wasmbus protocol's functions. The guest always imports from a module called `wasmbus`, and all function names are preceded by two underscores to avoid accidental collisions with other exported functions.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/index.md
@@ -6,6 +6,10 @@ draft: false
 description: "wasmCloud's original stable ABI"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 If you know in advance the memory and data exchange characteristics of your WebAssembly modules, and you know the lifetimes of the data being exchanged, and you can predict the kind of long-lived pointer behavior you'll have, then by all means use every tool and code generator at your disposal (e.g. [wasm-bindgen](https://rustwasm.github.io/docs/wasm-bindgen/)).
 
 A large number of use cases for WebAssembly fall into this pattern--treating the `.wasm` file much like a precompiled dependency with strongly-typed wrappers (think of how a compiler generates typed shims based on usage to support _generics_) similar to a dynamically-loaded library (.so, .dll, .dylib, etc).

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/index.md
@@ -7,7 +7,7 @@ description: "wasmCloud's original stable ABI"
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 If you know in advance the memory and data exchange characteristics of your WebAssembly modules, and you know the lifetimes of the data being exchanged, and you can predict the kind of long-lived pointer behavior you'll have, then by all means use every tool and code generator at your disposal (e.g. [wasm-bindgen](https://rustwasm.github.io/docs/wasm-bindgen/)).

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/code-generation.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/code-generation.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 You only need to read this section if you want to customize code generation, write a new target language generator, or if you want to know more about how it works.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/code-generation.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/code-generation.md
@@ -3,6 +3,10 @@ title: 'Code generation'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 You only need to read this section if you want to customize code generation, write a new target language generator, or if you want to know more about how it works.
 
 ## Code generation as code

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/codegen-toml.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/codegen-toml.md
@@ -3,6 +3,10 @@ title: 'codegen.toml files'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This document describes the syntax and functions of `codegen.toml` files.
 
 ## [[models]]

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/codegen-toml.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/codegen-toml.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This document describes the syntax and functions of `codegen.toml` files.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/crates-io.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/crates-io.md
@@ -3,6 +3,10 @@ title: 'Rust crates'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This document applies to interface crates built from `.smithy` models, and provides some information about how and when source files are updated.
 
 Interface projects contain one or more `.smithy` files, and a `codegen.toml`, which references the paths to the smithy files and to the output directories for the target languages.`codegen.toml` and `.smithy` files are language-agnostic, so they live one directory level above the `rust` folder, which contains `Cargo.toml`, `build.rs`, and the rust `src` folder.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/crates-io.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/crates-io.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This document applies to interface crates built from `.smithy` models, and provides some information about how and when source files are updated.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/index.md
@@ -6,6 +6,10 @@ description: 'Guides, reference docs, and tips for defining interfaces and gener
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 At its core, wasmCloud is a messaging system, and a scalable messaging system needs well-defined API contracts.
 
 Every capability provider has a capability contract - an interface definition - that defines a service and a set of operations it supports. Even [actor-to-actor](/docs/0.82/developer/communication/actor-to-actor-calls) messages, which don't use capability contracts, benefit by well-defined API contracts. In wasmCloud, we define these API contracts in [Smithy](https://awslabs.github.io/smithy/index.html) files.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/index.md
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 At its core, wasmCloud is a messaging system, and a scalable messaging system needs well-defined API contracts.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/avoid-single-member-structures.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/avoid-single-member-structures.md
@@ -3,6 +3,10 @@ title: 'Single-member structures'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 A function is modeled as an operation, with an optional `input` type
 for its parameters, and an optional `output` type for its return value.
 If either input or output type is a structure containing one member, it

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/avoid-single-member-structures.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/avoid-single-member-structures.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 A function is modeled as an operation, with an optional `input` type

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/clippy-warnings.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/clippy-warnings.md
@@ -3,6 +3,10 @@ title: "Clippy warnings"
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 ## Clippy warning on `&String` parameters
 
 If your `.smithy` model has an operation whose input parameter is a 'String', clippy may generate the following warning:

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/clippy-warnings.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/clippy-warnings.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 ## Clippy warning on `&String` parameters

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/error-messages.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/error-messages.md
@@ -3,6 +3,10 @@ title: "Error messages"
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Error messages from the smithy model parser, invoked by `build.rs` in Rust project, can be very long and detailed, sometimes more verbose than you need.
 
 Errors from `wash lint` or `wash validate` are usually more specific.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/error-messages.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/error-messages.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Error messages from the smithy model parser, invoked by `build.rs` in Rust project, can be very long and detailed, sometimes more verbose than you need.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/index.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This section contains some suggestions and tips for writing and debugging interface definitions.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/index.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/index.md
@@ -3,6 +3,10 @@ title: "Tips"
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This section contains some suggestions and tips for writing and debugging interface definitions.
 
 - [Use lint and validation tools](./lint-validate/)

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/lint-validate.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/lint-validate.md
@@ -3,6 +3,10 @@ title: 'Lint and validate checks'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The lint and validation checks are very useful for finding problems in smithy model files. They will detect syntax errors, missing dependencies, and style errors.
 
 To run lint checks, cd to the folder containing `codegen.toml`, and type

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/lint-validate.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/tips/lint-validate.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The lint and validation checks are very useful for finding problems in smithy model files. They will detect syntax errors, missing dependencies, and style errors.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/traits.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/traits.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The Smithy model defines several types of trait annotations. Some of these affect code generation or documentation generation. This document lists traits used in wasmCloud interfaces and used by the code generator. Some of the traits listed here do not currently influence code generation or system behavior, but we think may be used in the near future.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/traits.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/traits.md
@@ -3,6 +3,10 @@ title: 'Annotation traits'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The Smithy model defines several types of trait annotations. Some of these affect code generation or documentation generation. This document lists traits used in wasmCloud interfaces and used by the code generator. Some of the traits listed here do not currently influence code generation or system behavior, but we think may be used in the near future.
 
 ### @codegenRust

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/wasmcloud-smithy.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/wasmcloud-smithy.md
@@ -4,7 +4,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # wasmCloud-smithy guide

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/wasmcloud-smithy.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/interfaces/wasmcloud-smithy.md
@@ -3,6 +3,10 @@ title: 'wasmCloud Smithy'
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # wasmCloud-smithy guide
 
 wasmCloud's use of Smithy closely follows the [Smithy IDL specification](https://awslabs.github.io/smithy/1.0/spec/core/idl.html). This document is intended to be a quick reference to the major features of Smithy, and includes some conventions that wasmCloud has adopted for smithy-defined interfaces.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/protocol.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/protocol.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmbus has a few core requirements. The first is that the protocol must never expose the internal allocation strategy of either side of the conversation. This allows that same allocation strategy to change over time without requiring a rebuild and redeploy of any WebAssembly modules.

--- a/versioned_docs/version-0.82/hosts/abis/wasmbus/protocol.md
+++ b/versioned_docs/version-0.82/hosts/abis/wasmbus/protocol.md
@@ -5,6 +5,10 @@ sidebar_position: 6
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmbus has a few core requirements. The first is that the protocol must never expose the internal allocation strategy of either side of the conversation. This allows that same allocation strategy to change over time without requiring a rebuild and redeploy of any WebAssembly modules.
 
 The second requirement is that the protocol is effectively _stateless_. This means that state such as guest responses and error blobs and host responses and host error blobs will be maintained throughout the lifetime of _one host-initiated function call_, but all state should be considered wiped/discarded after the completion of that root call.

--- a/versioned_docs/version-0.82/hosts/custom-host/fromspec.md
+++ b/versioned_docs/version-0.82/hosts/custom-host/fromspec.md
@@ -6,6 +6,10 @@ draft: false
 description: 'Requirements and conditions all hosts must meet'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 In the preceding section of the documentation, we talked about how there are no restrictions in place preventing developers from building their own bespoke wasmCloud hosts that are optimized for specific environments.
 
 In this section, we'll talk about the specification and requirements for wasmCloud

--- a/versioned_docs/version-0.82/hosts/custom-host/fromspec.md
+++ b/versioned_docs/version-0.82/hosts/custom-host/fromspec.md
@@ -7,7 +7,7 @@ description: 'Requirements and conditions all hosts must meet'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 In the preceding section of the documentation, we talked about how there are no restrictions in place preventing developers from building their own bespoke wasmCloud hosts that are optimized for specific environments.

--- a/versioned_docs/version-0.82/hosts/custom-host/index.md
+++ b/versioned_docs/version-0.82/hosts/custom-host/index.md
@@ -5,4 +5,8 @@ sidebar_position: 10
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 This section of the documentation will give you the steps and specifications you need to create a host that can be deployed within a lattice and behave as a good citizen.

--- a/versioned_docs/version-0.82/hosts/custom-host/index.md
+++ b/versioned_docs/version-0.82/hosts/custom-host/index.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 This section of the documentation will give you the steps and specifications you need to create a host that can be deployed within a lattice and behave as a good citizen.

--- a/versioned_docs/version-0.82/hosts/elixir/architecture.md
+++ b/versioned_docs/version-0.82/hosts/elixir/architecture.md
@@ -8,7 +8,7 @@ sidebar_position: 0
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning

--- a/versioned_docs/version-0.82/hosts/elixir/architecture.md
+++ b/versioned_docs/version-0.82/hosts/elixir/architecture.md
@@ -7,6 +7,10 @@ type: "docs"
 sidebar_position: 0
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning
 wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
 :::

--- a/versioned_docs/version-0.82/hosts/elixir/healthchecks.md
+++ b/versioned_docs/version-0.82/hosts/elixir/healthchecks.md
@@ -5,6 +5,10 @@ sidebar_position: 12
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning
 wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
 :::

--- a/versioned_docs/version-0.82/hosts/elixir/healthchecks.md
+++ b/versioned_docs/version-0.82/hosts/elixir/healthchecks.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning

--- a/versioned_docs/version-0.82/hosts/elixir/host-configure.md
+++ b/versioned_docs/version-0.82/hosts/elixir/host-configure.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning

--- a/versioned_docs/version-0.82/hosts/elixir/host-configure.md
+++ b/versioned_docs/version-0.82/hosts/elixir/host-configure.md
@@ -5,6 +5,10 @@ sidebar_position: 3
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning
 wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
 :::

--- a/versioned_docs/version-0.82/hosts/elixir/index.md
+++ b/versioned_docs/version-0.82/hosts/elixir/index.md
@@ -7,6 +7,10 @@ type: "docs"
 sidebar_position: 6
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning
 wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
 :::

--- a/versioned_docs/version-0.82/hosts/elixir/index.md
+++ b/versioned_docs/version-0.82/hosts/elixir/index.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning

--- a/versioned_docs/version-0.82/hosts/elixir/running.md
+++ b/versioned_docs/version-0.82/hosts/elixir/running.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning

--- a/versioned_docs/version-0.82/hosts/elixir/running.md
+++ b/versioned_docs/version-0.82/hosts/elixir/running.md
@@ -5,6 +5,10 @@ sidebar_position: 11
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning
 wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
 :::

--- a/versioned_docs/version-0.82/hosts/elixir/safeshutdown.md
+++ b/versioned_docs/version-0.82/hosts/elixir/safeshutdown.md
@@ -5,6 +5,10 @@ sidebar_position: 12
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 :::warning
 wasmCloud's [Elixir host runtime](https://github.com/wasmcloud/wasmcloud-otp) has been deprecated. The [Rust wasmCloud runtime](https://github.com/wasmCloud/wasmCloud) is receiving all new features
 :::

--- a/versioned_docs/version-0.82/hosts/elixir/safeshutdown.md
+++ b/versioned_docs/version-0.82/hosts/elixir/safeshutdown.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 :::warning

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/control-interface.md
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/control-interface.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 The lattice control interface provides a way for clients to interact with the lattice to issue

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/control-interface.md
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/control-interface.md
@@ -5,6 +5,10 @@ sidebar_position: 3
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 The lattice control interface provides a way for clients to interact with the lattice to issue
 control commands and queries. This interface is a message broker protocol that supports
 functionality for starting and stopping actors and providers, declaring link definitions, monitoring

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/index.md
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/index.md
@@ -7,7 +7,7 @@ description: "A detailed specification on the requirements for being a good citi
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud's _lattice_ network protocols are all open and language agnostic and use NATS as the underlying transport. This section describes the various requirements

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/index.md
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/index.md
@@ -6,5 +6,9 @@ draft: false
 description: "A detailed specification on the requirements for being a good citizen on a wasmCloud cluster"
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud's _lattice_ network protocols are all open and language agnostic and use NATS as the underlying transport. This section describes the various requirements
 and specifications for lattice participants, including lattice RPC and the lattice control interface.

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/name.mdx
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/name.mdx
@@ -3,6 +3,10 @@ title: "Lattice name(space)"
 sidebar_position: 1
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 Lattices are designed to support multi-tenancy in that you can run multiple, isolated lattices on the same NATS cluster, without risking overlapping traffic. This is made possible through the use of a unique lattice name. The NATS subject hierarchy is sub-divided beneath this name.
 
 If you don't specify a name, wasmCloud will use `default`. This is fine when you're working on your development machine in isolation, but when you're running in a production environment, you might want to consider providing an explicit name for the lattice to avoid any chance of accidental overlap.

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/name.mdx
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/name.mdx
@@ -4,7 +4,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 Lattices are designed to support multi-tenancy in that you can run multiple, isolated lattices on the same NATS cluster, without risking overlapping traffic. This is made possible through the use of a unique lattice name. The NATS subject hierarchy is sub-divided beneath this name.

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/rpc.md
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/rpc.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 At its core, the _lattice_ is essentially a _Remote Procedure Call (RPC)_ bus layer built on top of the NATS message broker. When the lattice
 is enabled, participants in lattice RPC must conform to a set of standards in order to be able to send and handle messages.
 

--- a/versioned_docs/version-0.82/hosts/lattice-protocols/rpc.md
+++ b/versioned_docs/version-0.82/hosts/lattice-protocols/rpc.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 At its core, the _lattice_ is essentially a _Remote Procedure Call (RPC)_ bus layer built on top of the NATS message broker. When the lattice

--- a/versioned_docs/version-0.82/installation.mdx
+++ b/versioned_docs/version-0.82/installation.mdx
@@ -5,6 +5,10 @@ sidebar_position: 1
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # Installation
 
 First, we'll install `wash`, the WAsmcloud SHell, which we'll use to

--- a/versioned_docs/version-0.82/installation.mdx
+++ b/versioned_docs/version-0.82/installation.mdx
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # Installation

--- a/versioned_docs/version-0.82/intro.md
+++ b/versioned_docs/version-0.82/intro.md
@@ -2,6 +2,10 @@
 sidebar_position: 0
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # What is wasmCloud?
 
 wasmCloud is a **universal application platform** that helps you build and run globally distributed WebAssembly applications on any cloud and any edge.

--- a/versioned_docs/version-0.82/intro.md
+++ b/versioned_docs/version-0.82/intro.md
@@ -3,7 +3,7 @@ sidebar_position: 0
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # What is wasmCloud?

--- a/versioned_docs/version-0.82/kubernetes.mdx
+++ b/versioned_docs/version-0.82/kubernetes.mdx
@@ -4,6 +4,10 @@ title: 'wasmCloud on Kubernetes'
 
 import wrappedvalongside from './images/wrappedvalongside.png';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud and Kubernetes integrate via the open source [`wasmcloud-operator`](https://github.com/wasmCloud/wasmcloud-operator), which utilizes the [**operator pattern**](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) and [**custom resource definitions (CRDs)**](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to run wasmCloud hosts on Kubernetes&mdash;and thereby take full advantage of WebAssembly components in Kubernetes environments.
 
 With a Kubernetes cluster running the wasmCloud operator, launching components as Kubernetes services can be as simple as running `kubectl apply` on a wadm manifest:

--- a/versioned_docs/version-0.82/kubernetes.mdx
+++ b/versioned_docs/version-0.82/kubernetes.mdx
@@ -5,7 +5,7 @@ title: 'wasmCloud on Kubernetes'
 import wrappedvalongside from './images/wrappedvalongside.png';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud and Kubernetes integrate via the open source [`wasmcloud-operator`](https://github.com/wasmCloud/wasmcloud-operator), which utilizes the [**operator pattern**](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) and [**custom resource definitions (CRDs)**](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to run wasmCloud hosts on Kubernetes&mdash;and thereby take full advantage of WebAssembly components in Kubernetes environments.

--- a/versioned_docs/version-0.82/reference/official-oci/index.md
+++ b/versioned_docs/version-0.82/reference/official-oci/index.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our GitHub repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.

--- a/versioned_docs/version-0.82/reference/official-oci/index.md
+++ b/versioned_docs/version-0.82/reference/official-oci/index.md
@@ -5,4 +5,8 @@ sidebar_position: 2
 draft: false
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 We maintain a list of all officially supported, continually updated, first-party images managed by the wasmcloud team in our GitHub repositories. Refer to the [providers directory](https://github.com/wasmCloud/wasmCloud/tree/release/v0.82.0/crates/providers) for the latest updated versions of our first party capability providers, and the [examples directory](https://github.com/wasmCloud/wasmCloud/tree/main/examples) for the latest updated versions of our example actors and providers.

--- a/versioned_docs/version-0.82/roadmap/2023-q3q4.md
+++ b/versioned_docs/version-0.82/roadmap/2023-q3q4.md
@@ -6,6 +6,10 @@ sidebar_position: 999
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 wasmCloud is a constantly evolving project. The feature roadmap and release schedule aren't rigid at this time, instead, we're adopting a "Now, Next, Later" format to indicate when efforts are available for work. In addition to the higher-level roadmap on [GitHub Projects](https://github.com/orgs/wasmCloud/projects/7/views/3), wasmCloud is under constant development for smaller improvements, bug fixes and documentation. wasmCloud seeks to evolve with the WebAssembly ecosystem, adopting standards and best practices as they become available. We believe this is the best way, after hearing invaluable feedback from contributors and users, to accomplish our goals as a project.
 
 ## Goals

--- a/versioned_docs/version-0.82/roadmap/2023-q3q4.md
+++ b/versioned_docs/version-0.82/roadmap/2023-q3q4.md
@@ -7,7 +7,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 wasmCloud is a constantly evolving project. The feature roadmap and release schedule aren't rigid at this time, instead, we're adopting a "Now, Next, Later" format to indicate when efforts are available for work. In addition to the higher-level roadmap on [GitHub Projects](https://github.com/orgs/wasmCloud/projects/7/views/3), wasmCloud is under constant development for smaller improvements, bug fixes and documentation. wasmCloud seeks to evolve with the WebAssembly ecosystem, adopting standards and best practices as they become available. We believe this is the best way, after hearing invaluable feedback from contributors and users, to accomplish our goals as a project.

--- a/versioned_docs/version-0.82/roadmap/index.md
+++ b/versioned_docs/version-0.82/roadmap/index.md
@@ -7,6 +7,10 @@ sidebar_position: 998
 type: 'docs'
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # 2024 Q1 Roadmap (wasmCloud 1.0)
 
 :::info

--- a/versioned_docs/version-0.82/roadmap/index.md
+++ b/versioned_docs/version-0.82/roadmap/index.md
@@ -8,7 +8,7 @@ type: 'docs'
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # 2024 Q1 Roadmap (wasmCloud 1.0)

--- a/versioned_docs/version-0.82/tour/adding-capabilities.mdx
+++ b/versioned_docs/version-0.82/tour/adding-capabilities.mdx
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # Adding Capabilities

--- a/versioned_docs/version-0.82/tour/adding-capabilities.mdx
+++ b/versioned_docs/version-0.82/tour/adding-capabilities.mdx
@@ -5,6 +5,10 @@ sidebar_position: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # Adding Capabilities
 
 Going from "Hello World" to a full-fledged application requires just identifying what capabilities your application needs, and then adding them to your actor. Capabilities in wasmCloud can invoke a function handler in your actor in response to some external trigger (like HTTP Server and Messaging) and actors can invoke capabilities as a part of handling a request (like key-value store and logging). "Hello World" already has the HTTP Server capability, so let's add more features to this application with functional code and more capabilities.

--- a/versioned_docs/version-0.82/tour/hello-world.mdx
+++ b/versioned_docs/version-0.82/tour/hello-world.mdx
@@ -9,7 +9,7 @@ import HubspotForm from 'react-hubspot-form';
 import washboard_hello from '../images/washboard_hello.png';
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # Quickstart

--- a/versioned_docs/version-0.82/tour/hello-world.mdx
+++ b/versioned_docs/version-0.82/tour/hello-world.mdx
@@ -8,6 +8,10 @@ import HubspotForm from 'react-hubspot-form';
 
 import washboard_hello from '../images/washboard_hello.png';
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # Quickstart
 
 A familiar starting example to get you up and running with wasmCloud.

--- a/versioned_docs/version-0.82/tour/why-wasmcloud.mdx
+++ b/versioned_docs/version-0.82/tour/why-wasmcloud.mdx
@@ -3,7 +3,7 @@ sidebar_position: 3
 ---
 
 <head>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
 </head>
 
 # Hello Universe

--- a/versioned_docs/version-0.82/tour/why-wasmcloud.mdx
+++ b/versioned_docs/version-0.82/tour/why-wasmcloud.mdx
@@ -2,6 +2,10 @@
 sidebar_position: 3
 ---
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 # Hello Universe
 
 You've now built a simple microservice with wasmCloud that uses common capabilities (handle HTTP requests, interface with a key-value store) that many cloud native applications need. So, _why wasmCloud_? What makes this application that you built different from similar apps on other platforms? wasmCloud is an easy-to-use platform that's quick to get started with, which is essential for a great and intuitive developer experience, and this project extends far beyond "Hello World." This page emphasizes the intention behind the design of wasmCloud, and the benefits that follow after you've built your application.


### PR DESCRIPTION
Two SEO updates:

* Adding a robots.txt file that points to the sitemap and disallows crawling the 0.82 docs
* Adding noindex tags to all 0.82 pages

The idea here is to ensure that folks arriving in the docs via search are always finding the current version, and that Google's algorithms aren't mistakenly identifying 1.x and 0.82 versions of pages as duplicates and privileging the older version. (Google Search Console data indicates that this has been happening infrequently, but it has happened in some cases.)
