### PR TITLE
chore(docs): add admonitions on scheduling plans in roadmap

### DIFF
--- a/docs/concepts/lattice.mdx
+++ b/docs/concepts/lattice.mdx
@@ -6,6 +6,10 @@ sidebar_position: 5
 type: 'docs'
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 ## Overview
 
 The lattice is a self-forming, self-healing mesh network that provides a unified, flat topology across any number of environments, clouds, browsers, or even hardware. A lattice allows [components](/docs/concepts/components), [providers](/docs/concepts/providers), and [hosts](/docs/concepts/hosts) to communicate with each other across any number of infrastructure barriers. A network in wasmCloud should "just work," which enables short developer feedback loops as well as production performance and resilience.

--- a/docs/deployment/lattice/index.mdx
+++ b/docs/deployment/lattice/index.mdx
@@ -4,6 +4,10 @@ description: 'Provisioning a lattice'
 sidebar_position: 1
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 All wasmCloud hosts are segmented into distinct namespaces called [lattices](/docs/concepts/lattice).
 
 When running locally with `wash up`, the lattice name defaults to `default`. In production, it's common to run multiple lattices on the same NATS cluster, where each lattice gets its own name.

--- a/docs/deployment/lattice/metadata.mdx
+++ b/docs/deployment/lattice/metadata.mdx
@@ -4,6 +4,10 @@ description: 'How to ensure redundancy of lattice metadata'
 sidebar_position: 1
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 The wasmCloud lattice makes use of a _distributed cache_ for lattice-wide metadata. The information in this cache is required to allow a lattice to function properly. It contains the following information:
 
 - Claims - JWTs are stored for both providers and components

--- a/docs/deployment/lattice/starting-hosts.mdx
+++ b/docs/deployment/lattice/starting-hosts.mdx
@@ -4,6 +4,10 @@ description: "How to dynamically start hosts in a lattice"
 sidebar_position: 4
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 When a wasmCloud host starts with no additional parameters or configuration, it creates a new "lattice of one"; the host starts with an _ad hoc_ generated seed key and uses the corresponding public key for the issuers list, which means it will not be able to communicate with other hosts.
 
 To ensure that any set of hosts are able to join the same lattice and securely communicate with each other, specify the following [host config](/docs/reference/host-config) options:

