### PR TITLE
feat(docs): add diagram assets to contributing guide

### DIFF
--- a/docs/contributing/documentation.mdx
+++ b/docs/contributing/documentation.mdx
@@ -35,6 +35,21 @@ To serve the generated static content:
 npm run serve
 ```
 
+## Diagram assets
+
+You can find image assets for diagrams on the [community wasmCloud room in Excalidraw](https://excalidraw.com/#room=06971788f5402bcaacff,h2syuNVt8lmSYzHhJPdfRw). 
+
+We recommend copying assets that you would like to use to your own Excalidraw session and exporting your image as a PNG file with a transparent background (and careful use of black and white) for maximum compatibility with the documentation site's dark and light modes.
+
+wasmCloud's brand colors are:
+
+- Green Aqua - #00C389
+- Light Gray - #768692
+- Yellow - #FFB600
+- Space Blue - #002E5D
+- Gunmetal - #253746
+- Gainsboro - #D9E1E2
+
 ## Generating CLI documentation
 
 The [command-line documentation](/docs/cli/wash) at [`docs/cli/wash.mdx`](https://github.com/wasmCloud/wasmcloud.com/tree/main/docs/cli/wash.mdx) is generated using the `--help-markdown` argument with `wash`. An easy way to run the command is `wash app list --help-markdown > wash-help.md`. Once you've generated CLI documentation, copy the contents to the `wash.mdx` file linked above.


### PR DESCRIPTION
Adds instructions for accessing and using a community image library on Excalidraw when creating diagrams and images for the documentation site. 
