### PR TITLE
docs: Fix missing link to the Rust example repository

### DIFF
--- a/docs/examples/rust/index.mdx
+++ b/docs/examples/rust/index.mdx
@@ -7,7 +7,7 @@ This section includes examples of [WebAssembly components](/docs/concepts/compon
 Rust has excellent support for WebAssembly, and much of the upstream tooling in the WebAssembly ecosystem is written in Rust, taking advantage of it's efficiency and
 safety guarantees.
 
-Examples are automatically propagated from the [`wasmCloud/rust` repository](https://github.com/wasmCloud/rust).
+Examples are automatically propagated from [`wasmCloud/wasmCloud` repository](https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust).
 
 [rust]: https://www.rust-lang.org
 


### PR DESCRIPTION
## Problem

The link for the example repository on https://wasmcloud.com/docs/examples/rust/ is broken.
The current link is referring nonexistent repository.

## Related Issues

None

### Manual Verification

Track the link from https://github.com/g1eng/wasmcloud.com/blob/fix-rust-example-link/docs/examples/rust/index.mdx.
And from https://deploy-preview-933--dreamy-golick-5f201e.netlify.app/docs/examples/rust/.