### PR TITLE
chore(docs): add admonitions on transport layer changes in roadmap

### DIFF
--- a/docs/ecosystem/nats/index.mdx
+++ b/docs/ecosystem/nats/index.mdx
@@ -9,6 +9,10 @@ sidebar_position: 3
 
 # NATS
 
+:::warning[Planned changes to transport]
+The [**wasmCloud Q3 2025 Roadmap**](https://github.com/orgs/wasmCloud/projects/7) sets out plans for an overhaul to the transport layer in the next major release of wasmCloud. In the new approach, wRPC serves as the transport layer, with NATS as the default underlying transport. For more information, see the [Roadmap](https://github.com/orgs/wasmCloud/projects/7) and [Issue #4640: “Intentional distributed networking.”](https://github.com/wasmCloud/wasmCloud/issues/4640)
+:::
+
 ## Overview
 
 The wasmCloud [lattice](/docs/concepts/lattice) is built on [**NATS**](https://nats.io/), an open source connective technology hosted by the Cloud Native Computing Foundation (CNCF). NATS enables secure application-layer networking across diverse environments including edge, different vendors' clouds, and on-premise datacenters.


### PR DESCRIPTION
Adds admonitions to relevant pages on planned transport layer changes on the Q3 2025 roadmap.