### PR TITLE
chore(docs): update wasm shell plugin reference

### DIFF
--- a/versioned_docs/version-next/wash/plugins.mdx
+++ b/versioned_docs/version-next/wash/plugins.mdx
@@ -7,9 +7,12 @@ sidebar_position: 3
 
 The Wasm Shell (`wash`) CLI is extensible via a component-driven plugin system. New integrations and functionality can be implemented across any language that compiles to a WebAssembly component target, and then the component can plug in directly to `wash`.
 
-## Built-in Plugins
+## First-party plugins
 
-`wash` comes with a few built-in plugins for functionality like using the `wasi-blobstore interface` in `wash dev` sessions or facilitating OAuth. Plugin discovery is automatic, so those plugins being "built-in" simply means that they are included "out of the box." 
+The following plugins are available from the wasmCloud project:
+
+* `blobstore-filesystem`: Extends `wash dev` to support the `wasi:blobstore` interface backed by local filesystem. ([Source](https://github.com/wasmCloud/wash/tree/main/plugins/blobstore-filesystem) | [OCI](https://github.com/orgs/wasmCloud/packages/container/package/wash-plugins%2Fblobstore-filesystem))
+* `aspire-otel`: Launches the Aspire dashboard. ([Source](https://github.com/wasmCloud/wash/tree/main/plugins/aspire-otel))
 
 ## Subcommands
 
@@ -26,6 +29,27 @@ Install a plugin from an OCI reference or file:
 
 ```shell
 wash plugin install <SOURCE>
+```
+
+To install a plugin from an OCI reference, target the OCI artifact with `wash plugin intall`. For example, to install the `blobstore-filesystem` plugin:
+
+```shell
+wash plugin install ghcr.io/wasmcloud/wash-plugins/blobstore-filesystem:0.1.0
+```
+
+To install a plugin from source, build the component with `wash build` and then target the component binary with `wash plugin install`. For example, to build the `blobstore-filesystem` component from source:
+
+```shell
+git clone https://github.com/wasmCloud/wash.git
+```
+```shell
+cd wash/plugins/blobstore-filesystem
+```
+```shell
+wash build
+```
+```shell
+wash plugin install ./target/wasm32-wasip2/release/blobstore_filesystem.wasm
 ```
 
 See the command reference for [complete command options](./commands.mdx#wash-plugin-install).


### PR DESCRIPTION
Updates the Plugin reference for `wash` in the `next` version, clarifying installation and referring to examples.
