### PR TITLE
Update workflow for docs sync

### DIFF
--- a/.github/workflows/sync-examples-go.yml
+++ b/.github/workflows/sync-examples-go.yml
@@ -40,6 +40,6 @@ jobs:
           body: Updates Go example docs from wasmcloud-go. This is an automatic PR.
           branch: chore/update-go-example-docs
           delete-branch: true
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          committer: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          author: wasmCloud Automation Bot <151542377+wasmcloud-automation-app[bot]@users.noreply.github.com>
+          committer: wasmCloud Automation Bot <151542377+wasmcloud-automation-app[bot]@users.noreply.github.com>
           signoff: true

--- a/.github/workflows/sync-examples-rust.yml
+++ b/.github/workflows/sync-examples-rust.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 1 * * *'
   workflow_dispatch:
 
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/sync-examples-rust.yml'
+
 permissions:
   contents: write
   pull-requests: write
@@ -42,7 +48,8 @@ jobs:
             })
 
       - name: Create Docs PR
-        if: steps.sync-docs.outputs.docs_changed == 'true'
+        id: create-pr
+        if: github.event_name != 'pull_request' && steps.sync-docs.outputs.docs_changed == 'true'
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           path: ./wasmcloud.com
@@ -56,3 +63,34 @@ jobs:
           author: wasmCloud Automation Bot <151542377+wasmcloud-automation-app[bot]@users.noreply.github.com>
           committer: wasmCloud Automation Bot <151542377+wasmcloud-automation-app[bot]@users.noreply.github.com>
           signoff: true
+
+      - name: Workflow Summary
+        id: workflow-summary
+        if: ${{ always() }}
+        env:
+          UPDATE_DOCS: ${{ steps.sync-docs.outcome }}
+          PR_CREATION: ${{ steps.create-pr.outcome }}
+          ANY_CHANGED: ${{ steps.sync-docs.outputs.docs_changed }}
+        run: | #shell
+          echo "### Docs Sync Result" >> $GITHUB_STEP_SUMMARY
+
+          case "$UPDATE_DOCS" in
+            success)   echo "- ✅ \`updateDocs()\` was called and completed successfully" >> $GITHUB_STEP_SUMMARY;;
+            skipped)   echo "- ⏭️ \`updateDocs()\` was skipped" >> $GITHUB_STEP_SUMMARY;;
+            cancelled) echo "- 🚫 \`updateDocs()\` was cancelled" >> $GITHUB_STEP_SUMMARY;;
+            failure)   echo "- ❌ \`updateDocs()\` failed" >> $GITHUB_STEP_SUMMARY;;
+          esac
+
+          case "$ANY_CHANGED" in
+            false) echo "- 🟰 Docs were not changed (not a problem, probably just nothing new)" >> $GITHUB_STEP_SUMMARY;;
+            true) echo "- ✅ Docs were changed" >> $GITHUB_STEP_SUMMARY;;
+          esac
+
+          case "$PR_CREATION" in
+            success)   echo "- ✅ PR created" >> $GITHUB_STEP_SUMMARY;;
+            skipped)   echo "- ⏭️ PR creation was skipped" >> $GITHUB_STEP_SUMMARY;;
+            cancelled) echo "- 🚫 PR creation was cancelled" >> $GITHUB_STEP_SUMMARY;;
+            failure)   echo "- ❌ PR creation failed" >> $GITHUB_STEP_SUMMARY;;
+          esac
+
+          echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-examples-rust.yml
+++ b/.github/workflows/sync-examples-rust.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           script: |
             const { updateDocs } = await import("${{ github.workspace }}/wasmcloud.com/scripts/update-docs.mjs");
-            await updateDocs({
+            const result = await updateDocs({
               outputFolder: "./wasmcloud.com/docs/examples/rust",
               readmePaths: [
                 "./wasmcloud/examples/rust/components/**/README.md",
@@ -45,7 +45,8 @@ jobs:
               skipProjects: [
                 "echo-messaging-0-3-0",
               ],
-            })
+            }, { glob })
+            core.setOutput('docs_changed', result.docs_changed);
 
       - name: Create Docs PR
         id: create-pr

--- a/.github/workflows/sync-examples-rust.yml
+++ b/.github/workflows/sync-examples-rust.yml
@@ -53,6 +53,6 @@ jobs:
             Updates Rust example docs from wasmcloud-go. This is an automatically generated PR.
           branch: chore/update-rust-example-docs
           delete-branch: true
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          committer: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          author: wasmCloud Automation Bot <151542377+wasmcloud-automation-app[bot]@users.noreply.github.com>
+          committer: wasmCloud Automation Bot <151542377+wasmcloud-automation-app[bot]@users.noreply.github.com>
           signoff: true

--- a/.github/workflows/sync-examples-rust.yml
+++ b/.github/workflows/sync-examples-rust.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const { updateDocs } = await import("${{ github.workspace }}/scripts/update-docs.mjs");
+            const { updateDocs } = await import("${{ github.workspace }}/wasmcloud.com/scripts/update-docs.mjs");
             await updateDocs({
               outputFolder: "./wasmcloud.com/docs/examples/rust",
               readmePaths: [


### PR DESCRIPTION
Had to change a few things with the script because the latest version of `actions/github-script` only runs node 20 and doesn't include `import('fs/promises').glob`.

Also added a workflow summary so I could test against the PR, but this will be useful in future.