### PR TITLE
Improve GitHub Actions with docusaurus caching

### DIFF
--- a/.github/workflows/agenda.yml
+++ b/.github/workflows/agenda.yml
@@ -14,12 +14,12 @@ jobs:
   create_agenda:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create Community Agenda
         run: |
           bash agenda.sh ${{ inputs.date }} ${{ inputs.livestream_url }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           commit-message: added community meeting agenda for ${{ inputs.date }}
           title: Community Agenda ${{ inputs.date }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -12,12 +12,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           cache: npm
+
+      - name: Docusaurus Cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: node_modules/.cache
+          key: ${{ runner.os }}-docusaurus-${{ hashFiles('**/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-${{ hashFiles('**/package-lock.json') }}-
+            ${{ runner.os }}-docusaurus-
 
       - name: Install
         run: npm install
@@ -26,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: Upload Build
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-assets
           path: |

--- a/src/theme/MDXComponents/Code/index.tsx
+++ b/src/theme/MDXComponents/Code/index.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from 'react';
 import React from 'react';
 import CopyButton from './CopyButton';
 import codeBlockStyles from './CodeBlock.module.css';
+import { getTextForCopy } from '@site/src/theme/MDXComponents/Code/utils/getTextForCopy';
 
 function shouldBeInline(props: Props): boolean {
   return (
@@ -16,58 +17,10 @@ function shouldBeInline(props: Props): boolean {
   );
 }
 
-function nodeIsReactElement<P extends Record<string, unknown>>(
-  node: React.ReactNode,
-  props?: P,
-): node is React.ReactElement<P> {
-  if (!React.isValidElement(node)) return false;
-
-  const hasAllProps = props && Object.keys(props).every((key) => key in (node.props as object));
-  if (!hasAllProps) return false;
-
-  return true;
-}
-
-function hasClassName(node: React.ReactNode, className: string): boolean {
-  if (!nodeIsReactElement(node)) return false;
-  if (typeof node.props.className !== 'string') return false;
-  return node.props.className.includes(className);
-}
-
-// the `\uFEFF` character is the ZERO WIDTH NO-BREAK SPACE that is invisible in most fonts
-const WHITESPACE_REPLACEMENT_STRING = '\uFEFF \n';
-const WHITESPACE_REPLACEMENT_REGEX = new RegExp(`${WHITESPACE_REPLACEMENT_STRING}\n`, 'g');
-
-function getTextForCopy(node: React.ReactNode): string {
-  if (node === null) return '';
-
-  switch (typeof node) {
-    case 'string':
-    case 'number':
-      return node.toString();
-    case 'boolean':
-      return '';
-    case 'object':
-      if (node instanceof Array) return React.Children.map(node, getTextForCopy).join('');
-      if (!nodeIsReactElement(node)) return '';
-      // when skipping lines that are "removed" in a diff, we also need to remove the following line, so here we are
-      // adding a recognizable but invisible whitespace character which will be stripped later
-      if (hasClassName(node, 'diff remove')) return WHITESPACE_REPLACEMENT_STRING;
-      return getTextForCopy(React.isValidElement(node.props.children) ? node.props.children : null);
-    default:
-      return '';
-  }
-}
-
-function stripDiffSpacer(str: string): string {
-  // remove the extra space added to removed lines in diffs
-  return str.replace(WHITESPACE_REPLACEMENT_REGEX, '');
-}
-
 function CodeBlock(props: ComponentProps<'code'>) {
   const codeRef = React.useRef<HTMLElement>(null);
   const language = props.className?.replace(/language-/, '');
-  const code = stripDiffSpacer(getTextForCopy(props.children));
+  const code = getTextForCopy(props.children);
 
   return (
     <div className={codeBlockStyles.CodeBlock}>

--- a/src/theme/MDXComponents/Code/utils/getTextForCopy.ts
+++ b/src/theme/MDXComponents/Code/utils/getTextForCopy.ts
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+function nodeIsReactElement<P extends Record<string, unknown>>(
+  node: React.ReactNode,
+  props?: P,
+): node is React.ReactElement<P> {
+  if (!React.isValidElement(node)) return false;
+
+  const hasAllProps = props && Object.keys(props).every((key) => key in (node.props as object));
+  if (!hasAllProps) return false;
+
+  return true;
+}
+
+function hasClassName(node: React.ReactNode, className: string): boolean {
+  if (!nodeIsReactElement(node)) return false;
+  if (typeof node.props.className !== 'string') return false;
+  return node.props.className.includes(className);
+}
+
+function hasReactChildren(
+  node: React.ReactNode,
+): node is React.ReactElement<React.PropsWithChildren> {
+  if (!nodeIsReactElement(node)) return false;
+  return React.Children.count(node.props.children) > 0;
+}
+
+function getTextForCopy(node?: React.ReactNode | null): string {
+  if (node === null || node === undefined) return '';
+
+  // When getting all the text from a node, we want to remove the diff lines that were marked as
+  // "removed" in the diff. Since code blocks are split up by line, and here we are only handling
+  // one line at a time, we can't remove the following newline at the same time. To do that, we are
+  // adding a recognizable but invisible whitespace character which will be stripped later.
+
+  // the `\uFEFF` character is the ZERO WIDTH NO-BREAK SPACE that is invisible in most fonts
+  const WHITESPACE_REPLACEMENT_STRING = '\uFEFF \n';
+
+  // should be identical to `WHITESPACE_REPLACEMENT_STRING` but with the additional newline char
+  const WHITESPACE_REPLACEMENT_REGEXP = /\uFEFF \n\n/g;
+  const stripDiffSpacer = (str: string): string => str.replace(WHITESPACE_REPLACEMENT_REGEXP, '');
+
+  const getTextFromNode = (node: React.ReactNode): string => {
+    switch (typeof node) {
+      case 'string':
+      case 'number':
+        return node.toString();
+      case 'boolean':
+        return '';
+      case 'object':
+        if (node instanceof Array) return React.Children.map(node, getTextForCopy).join('');
+        if (hasReactChildren(node)) return getTextFromNode(node.props.children);
+        if (!nodeIsReactElement(node)) return '';
+        // This is where we handle the case of a diff line that is marked as "removed".
+        if (hasClassName(node, 'diff remove')) return WHITESPACE_REPLACEMENT_STRING;
+        return '';
+      default:
+        return '';
+    }
+  };
+
+  return stripDiffSpacer(getTextFromNode(node));
+}
+
+export { getTextForCopy };


### PR DESCRIPTION
- **ci: add caching for github actions**
  Made some changes to the actions so they are using the latest action versions, and added the docusaurus build cache to the workflow.
- **fix(theme): Move getTextForCopy to a separate file** 
  I also made a small change to the Code UI element, purely for organization.