--- a/docs/deployment/nats/cluster-config.mdx
+++ b/docs/deployment/nats/cluster-config.mdx
@@ -4,6 +4,10 @@ description: 'How to set up a NATS server/cluster'
 sidebar_position: 1
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 A wasmCloud deployment requires at least one NATS server configured to use [JetStream](https://docs.nats.io/nats-concepts/jetstream). A production deployment should use at least one NATS [_cluster_](https://docs.nats.io/running-a-nats-service/configuration/clustering) with three or five servers depending on your reliability requirements.
 
 :::info

--- a/docs/deployment/nats/js-leaf.md
+++ b/docs/deployment/nats/js-leaf.md
@@ -3,6 +3,10 @@ title: 'Leaf Node Config (JetStream)'
 sidebar_position: 3
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 NATS leaf nodes are a simple concept but they enable an incredible amount of power, flexibility, and use cases. A leaf node allows NATS servers to bridge or join security domains. On any given server, you can set up [leaf node remotes](https://docs.nats.io/running-a-nats-service/configuration/leafnodes) that tether one account space on one side of the node to a different account space on the other side of the node.
 
 This simplicity and power makes leaf nodes work like a universal connector for stitching together disparate infrastructures and they are part of the magic sauce that makes wasmCloud lattices so powerful.

--- a/docs/deployment/nats/leaf-nodes.mdx
+++ b/docs/deployment/nats/leaf-nodes.mdx
@@ -4,6 +4,10 @@ description: 'A common way to for hosts to connect securely to a lattice'
 sidebar_position: 2
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 [NATS leaf nodes](https://docs.nats.io/nats-server/configuration/leafnodes) are a flexible way to extend NATS infrastructure. Leaf nodes enable segmentation or isolation of traffic and/or security boundaries.
 
 wasmCloud can use leaf nodes to simplify lattice configuration. A common pattern involves starting a NATS leaf node alongside a wasmCloud host on a system (virtual or otherwise). The leaf node is configured with credentials for authenticating with an external NATS cluster. By delegating the NATS authentication to the leaf node, the wasmCloud host can connect to the leaf node anonymously.

--- a/docs/deployment/nats/ngs.mdx
+++ b/docs/deployment/nats/ngs.mdx
@@ -4,6 +4,10 @@ description: 'Deploying wasmCloud on the Synadia Cloud network'
 sidebar_position: 3
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 [Synadia](https://www.synadia.com/) is the company behind the NATS messaging system that powers the wasmCloud [lattice](/docs/concepts/lattice.mdx). They offer a cloud-based service called Synadia Cloud (previously NGS) that provides a managed NATS service. NGS is a great way to get started with wasmCloud, as it provides a secure, scalable, and reliable messaging infrastructure.
 
 Deploying wasmCloud on Synadia Cloud is similar to deploying on any NATS infrastructure. The primary difference is that you will need to configure your wasmCloud hosts and [wadm](/docs/ecosystem/wadm/) to connect to the Synadia Cloud network. You can follow the steps in this guide replacing the Synadia Cloud-specific details with your own NATS infrastructure details as well.

--- a/docs/deployment/wadm/configuration.mdx
+++ b/docs/deployment/wadm/configuration.mdx
@@ -4,6 +4,10 @@ description: "A reference for configuration options for wadm"
 sidebar_position: 3
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/ecosystem/wadm/).
 :::

--- a/docs/deployment/wadm/deploy-architecture.mdx
+++ b/docs/deployment/wadm/deploy-architecture.mdx
@@ -4,6 +4,10 @@ description: "How to set up wadm for high availability and performance"
 sidebar_position: 2
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/ecosystem/wadm/).
 :::

--- a/docs/deployment/wadm/index.mdx
+++ b/docs/deployment/wadm/index.mdx
@@ -3,6 +3,10 @@ title: "Deploying Wadm"
 description: "Deploying and operating Wadm"
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 :::info
 These guides are for deploying wadm in **production**. For local development and testing, simply run `wash up`. For more information on wadm, see the [wadm docs](/docs/ecosystem/wadm/).
 :::

--- a/docs/deployment/wadm/installing.mdx
+++ b/docs/deployment/wadm/installing.mdx
@@ -4,6 +4,10 @@ description: "Installing wadm from releases or with Docker"
 sidebar_position: 1
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 `wadm` releases include a standalone binary and Docker image.
 
 ### Standalone Binary

--- a/docs/deployment/wadm/nats-credentials.mdx
+++ b/docs/deployment/wadm/nats-credentials.mdx
@@ -4,6 +4,10 @@ description: 'How to configure NATS credentials for wadm'
 sidebar_position: 4
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 :::info
 These guides are for deploying `wadm` in **production**. For local development and testing, simply run `wash up`. For more information on `wadm`, see the [`wadm` docs](/docs/ecosystem/wadm/).
 :::

--- a/docs/ecosystem/wadm/api.md
+++ b/docs/ecosystem/wadm/api.md
@@ -7,16 +7,14 @@ type: 'docs'
 sidebar_position: 4
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 The most common way to interact with a Wadm installation (which could be a single server or a
 cluster) is through the [wash](/docs/ecosystem/wadm/usage/) command-line tool or the [Rust client
 crate](https://docs.rs/wadm-client/latest/wadm_client/). However, if you are planning on creating
 your own integration or writing a non-Rust language binding, then this reference will help.
-
-:::warning
-**The wadm API is not currently 1.0**. This means the API is likely to undergo changes and there may
-be some pieces that aren't yet implemented. This document will be updated as we continue to work on
-the API. All API changes will also be communicated via the release notes for wadm.
-:::
 
 Please note that in production deployments, you will likely be using separate NATS credentials for
 accessing wadm. Please see the [operator guide](/docs/deployment/wadm/) for more information for running

--- a/docs/ecosystem/wadm/index.md
+++ b/docs/ecosystem/wadm/index.md
@@ -7,6 +7,10 @@ type: 'docs'
 sidebar_position: 0
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 ## Overview
 
 The **wasmCloud Application Deployment Manager (wadm)** manages declarative [application](/docs/concepts/applications) deployments, reconciling the current state of an application with the desired state.

--- a/docs/ecosystem/wadm/migrating.md
+++ b/docs/ecosystem/wadm/migrating.md
@@ -7,6 +7,10 @@ type: 'docs'
 sidebar_position: 5
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 The manifest format changed between wasmCloud `0.82.0` and wasmCloud `1.0.0`, and this page aims to guide you through converting your manifest to the latest compatible format. This page assumes that any [components](/docs/concepts/components.mdx) you specify in your manifest are built using WIT interfaces.
 
 ## Component changes

--- a/docs/ecosystem/wadm/model.md
+++ b/docs/ecosystem/wadm/model.md
@@ -7,6 +7,10 @@ type: 'docs'
 sidebar_position: 2
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 The **wasmCloud Application Deployment Manager** (`wadm`) uses the [Open Application Model](https://oam.dev/) to define application specifications. Because the OAM specification is extensible and platform-agnostic, it makes for an ideal way to represent applications with metadata specific to wasmCloud. 
 
 :::note[OAM expertise not required]

--- a/docs/ecosystem/wadm/status.md
+++ b/docs/ecosystem/wadm/status.md
@@ -7,6 +7,10 @@ type: 'docs'
 sidebar_position: 4
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 This page details the four different statuses that an application can have and what they mean. You will see the status of each application on the summary view of `wash app list`, or for an individual application by running `wash app status <app_name>`.
 
 ## Undeployed

--- a/docs/ecosystem/wadm/usage.md
+++ b/docs/ecosystem/wadm/usage.md
@@ -6,6 +6,10 @@ type: "docs"
 sidebar_position: 3
 ---
 
+:::warning[Planned changes to scheduling]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to scheduling in the next major release of wasmCloud. The new scheduling API will not use NATS to communicate between components by default, but will still support distributed communication via NATS. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 Using wadm typically involves using the `wash` command line tool. However, you can also use wash's supporting library in your Rust application or interact with wadm directly over a NATS connection.
 
 The following page on wadm API usage is an overview of the high-level functionality exposed by wadm. To see the corresponding commands in the `wash` CLI, issue the following command:


### PR DESCRIPTION
Adds admonitions to relevant pages on planned scheduling API changes on the Q3 2025 roadmap.