### PR TITLE
chore(docs): add admonitions on secrets changes in roadmap

### DIFF
--- a/docs/capabilities/index.mdx
+++ b/docs/capabilities/index.mdx
@@ -21,6 +21,10 @@ Every capability consists of a **standard API** and one or more swappable plugin
 | Runtime Configuration | [`wasi:runtime-config`](https://github.com/WebAssembly/wasi-runtime-config)                      | [Runtime](https://github.com/wasmCloud/wasmCloud/tree/main/crates/runtime)                                                                                                                                                                                                            |
 | Secrets               | [`wasmcloud:secrets`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/secrets-types/wit) | [NATS Key-Value](https://github.com/wasmCloud/wasmCloud/tree/main/crates/secrets-nats-kv), [Vault](https://github.com/wasmCloud/contrib/tree/main/secrets/secrets-vault), [Kubernetes](https://github.com/wasmCloud/contrib/tree/main/secrets/secrets-kubernetes) |
 
+:::warning[Planned changes to secrets]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for changes to the secrets implementation in the next major release of wasmCloud. The new approach discontinues usage of xkeys (an extension on top of NATS' nkeys format) and leverages `wasi:config` backed by Kubernetes secrets. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4639: “Remove usage of wascap and nkeys,”](https://github.com/wasmCloud/wasmCloud/issues/4639) and [Issue #4638: “Simplify interface maintenance.”](https://github.com/wasmCloud/wasmCloud/issues/4638)
+:::
+
 ## Third-party capabilities
 
 | NAME      | INTERFACE                                                                                                      | PROVIDERS                                                                  |

--- a/docs/concepts/secrets.mdx
+++ b/docs/concepts/secrets.mdx
@@ -9,6 +9,10 @@ type: 'docs'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::warning[Planned changes to secrets]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for changes to the secrets implementation in the next major release of wasmCloud. The new approach discontinues usage of xkeys (an extension on top of NATS' nkeys format) and leverages `wasi:config` backed by Kubernetes secrets. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4639: “Remove usage of wascap and nkeys,”](https://github.com/wasmCloud/wasmCloud/issues/4639) and [Issue #4638: “Simplify interface maintenance.”](https://github.com/wasmCloud/wasmCloud/issues/4638)
+:::
+
 ## Overview
 
 Production applications often require secrets at runtime to access internal or external systems. wasmCloud provides first-class support for secrets in distributed environments.

--- a/docs/deployment/security/secrets.mdx
+++ b/docs/deployment/security/secrets.mdx
@@ -4,6 +4,10 @@ description: 'Using secrets backends with wasmCloud'
 sidebar_position: 4
 ---
 
+:::warning[Planned changes to secrets]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for changes to the secrets implementation in the next major release of wasmCloud. The new approach discontinues usage of xkeys (an extension on top of NATS' nkeys format) and leverages `wasi:config` backed by Kubernetes secrets. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7), [Issue #4639: “Remove usage of wascap and nkeys,”](https://github.com/wasmCloud/wasmCloud/issues/4639) and [Issue #4638: “Simplify interface maintenance.”](https://github.com/wasmCloud/wasmCloud/issues/4638)
+:::
+
 wasmCloud hosts retrieve secrets from secrets backends, which communicate with hosts over NATS using specified NATS subject prefixes. Secrets backends conform to a common API so that anyone can write a backend and add an implementation to their cluster. You can learn more about wasmCloud's implementation of secrets in the [Secrets page of the Platform Overview](/docs/concepts/secrets). 
 
 ## Implementing a secrets backend


### PR DESCRIPTION
Adds admonitions to relevant pages on planned secrets changes in the Q3 2025 roadmap.