### PR TITLE
docs: add missing build dependency for go provider tutorial

### DIFF
--- a/docs/developer/languages/go/providers.mdx
+++ b/docs/developer/languages/go/providers.mdx
@@ -33,7 +33,7 @@ Additionally, for the purposes of the "testing" section of this example, you'll 
 * [`nats-cli`](https://github.com/nats-io/natscli)
 * [`nats-server`](https://github.com/nats-io/nats-server)
 
-Finally, for running it on wasmCloud you will need to build a component for which you'll want:
+Finally, building the Go-based test component requires:
 
 * [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+
 

--- a/docs/developer/languages/go/providers.mdx
+++ b/docs/developer/languages/go/providers.mdx
@@ -33,6 +33,10 @@ Additionally, for the purposes of the "testing" section of this example, you'll 
 * [`nats-cli`](https://github.com/nats-io/natscli)
 * [`nats-server`](https://github.com/nats-io/nats-server)
 
+Finally, for running it on wasmCloud you will need to build a component for which you'll want:
+
+* [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+
+
 ### Create a new provider
 
 Use `wash` to start a new provider project:


### PR DESCRIPTION
## Feature or Problem

The command `cd component && wash build` requires tinygo to be installed, but this is not listed as a build dependency for the tutorial.

### Manual Verification

Tried to go through the tutorial and `wash build` complained that TinyGo is not installed.
