### PR TITLE
Update scale-and-distribute.mdx: Fix wrong "Bob" logs to "Alice"

### DIFF
--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -354,18 +354,18 @@ curl: (28) Operation timed out after 3001 milliseconds with 0 bytes received
 As you can see, only the first `curl` command receives the expected response in time, while all the others run into a timeout. However, if you check the logs of the wasmCloud host, you will see that multiple requests have been received and forwarded to our component one after the other.
 
 ```text
-2024-10-20T19:29:30.897232Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Bob component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:30.897232Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Alice component_id="rust_hello_world-http_component" level=Level::Info context=""
 2024-10-20T19:29:30.897253Z  INFO log: wasmcloud_host::wasmbus::handler: Sleep for 2 to simulate longer processing time component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:32.905355Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x1, Bob!' component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:32.906138Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Bob component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:32.905355Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x1, Alice!' component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:32.906138Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Alice component_id="rust_hello_world-http_component" level=Level::Info context=""
 2024-10-20T19:29:32.906258Z  INFO log: wasmcloud_host::wasmbus::handler: Sleep for 2 to simulate longer processing time component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:34.914152Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x2, Bob!' component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:34.914992Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Bob component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:34.914152Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x2, Alice!' component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:34.914992Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Alice component_id="rust_hello_world-http_component" level=Level::Info context=""
 2024-10-20T19:29:34.915023Z  INFO log: wasmcloud_host::wasmbus::handler: Sleep for 2 to simulate longer processing time component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:36.923568Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x3, Bob!' component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:36.924326Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Bob component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:36.923568Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x3, Alice!' component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:36.924326Z  INFO log: wasmcloud_host::wasmbus::handler: Greeting Alice component_id="rust_hello_world-http_component" level=Level::Info context=""
 2024-10-20T19:29:36.924351Z  INFO log: wasmcloud_host::wasmbus::handler: Sleep for 2 to simulate longer processing time component_id="rust_hello_world-http_component" level=Level::Info context=""
-2024-10-20T19:29:38.933227Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x4, Bob!' component_id="rust_hello_world-http_component" level=Level::Info context=""
+2024-10-20T19:29:38.933227Z  INFO log: wasmcloud_host::wasmbus::handler: Replying greeting 'Hello x4, Alice!' component_id="rust_hello_world-http_component" level=Level::Info context=""
 ```
 
 :::note[Checking the `DEBUG` or `TRACE` logs of the wasmCloud host]


### PR DESCRIPTION
## Feature or Problem
Noticed that after curling ten times with the name "Alice" via `seq 1 10 | xargs -P0 -I {} curl --max-time 3 "localhost:8000?name=Alice"` the logs of the wasmCloud host are expected to greet "Bob"

## Related Issues
-

## Release Information
next

## Consumer Impact
no dependencies, just doc

## Testing
follow the https://wasmcloud.com/docs/tour/deploy-and-scale/ tour

### Unit Test(s)
-

### Acceptance or Integration
-

### Manual Verification
follow the https://wasmcloud.com/docs/tour/deploy-and-scale/ tour
