### PR TITLE
Use : instead of = in nats config file

### DIFF
--- a/docs/deployment/nats/cluster-config.mdx
+++ b/docs/deployment/nats/cluster-config.mdx
@@ -26,9 +26,9 @@ server_name: myserver
 
 jetstream: enabled
 jetstream {
-  store_dir = /path/to/data/directory
+  store_dir: /path/to/data/directory
   # Use a domain suitable for your environment
-  domain    = wasmcloud
+  domain: wasmcloud
 }
 ```
 
@@ -64,9 +64,9 @@ cluster {
 }
 
 jetstream {
-  store_dir = /path/to/data/directory
+  store_dir: /path/to/data/directory
   # Use a domain suitable for your environment
-  domain    = wasmcloud
+  domain: wasmcloud
 }
 ```
 
@@ -89,9 +89,9 @@ cluster {
 }
 
 jetstream {
-  store_dir = /path/to/data/directory
+  store_dir: /path/to/data/directory
   # Use a domain suitable for your environment
-  domain    = wasmcloud
+  domain: wasmcloud
 }
 ```
 
@@ -106,9 +106,9 @@ cluster {
 }
 
 jetstream {
-  store_dir = /path/to/data/directory
+  store_dir: /path/to/data/directory
   # Use a domain suitable for your environment
-  domain    = wasmcloud
+  domain: wasmcloud
 }
 ```
 


### PR DESCRIPTION
## Feature or Problem
Fixes incorrect NATS config file syntax.

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
Allows copy & paste of the NATS config examples.

## Testing
Create a NATS config file with the updated values and verify it works as expected.

### Unit Test(s)
N/A

### Acceptance or Integration
N/A

### Manual Verification
Confirmed `:` works in a NATS config file.
