### PR TITLE
chore(docs): add admonitions on provider plans in roadmap

### DIFF
--- a/docs/capabilities/index.mdx
+++ b/docs/capabilities/index.mdx
@@ -2,6 +2,12 @@
 title: 'Capability Catalog'
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 **Capabilities** are pluggable pieces of functionality for your applications. Plug them in and swap them out whenever you want.
 
 Every capability consists of a **standard API** and one or more swappable plugins called **capability providers**. Learn more about capabilities, providers, interfaces, and other core concepts in the [Platform Guide](/docs/concepts/index.mdx).

--- a/docs/concepts/providers.mdx
+++ b/docs/concepts/providers.mdx
@@ -7,7 +7,13 @@ sidebar_position: 2
 type: 'docs'
 ---
 
-## Overview
+## Overview 
+
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
 
 **Providers** are swappable [host](/docs/concepts/hosts) plugins&mdash;executables (usually dedicated to longer-lived processes) that deliver common functionalities called **capabilities**. Providers are typically responsible for [capabilities](/docs/concepts/capabilities) that are not considered part of the core business logic of an application, such as...
 

--- a/docs/developer/languages/go/providers.mdx
+++ b/docs/developer/languages/go/providers.mdx
@@ -6,6 +6,12 @@ draft: false
 description: 'How to develop WebAssembly providers with Go'
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 # Building providers with Go
 
 wasmCloud provides a complete [SDK for building capability providers in Go](https://github.com/wasmCloud/go/tree/main/provider) (available as the Go package [`go.wasmcloud.dev/provider`](https://pkg.go.dev/go.wasmcloud.dev/provider)), meaning that Go developers can write every part of a wasmCloud application. 

--- a/docs/developer/languages/rust/providers.mdx
+++ b/docs/developer/languages/rust/providers.mdx
@@ -6,6 +6,12 @@ draft: false
 description: 'How to develop WebAssembly providers with Rust'
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 # Building providers with Rust
 
 wasmCloud provides a [`wasmcloud-provider-sdk` crate][crate-wasmcloud-provider-sdk] for building capability providers in Rust, along with

--- a/docs/developer/providers/build.md
+++ b/docs/developer/providers/build.md
@@ -5,6 +5,12 @@ sidebar_position: 2
 draft: false
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 A [provider archive](/docs/reference/glossary#provider-archive) (also called a _par file_) is an archive file (in unix 'tar' format) containing platform-specific executable files for a variety of CPU and OS combinations. A typical provider archive file contains executables for 64-bit Linux, x86_64 macOs, aarch64 macOs, and other supported platforms. The par file includes a cryptographically signed JSON Web Token (JWT) that contains a set of claims attestations for the capability provider.
 
 A provider archive can be uploaded to, or downloaded from, OCI registries.

--- a/docs/developer/providers/configure.mdx
+++ b/docs/developer/providers/configure.mdx
@@ -8,6 +8,12 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 Capability providers can be passed a map of configuration at runtime to use when executing. This configuration should first be defined using [wash](/docs/ecosystem/wash/) or as a part of your [wadm](/docs/ecosystem/wadm/) manifest, and then given to the capability provider at runtime.
 
 ## Define Configuration

--- a/docs/developer/providers/create.md
+++ b/docs/developer/providers/create.md
@@ -5,6 +5,12 @@ sidebar_position: 1
 draft: false
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 The first step in creating our new provider is to generate a new project from a template. We provide an example template to generate a capability provider that has scaffolding to implement the `wasmcloud:messaging` interface. This page will walk you through generating this capability provider and then implementing the functionality using [NATS](https://nats.io).
 
 :::info[Dependencies]

--- a/docs/developer/providers/index.md
+++ b/docs/developer/providers/index.md
@@ -5,6 +5,12 @@ sidebar_position: 0
 draft: false
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 Providers are executable host plug-ins&mdash;stateful, standalone processes that fulfill non-functional requirements for stateless components. For a high-level introduction to providers and why you might want to build one, see [Providers in the Concepts](/docs/concepts/providers/) section.
 
 Here, you can learn how to build your own provider. We'll walk you through implementing your own messaging provider for NATS, and you can use the same process to implement a capability provider using standard interfaces like `wasi:http`, `wasi:keyvalue`, `wasi:blobstore`, and `wasmcloud:messaging`.

--- a/docs/developer/providers/publish.md
+++ b/docs/developer/providers/publish.md
@@ -5,6 +5,12 @@ sidebar_position: 4
 draft: false
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 You can publish your provider to any OCI compliant registry that supports **OCI artifacts**. These artifacts are not container images, but conform to OCI standards and may be stored on any OCI-compatible registry. See the [Packaging](/docs/concepts/packaging.mdx) page for more details on how the wasmCloud ecosystem uses OCI artifacts for packaging.
 
 First-party wasmCloud providers are [hosted on GitHub Packages](https://ghcr.io/wasmcloud/wasmcloud), but any OCI-compliant registry is supported. 

--- a/docs/developer/providers/test.md
+++ b/docs/developer/providers/test.md
@@ -5,6 +5,12 @@ sidebar_position: 3
 draft: false
 ---
 
+:::warning[Planned changes to providers]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to capability providers in the next major release of wasmCloud. This overhaul transitions providers to a "wRPC server" model in which WIT interfaces are served via one of the transports available with wRPC (e.g., TCP, NATS, QUIC, or UDP), enabling capability implementations to be written in any language and to be deployed independently in containers. 
+
+For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4642: “Transition the capability provider model into support for wRPC servers,”](https://github.com/wasmCloud/wasmCloud/issues/4642) and [Issue #4636: "Support configuring a wasmCloud host with shared capability providers."](https://github.com/wasmCloud/wasmCloud/issues/4636)
+:::
+
 To test a provider, we can run it in a local wasmCloud environment, interacting with a real host and real components. To set up the environment:
 
 1. Run a local development environment with `wash up`


### PR DESCRIPTION
Adds admonitions to relevant pages on planned provider changes on the Q3 2025 roadmap.