### PR TITLE
fix: react children docusaurus rendered elements are copiable blocks with the copy button

### DIFF
--- a/src/theme/MDXComponents/Code/utils/getTextForCopy.ts
+++ b/src/theme/MDXComponents/Code/utils/getTextForCopy.ts
@@ -4,12 +4,12 @@ function nodeIsReactElement<P extends Record<string, unknown>>(
   node: React.ReactNode,
   props?: P,
 ): node is React.ReactElement<P> {
+  // Most of the times the copiable elements are within one span and as children finger
+  if (React.Children.count(node) === 1 && React.isValidElement(node) && node.type === "span") {
+    return true;
+  }
   if (!React.isValidElement(node)) return false;
-
-  const hasAllProps = props && Object.keys(props).every((key) => key in (node.props as object));
-  if (!hasAllProps) return false;
-
-  return true;
+  return props && Object.keys(props).every((key) => key in (node.props as object));
 }
 
 function hasClassName(node: React.ReactNode, className: string): boolean {
@@ -27,39 +27,47 @@ function hasReactChildren(
 
 function getTextForCopy(node?: React.ReactNode | null): string {
   if (node === null || node === undefined) return '';
+  return stripDiffSpacer(getTextFromNode(node));
+}
 
+// the `\uFEFF` character is the ZERO WIDTH NO-BREAK SPACE that is invisible in most fonts
+const WHITESPACE_REPLACEMENT_STRING = '\uFEFF \n' as const;
+
+// should be identical to `WHITESPACE_REPLACEMENT_STRING` but with the additional newline char
+const WHITESPACE_REPLACEMENT_REGEXP = /\uFEFF \n\n/g;
+const stripDiffSpacer = (str: string): string => str.replace(WHITESPACE_REPLACEMENT_REGEXP, '');
+
+const getTextFromNode = (node: React.ReactNode): string => {
   // When getting all the text from a node, we want to remove the diff lines that were marked as
   // "removed" in the diff. Since code blocks are split up by line, and here we are only handling
   // one line at a time, we can't remove the following newline at the same time. To do that, we are
   // adding a recognizable but invisible whitespace character which will be stripped later.
 
-  // the `\uFEFF` character is the ZERO WIDTH NO-BREAK SPACE that is invisible in most fonts
-  const WHITESPACE_REPLACEMENT_STRING = '\uFEFF \n';
-
-  // should be identical to `WHITESPACE_REPLACEMENT_STRING` but with the additional newline char
-  const WHITESPACE_REPLACEMENT_REGEXP = /\uFEFF \n\n/g;
-  const stripDiffSpacer = (str: string): string => str.replace(WHITESPACE_REPLACEMENT_REGEXP, '');
-
-  const getTextFromNode = (node: React.ReactNode): string => {
-    switch (typeof node) {
-      case 'string':
-      case 'number':
-        return node.toString();
-      case 'boolean':
-        return '';
-      case 'object':
-        if (node instanceof Array) return React.Children.map(node, getTextForCopy).join('');
-        if (hasReactChildren(node)) return getTextFromNode(node.props.children);
-        if (!nodeIsReactElement(node)) return '';
-        // This is where we handle the case of a diff line that is marked as "removed".
-        if (hasClassName(node, 'diff remove')) return WHITESPACE_REPLACEMENT_STRING;
-        return '';
-      default:
-        return '';
-    }
-  };
-
-  return stripDiffSpacer(getTextFromNode(node));
-}
+  switch (typeof node) {
+    case 'string':
+    case 'number':
+      return node.toString();
+    case 'boolean':
+      return '';
+    case 'object':
+      // The code snippet declares that this part is historical, removed with this step
+      if (hasClassName(node, 'diff remove')) return WHITESPACE_REPLACEMENT_STRING;
+      // Recursion since the multiple level of the copiable contens react segmentaion
+      if (hasReactChildren(node)) {
+        return getTextFromNode(node.props.children)
+      };
+      // Recursion since the multiple level of the copiable contens react segmentaion
+      if (node instanceof Array) {
+        return React.Children.map(node, getTextForCopy).join('');
+      }
+      // Cannot serialise to make it copiable
+      if (!nodeIsReactElement(node)) return '';
+      // Default empty
+      return '';
+    default:
+      // Fallback default empty
+      return '';
+  }
+};
 
 export { getTextForCopy };


### PR DESCRIPTION
If anyone would have a better implementation - a bit of a refactor of the code what would be really nice - or if someone has any 2 cents. The code is a bit fragmented, since I made it with trial error, not sure when did this functionality break, but this should more or less solve it.


## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Current behavior: Currently the Copy buttons are copying only newline chars `\n`.
Expected behavior: Copy buttons are copying the content of the associated text to the clipboard.

 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

closes: #952 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

Please be so king and click through some of the buttons that are more complex; containing: 
 - yaml
 - code changes
 - special characters if any.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

1. Open the app - locally with npm or with the preview;
1. open the docs site(s)
1. click on the "Copy" button
1. past is somewhere else
