### PR TITLE
feat(docusaurus): move scarf pixel to plugin

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -6,9 +6,10 @@ import {
 } from '@docusaurus/preset-classic';
 import { Options as PluginContentBlogOptions } from '@docusaurus/plugin-content-blog';
 import { Options as PluginGoogleAnalyticsOptions } from '@docusaurus/plugin-google-analytics';
-import { Options as PluginSEOChecksOptions } from '@wasmcloud/docusaurus-seo-checks';
 import { Options as PluginGithubStarsOptions } from '@wasmcloud/docusaurus-github-stars';
 import { Options as PluginHubspotAnalyticsOptions } from '@wasmcloud/docusaurus-hubspot-analytics';
+import { Options as PluginSEOChecksOptions } from '@wasmcloud/docusaurus-seo-checks';
+import { Options as PluginScarfAnalyticsOptions } from '@wasmcloud/docusaurus-scarf-analytics';
 import rehypeShiki, { RehypeShikiOptions } from '@shikijs/rehype';
 import { bundledLanguages } from 'shiki';
 import {
@@ -179,6 +180,12 @@ const config = (async (): Promise<Config> => {
           hubspotId: process.env.HUBSPOT_ID || 'localdev',
         } satisfies PluginHubspotAnalyticsOptions,
       ],
+      [
+        '@wasmcloud/docusaurus-scarf-analytics',
+        {
+          pixelId: process.env.SCARF_PIXEL_ID || 'localdev',
+        } satisfies PluginScarfAnalyticsOptions,
+      ],
       customPostCssPlugin, // PostCSS plugin function registration
     ],
 
@@ -328,13 +335,6 @@ const config = (async (): Promise<Config> => {
         attributes: {
           href: 'https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Lexend:wght@100..900&family=Inter:wght@100..900&display=swap',
           rel: 'stylesheet',
-        },
-      },
-      {
-        tagName: 'img',
-        attributes: {
-          src: 'https://static.scarf.sh/a.png?x-pxid=c2e66ae7-621b-4451-8c30-36d2c33d804b',
-          referrerpolicy: 'no-referrer-when-downgrade',
         },
       },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@shikijs/rehype": "~1.11.1",
         "@shikijs/transformers": "~1.11.1",
         "@wasmcloud/docusaurus-github-stars": "0.0.0",
+        "@wasmcloud/docusaurus-scarf-analytics": "0.0.0",
         "@wasmcloud/docusaurus-seo-checks": "0.0.0",
         "clsx": "^2.1.1",
         "react": "^19.0.0",
@@ -5788,6 +5789,10 @@
     },
     "node_modules/@wasmcloud/docusaurus-hubspot-analytics": {
       "resolved": "packages/docusaurus-hubspot-analytics",
+      "link": true
+    },
+    "node_modules/@wasmcloud/docusaurus-scarf-analytics": {
+      "resolved": "packages/docusaurus-scarf-analytics",
       "link": true
     },
     "node_modules/@wasmcloud/docusaurus-seo-checks": {
@@ -19343,6 +19348,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "packages/docusaurus-analytics-scarf": {
+      "name": "@wasmcloud/docusaurus-analytics-scarf",
+      "version": "0.0.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wasmcloud/docusaurus-helpers": "0.0.0"
+      }
+    },
     "packages/docusaurus-github-stars": {
       "name": "@wasmcloud/docusaurus-github-stars",
       "version": "0.0.0",
@@ -19367,6 +19381,14 @@
     },
     "packages/docusaurus-hubspot-analytics": {
       "name": "@wasmcloud/docusaurus-hubspot-analytics",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wasmcloud/docusaurus-helpers": "0.0.0"
+      }
+    },
+    "packages/docusaurus-scarf-analytics": {
+      "name": "@wasmcloud/docusaurus-scarf-analytics",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@shikijs/rehype": "~1.11.1",
     "@shikijs/transformers": "~1.11.1",
     "@wasmcloud/docusaurus-github-stars": "0.0.0",
+    "@wasmcloud/docusaurus-scarf-analytics": "0.0.0",
     "@wasmcloud/docusaurus-seo-checks": "0.0.0",
     "clsx": "^2.1.1",
     "react": "^19.0.0",

--- a/packages/docusaurus-scarf-analytics/package.json
+++ b/packages/docusaurus-scarf-analytics/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@wasmcloud/docusaurus-scarf-analytics",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "main": "src/index.ts",
+  "type": "module",
+  "author": "@wasmcloud",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@wasmcloud/docusaurus-helpers": "0.0.0"
+  }
+}

