### PR TITLE
fix(docs): fix Go quickstart and add wasm-tools admonitions

### DIFF
--- a/docs/developer/languages/go/components.mdx
+++ b/docs/developer/languages/go/components.mdx
@@ -37,7 +37,11 @@ In this walkthrough, we will create an HTTP server from scratch using the [Go Co
 * [Go](https://go.dev/doc/install) 1.23.0+
 * [TinyGo](https://tinygo.org/getting-started/install/) 0.33.0+
 * [wasmCloud Shell (`wash`)](https://wasmcloud.com/docs/installation) CLI 0.36.1+ for building and deploying components
-* [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) for Go binding generation
+* [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) v1.225.0 for Go binding generation
+
+:::warning[]
+Due to incompatibilities introduced in `wasm-tools` v1.226.0 and higher, **we strongly recommend using `wasm-tools` v1.225.0** when building Go projects. The easiest way to download `wasm-tools` v1.225.0 is via [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html): `cargo install --locked wasm-tools@1.225.0`
+:::
 
 ### Step 1: Set up with `wash`
 

--- a/docs/tour/add-features.mdx
+++ b/docs/tour/add-features.mdx
@@ -234,6 +234,8 @@ We've given our application the ability to perform atomic incrementation and sto
 
 Now let's use the atomic increment function to keep track of how many times we've greeted each person.
 
+**Note:** We'll need to restart the dev loop for the next step, so go ahead and stop it with Ctrl+C.
+
 ```go
 //go:generate go run go.bytecodealliance.org/cmd/wit-bindgen-go generate --world hello --out gen ./wit
 package main
@@ -242,8 +244,8 @@ import (
   "fmt"
   "net/http"
 
-  atomics "github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world/gen/wasi/keyvalue/atomics"  // [!code ++]
-  store "github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world/gen/wasi/keyvalue/store"  // [!code ++]
+  atomics "hello/gen/wasi/keyvalue/atomics"  // [!code ++]
+  store "hello/gen/wasi/keyvalue/store"  // [!code ++]
   "go.wasmcloud.dev/component/log/wasilog"  // [!code ++]
   "go.wasmcloud.dev/component/net/wasihttp"
 )
@@ -285,6 +287,12 @@ Download the `wasilog` module for idiomatic Go logging that compiles to a compon
 
 ```shell
 go get go.wasmcloud.dev/component/log/wasilog
+```
+
+Now restart the dev loop:
+
+```shell
+wash dev
 ```
 
   </TabItem>
@@ -332,6 +340,8 @@ impl http::Server for Component {
     }
 }
 ```
+
+We've made changes, so once we save, `wash dev` will once again automatically update the running application.
 
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
@@ -403,10 +413,12 @@ function handle(req: IncomingRequest, resp: ResponseOutparam) {
 }
 ```
 
+We've made changes, so once we save, `wash dev` will once again automatically update the running application.
+
   </TabItem>
 </Tabs>
 
-We've made changes, so once we save, `wash dev` will once again automatically update the running application.
+Let's `curl` the component again:
 
 ```shell
 curl 'localhost:8000?name=Bob'

--- a/docs/tour/hello-world.mdx
+++ b/docs/tour/hello-world.mdx
@@ -99,7 +99,11 @@ Requirements:
 
 - [Go](https://go.dev/doc/install) 1.23.0+
 - [TinyGo](https://tinygo.org/getting-started/install/) (always use the latest version):
-- [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) 1.219+
+- [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools#installation) **v1.225.0**
+
+:::warning[]
+Due to incompatibilities introduced in `wasm-tools` v1.226.0 and higher, **we strongly recommend using `wasm-tools` v1.225.0** when building Go projects. The easiest way to download `wasm-tools` v1.225.0 is via [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html): `cargo install --locked wasm-tools@1.225.0`
+:::
 
 <Tabs groupId="os" queryString>
   <TabItem value="macos" label="macOS">
@@ -114,11 +118,7 @@ brew install go
 brew install tinygo-org/tools/tinygo
 ```
 
-**You will also need the `wasm-tools` utility.** You can use `brew`:
-
-```shell
-brew install wasm-tools
-```
+**You will also need the `wasm-tools` utility.**
 
   </TabItem>
 
@@ -205,13 +205,13 @@ tinygo version
 
 </Tabs>
 
-If you have the [Rust toolchain](https://www.rust-lang.org/tools/install), you can use `cargo` to install `wasm-tools`:
+For the best experience, we strongly recommend using `wasm-tools` v1.225.0 and installing with [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
 
 ```shell
-cargo install wasm-tools
+cargo install --locked wasm-tools@1.225.0
 ```
 
-Otherwise, [download the binary for the latest version of `wasm-tools` for your architecture](https://github.com/bytecodealliance/wasm-tools#installation) and add it to your PATH.
+Otherwise, [download the binary for `wasm-tools` v1.225.0 for your architecture](https://github.com/bytecodealliance/wasm-tools/releases/tag/v1.225.0) and add it to your PATH.
 
   </TabItem>
   <TabItem value="rust" label="Rust" default>

--- a/docs/tour/scale-and-distribute.mdx
+++ b/docs/tour/scale-and-distribute.mdx
@@ -129,8 +129,8 @@ import (
 	"net/http"
 	"time" // [!code ++]
 
-	atomics "github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world/gen/wasi/keyvalue/atomics"
-	store "github.com/wasmcloud/wasmcloud/examples/golang/components/http-hello-world/gen/wasi/keyvalue/store"
+	atomics "hello/gen/wasi/keyvalue/atomics"
+	store "hello/gen/wasi/keyvalue/store"
 	"go.wasmcloud.dev/component/log/wasilog"
 	"go.wasmcloud.dev/component/net/wasihttp"
 )


### PR DESCRIPTION
There were several issues introducing errors or potential errors in the Go quickstart: the specified "packages" for bindings in the example code didn't match the module name when following the instructions precisely, `wash dev` requires a restart at one point, and most importantly, the whole thing will fail if the user has a version of `wasm-tools` above v1.225.0. 

This PR adds a warning to use `wasm-tools` v1.225.0, updates the code examples, and adds an admonition about `wasm-tools` to the Go developer guide. 

Resolves #947 