### PR TITLE
Add note about provider sdks as wasm components

### DIFF
--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -35,6 +35,10 @@ For example...
 
 wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own providers, and write your own interfaces in the [WebAssembly Interface Type (WIT)](/docs/concepts/interfaces) interface description language. 
 
+:::info[Note]
+The long term plan is to be able to develop capability providers as wasm components. Providers need to handle NATS subscriptions and generate types for wRPC and then run as a standalone binary. Adding native SDKs for more languages would also require native SDKs for these languages in NATS and wRPC, so the most flexible option is to enable wasm component providers.
+:::
+
 For more information, see...
 
 * [Creating a provider](/docs/developer/providers/)

--- a/docs/concepts/capabilities.mdx
+++ b/docs/concepts/capabilities.mdx
@@ -36,7 +36,7 @@ For example...
 wasmCloud supports custom capabilities&mdash;use our provider SDKs for [Rust](https://crates.io/crates/wasmcloud-provider-sdk) and [Go](https://github.com/wasmCloud/provider-sdk-go) to create your own providers, and write your own interfaces in the [WebAssembly Interface Type (WIT)](/docs/concepts/interfaces) interface description language. 
 
 :::info[Note]
-The long term plan is to be able to develop capability providers as wasm components. Providers need to handle NATS subscriptions and generate types for wRPC and then run as a standalone binary. Adding native SDKs for more languages would also require native SDKs for these languages in NATS and wRPC, so the most flexible option is to enable wasm component providers.
+The long term plan is to be able to develop capability providers as Wasm components. Providers are fairly simple, only needing to handle NATS subscriptions for wRPC, generate types from WIT, and then execute as a standalone binary. Enabling Wasm component providers would remove the complexity of cross-compilation and the need to execute as a native binary, as well as improving performance and security. We're continuously evaluating the Wasm landscape to determine when we can make this shift.
 :::
 
 For more information, see...


### PR DESCRIPTION
I was a bit confused by the documentation, that there are only provider SDKs in Rust and Go, while my initial thought was that wasmcloud would be fully component based. 

I posed a question in #capability-providers in slack, and wanted to add the answers to the documentation, to clear up any confusion for others...

I'm sure the note could be rephrased (I'm not a native speaker), feel free to do that.