### PR TITLE
chore(docs): add admonitions on cloudevents changes in roadmap

### DIFF
--- a/docs/concepts/hosts.mdx
+++ b/docs/concepts/hosts.mdx
@@ -44,6 +44,10 @@ The API for managing hosts, their inventories (components and providers), and ho
 
 ### Interoperable events
 
+:::warning[Planned changes to events]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for changes to the events implementation in the next major release of wasmCloud. In the new approach, events are handled at the operator layer, leveraging OpenTelemetry and discontinuing usage of CloudEvents. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4641: “Reduce host responsibility and API surface.”](https://github.com/wasmCloud/wasmCloud/issues/4641)
+:::
+
 Hosts will emit [CloudEvents](https://cloudevents.io/) during normal operation, as well as in response to errors. These [events](/docs/reference/cloud-event-list) reflect coarse-grained state changes for a lattice. This event log is useful for monitoring and observability, and is used internally by [wadm](/docs/ecosystem/wadm/) to track whether applications have been successfully deployed.
 
 ## Keep reading

--- a/docs/reference/cloud-event-list.mdx
+++ b/docs/reference/cloud-event-list.mdx
@@ -9,6 +9,10 @@ type: 'docs'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::warning[Planned changes to events]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for changes to the events implementation in the next major release of wasmCloud. In the new approach, events are handled at the operator layer, leveraging OpenTelemetry and discontinuing usage of CloudEvents. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4641: “Reduce host responsibility and API surface.”](https://github.com/wasmCloud/wasmCloud/issues/4641)
+:::
+
 The following is a list of all of the [CloudEvents](https://cloudevents.io) emitted by wasmCloud hosts in a lattice. The events are published to `wasmbus.evt.{lattice-id}.{event-type}`, and so will publish to `wasmbus.evt.default.>` by default.
 
 All of the events in the table below are namespaced by the prefix `com.wasmcloud.lattice`, so the `component_started` event has the Cloud Event type of `com.wasmcloud.lattice.component_started`. These event types do _not_ include the lattice identifier.


### PR DESCRIPTION
Adds admonitions to relevant pages on planned events changes in the Q3 2025 roadmap.