### PR TITLE
chore(docs): adjust headings on Advanced page so h1 title displays

### DIFF
--- a/docs/developer/components/advanced.mdx
+++ b/docs/developer/components/advanced.mdx
@@ -12,7 +12,7 @@ This page documents some advanced use-cases for more complex components, along w
 
 [wasmcloud-component]: https://crates.io/crates/wasmcloud-component
 
-# Reusing code from helper libraries with custom interfaces (e.g. `wasmcloud-component`)
+## Reusing code from helper libraries with custom interfaces (e.g. `wasmcloud-component`)
 
 When building a component that contains custom interfaces *in addition* to using a standardized interfaces like `wasi:http`, your component's WIT interface might look something like this:
 
@@ -62,7 +62,7 @@ impl wasmcloud_component::http::Server for Component {
 }
 ```
 
-## Problem: Helper crates with pre-defined WASI exports
+### Problem: Helper crates with pre-defined WASI exports
 
 While `wasmcloud_component` is helpful, in the example component it causes an issue -- the component must implement *two* exports:
 
@@ -84,7 +84,7 @@ error: failed to encode component
               2: failed to find export of interface `example:component/transform` function `transform-bytes`
 ```
 
-## Solution: Merging pre-defined exports with local custom interfaces, using `wit-bindgen` manually
+### Solution: Merging pre-defined exports with local custom interfaces, using `wit-bindgen` manually
 
 To make this work properly, we'll need to write code that uses [`wit-bindgen`][wit-bindgen], rather than *just* `wasmcloud-component`:
 


### PR DESCRIPTION
Teensy adjustment to headings so they display consistently with other pages in this section and h1 title displays