--- a/packages/docusaurus-scarf-analytics/src/index.ts
+++ b/packages/docusaurus-scarf-analytics/src/index.ts
@@ -1,0 +1,31 @@
+import { Plugin, LoadContext } from '@docusaurus/types';
+import { getPluginName } from '@wasmcloud/docusaurus-helpers';
+
+import { PluginOptions } from './options';
+
+const PLUGIN_NAME = getPluginName(__dirname);
+
+export default async function docusaurusChecks(
+  context: LoadContext,
+  options: PluginOptions,
+): Promise<Plugin<void>> {
+  return {
+    name: PLUGIN_NAME,
+    injectHtmlTags() {
+      return {
+        preBodyTags: [
+          {
+            tagName: 'img',
+            attributes: {
+              src: `https://static.scarf.sh/a.png?x-pxid=${options.pixelId}`,
+              alt: '',
+              referrerpolicy: 'no-referrer-when-downgrade',
+            },
+          },
+        ],
+      };
+    },
+  };
+}
+
+export { validateOptions, type Options } from './options';

--- a/packages/docusaurus-scarf-analytics/src/options.ts
+++ b/packages/docusaurus-scarf-analytics/src/options.ts
@@ -1,0 +1,18 @@
+import { Joi } from '@docusaurus/utils-validation';
+import type { OptionValidationContext } from '@docusaurus/types';
+
+type Options = { pixelId: string };
+type PluginOptions = Options;
+
+const schema = Joi.object({
+  pixelId: Joi.string().description('The Pixel ID to use for Scarf tracking').required(),
+});
+
+function validateOptions({
+  validate,
+  options,
+}: OptionValidationContext<Options, PluginOptions>): PluginOptions {
+  return validate(schema, options);
+}
+
+export { type Options, type PluginOptions, validateOptions };

--- a/packages/docusaurus-scarf-analytics/tsconfig.json
+++ b/packages/docusaurus-scarf-analytics/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Node10",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "composite": true,
+    "incremental": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "checkJs": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
The scarf pixel as an img tag was messing with the build output enough that it was causing warnings on every page. This plugin moves the `<img>` from inside the `<head>` (invalid html) to inside of the `<body>` tag.


Edit: No more build warnings:

``` plaintext
2:36:53 PM: Netlify Build                                                 
2:36:53 PM: ────────────────────────────────────────────────────────────────
2:36:53 PM: ​
2:36:53 PM: ❯ Version
2:36:53 PM:   @netlify/build 32.0.0
2:36:53 PM: ​
2:36:53 PM: ❯ Flags
2:36:53 PM:   accountId: 5e61148522b4c7bee4b74e49
2:36:53 PM:   baseRelDir: true
2:36:53 PM:   buildId: 67fea708fb64570008983a54
2:36:53 PM:   deployId: 67fea708fb64570008983a56
2:36:53 PM: ​
2:36:53 PM: ❯ Current directory
2:36:53 PM:   /opt/build/repo
2:36:53 PM: ​
2:36:53 PM: ❯ Config file
2:36:53 PM:   /opt/build/repo/netlify.toml
2:36:53 PM: ​
2:36:53 PM: ❯ Context
2:36:53 PM:   deploy-preview
2:36:53 PM: ​
2:36:53 PM: Build command from Netlify app                                
2:36:53 PM: ────────────────────────────────────────────────────────────────
2:36:53 PM: ​
2:36:53 PM: $ npm run build
2:36:53 PM: > wasmcloud.com@0.1.0 build
2:36:53 PM: > docusaurus build
2:36:56 PM: [INFO] [en] Creating an optimized production build...
2:36:56 PM: The exported identifier "DefaultCheckOptions" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
2:36:56 PM: never encountered it as a TypeScript type declaration.
2:36:56 PM: It will be treated as a JavaScript value.
2:36:56 PM: This problem is likely caused by another plugin injecting
2:36:56 PM: "DefaultCheckOptions" without registering it in the scope tracker. If you are the author
2:36:56 PM:  of that plugin, please use "scope.registerDeclaration(declarationPath)".
2:36:56 PM: The exported identifier "DefaultCheckOptions" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
2:36:56 PM: never encountered it as a TypeScript type declaration.
2:36:56 PM: It will be treated as a JavaScript value.
2:36:56 PM: This problem is likely caused by another plugin injecting
2:36:56 PM: "DefaultCheckOptions" without registering it in the scope tracker. If you are the author
2:36:56 PM:  of that plugin, please use "scope.registerDeclaration(declarationPath)".
2:37:28 PM: [INFO] [[@wasmcloud/docusaurus-seo-checks]] Running post-build checks
2:37:28 PM: [SUCCESS] Generated static files in "build".
2:37:28 PM: [INFO] Use `npm run serve` command to test your build locally.
2:37:29 PM: ​
2:37:29 PM: (build.command completed in 35.5s)
2:37:29 PM: ​
2:37:33 PM: (Netlify Build completed in 39.5s)
2:37:33 PM: Section completed: building
```
