### PR TITLE
feat(docs): add CRDs and API reference for next version

### DIFF
--- a/versioned_docs/version-next/kubernetes-operator/_category_.json
+++ b/versioned_docs/version-next/kubernetes-operator/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Kubernetes Operator",
+  "position": 2
+}

--- a/versioned_docs/version-next/kubernetes-operator/api-reference.md
+++ b/versioned_docs/version-next/kubernetes-operator/api-reference.md
@@ -1,0 +1,548 @@
+---
+title: "API Reference"
+sidebar_position: 2
+---
+
+## Packages
+- [runtime.wasmcloud.dev/v1alpha1](#runtimewasmclouddevv1alpha1)
+
+
+## runtime.wasmcloud.dev/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the runtime v1alpha1 API group.
+
+### Resource Types
+- [Artifact](#artifact)
+- [ArtifactList](#artifactlist)
+- [Host](#host)
+- [HostList](#hostlist)
+- [Workload](#workload)
+- [WorkloadDeployment](#workloaddeployment)
+- [WorkloadDeploymentList](#workloaddeploymentlist)
+- [WorkloadList](#workloadlist)
+- [WorkloadReplicaSet](#workloadreplicaset)
+- [WorkloadReplicaSetList](#workloadreplicasetlist)
+
+
+
+#### Artifact
+
+
+
+Artifact is the Schema for the artifacts API.
+
+
+
+_Appears in:_
+- [ArtifactList](#artifactlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `Artifact` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[ArtifactSpec](#artifactspec)_ |  |  |  |
+
+
+#### ArtifactList
+
+
+
+ArtifactList contains a list of Artifact.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `ArtifactList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[Artifact](#artifact) array_ |  |  |  |
+
+
+#### ArtifactSpec
+
+
+
+ArtifactSpec defines the desired state of Artifact.
+
+
+
+_Appears in:_
+- [Artifact](#artifact)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ |  |  | Required: \{\} <br /> |
+| `imagePullSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core)_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+#### ConfigLayer
+
+
+
+
+
+
+
+_Appears in:_
+- [HostInterface](#hostinterface)
+- [LocalResources](#localresources)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `configFrom` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core) array_ | ConfigFrom is a list of references to ConfigMaps that will be provided to the workload.<br />The keys and values of all referenced ConfigMaps will be merged. In case of key conflicts,<br />the last ConfigMap in the list wins. |  | Optional: \{\} <br /> |
+| `secretFrom` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core) array_ | The keys and values of all referenced Secrets will be merged. In case of key conflicts,<br />the last Secret in the list wins.<br />The values of the Secrets will be base64-decoded, utf-8 decoded before being provided to the workload. |  | Optional: \{\} <br /> |
+| `config` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+
+
+#### EphemeralVolume
+
+
+
+EphemeralVolume represents a temporary directory that shares a workload's lifetime.
+
+
+
+_Appears in:_
+- [Volume](#volume)
+
+
+
+#### Host
+
+
+
+Host is the Schema for the Hosts API.
+
+
+
+_Appears in:_
+- [HostList](#hostlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `Host` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `hostId` _string_ |  |  | Required: \{\} <br /> |
+| `hostname` _string_ |  |  | Optional: \{\} <br /> |
+| `httpPort` _integer_ |  |  | Optional: \{\} <br /> |
+
+
+#### HostInterface
+
+
+
+
+
+
+
+_Appears in:_
+- [WorkloadSpec](#workloadspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `configFrom` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core) array_ | ConfigFrom is a list of references to ConfigMaps that will be provided to the workload.<br />The keys and values of all referenced ConfigMaps will be merged. In case of key conflicts,<br />the last ConfigMap in the list wins. |  | Optional: \{\} <br /> |
+| `secretFrom` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core) array_ | The keys and values of all referenced Secrets will be merged. In case of key conflicts,<br />the last Secret in the list wins.<br />The values of the Secrets will be base64-decoded, utf-8 decoded before being provided to the workload. |  | Optional: \{\} <br /> |
+| `config` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `namespace` _string_ |  |  | Required: \{\} <br /> |
+| `package` _string_ |  |  | Required: \{\} <br /> |
+| `interfaces` _string array_ |  |  | MinItems: 1 <br />Required: \{\} <br /> |
+| `version` _string_ |  |  | Optional: \{\} <br /> |
+
+
+#### HostList
+
+
+
+HostList contains a list of Host.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `HostList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[Host](#host) array_ |  |  |  |
+
+
+#### HostPathVolume
+
+
+
+HostPathVolume represents a pre-existing file or directory on the host machine.
+
+
+
+_Appears in:_
+- [Volume](#volume)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `path` _string_ | Path of the file or directory on the host. |  | Required: \{\} <br /> |
+
+
+
+
+#### LocalResources
+
+
+
+LocalResources describes resources that will be made available to a workload component.
+
+
+
+_Appears in:_
+- [WorkloadComponent](#workloadcomponent)
+- [WorkloadService](#workloadservice)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `volumeMounts` _[VolumeMount](#volumemount) array_ | VolumeMounts is a list of volume mounts that will be mounted into the workload component.<br />The volumes must be defined in the WorkloadSpec.Volumes field. |  | Optional: \{\} <br /> |
+| `environment` _[ConfigLayer](#configlayer)_ |  |  | Optional: \{\} <br /> |
+| `config` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `allowedHosts` _string array_ |  |  | Optional: \{\} <br /> |
+
+
+#### ReplicaSetStatus
+
+
+
+
+
+
+
+_Appears in:_
+- WorkloadDeploymentStatus
+- WorkloadReplicaSetStatus
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `expected` _integer_ |  |  | Optional: \{\} <br /> |
+| `current` _integer_ |  |  | Optional: \{\} <br /> |
+| `ready` _integer_ |  |  | Optional: \{\} <br /> |
+| `unavailable` _integer_ |  |  | Optional: \{\} <br /> |
+
+
+#### Volume
+
+
+
+Volume represents a named volume that can be mounted by components.
+
+
+
+_Appears in:_
+- [WorkloadSpec](#workloadspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the volume. Must be a DNS_LABEL and unique within the Workload. |  | Required: \{\} <br /> |
+| `ephemeral` _[EphemeralVolume](#ephemeralvolume)_ | EphemeralVolume represents a temporary directory that shares a workload's lifetime. |  | Optional: \{\} <br /> |
+| `hostPath` _[HostPathVolume](#hostpathvolume)_ | HostPathVolume represents a pre-existing file or directory on the host machine. |  | Optional: \{\} <br /> |
+
+
+#### VolumeMount
+
+
+
+VolumeMount describes a mounting of a Volume within a component.
+
+
+
+_Appears in:_
+- [LocalResources](#localresources)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name must match the Name of a Volume defined in the WorkloadSpec.Volumes field. |  | Required: \{\} <br /> |
+| `mountPath` _string_ | MountPath is the path within the component where the volume should be mounted. |  | Required: \{\} <br /> |
+
+
+#### Workload
+
+
+
+Workload is the Schema for the artifacts API.
+
+
+
+_Appears in:_
+- [WorkloadList](#workloadlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `Workload` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[WorkloadSpec](#workloadspec)_ |  |  |  |
+
+
+#### WorkloadComponent
+
+
+
+WorkloadComponent represents a component of a workload.
+Components are stateless, invocation-driven units of computation.
+Components are isolated from each other and can be scaled independently.
+Each Component has a Root WIT World, representing the Components imports/exports. The combined
+list of all Components' Root WIT Worlds within a workload must be compatible with the Host's WIT World.
+All components within a workload are guaranteed to be placed on the same Wasm Host.
+
+
+
+_Appears in:_
+- [WorkloadSpec](#workloadspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  | Required: \{\} <br /> |
+| `image` _string_ |  |  | Required: \{\} <br /> |
+| `imagePullSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core)_ |  |  | Optional: \{\} <br /> |
+| `poolSize` _integer_ |  |  | Optional: \{\} <br /> |
+| `maxInvocations` _integer_ |  |  | Optional: \{\} <br /> |
+| `localResources` _[LocalResources](#localresources)_ |  |  | Optional: \{\} <br /> |
+
+
+#### WorkloadDeployPolicy
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [WorkloadDeploymentSpec](#workloaddeploymentspec)
+
+| Field | Description |
+| --- | --- |
+| `RollingUpdate` |  |
+| `Recreate` |  |
+
+
+#### WorkloadDeployment
+
+
+
+WorkloadDeployment is the Schema for the artifacts API.
+
+
+
+_Appears in:_
+- [WorkloadDeploymentList](#workloaddeploymentlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `WorkloadDeployment` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[WorkloadDeploymentSpec](#workloaddeploymentspec)_ |  |  |  |
+
+
+#### WorkloadDeploymentArtifact
+
+
+
+
+
+
+
+_Appears in:_
+- [WorkloadDeploymentSpec](#workloaddeploymentspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  | Required: \{\} <br /> |
+| `artifactFrom` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core)_ |  |  | Required: \{\} <br /> |
+
+
+#### WorkloadDeploymentList
+
+
+
+WorkloadDeploymentList contains a list of HttpTrigger.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `WorkloadDeploymentList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[WorkloadDeployment](#workloaddeployment) array_ |  |  |  |
+
+
+#### WorkloadDeploymentSpec
+
+
+
+WorkloadDeploymentSpec defines the desired state of WorkloadDeployment.
+
+
+
+_Appears in:_
+- [WorkloadDeployment](#workloaddeployment)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `replicas` _integer_ |  |  | Optional: \{\} <br /> |
+| `template` _[WorkloadReplicaTemplate](#workloadreplicatemplate)_ |  |  | Required: \{\} <br /> |
+| `deployPolicy` _[WorkloadDeployPolicy](#workloaddeploypolicy)_ |  | RollingUpdate | Optional: \{\} <br /> |
+| `artifacts` _[WorkloadDeploymentArtifact](#workloaddeploymentartifact) array_ |  |  | Optional: \{\} <br /> |
+
+
+
+
+#### WorkloadList
+
+
+
+WorkloadList contains a list of Workload.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `WorkloadList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[Workload](#workload) array_ |  |  |  |
+
+
+#### WorkloadReplicaSet
+
+
+
+WorkloadReplicaSet is the Schema for the artifacts API.
+
+
+
+_Appears in:_
+- [WorkloadReplicaSetList](#workloadreplicasetlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `WorkloadReplicaSet` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[WorkloadReplicaSetSpec](#workloadreplicasetspec)_ |  |  |  |
+
+
+#### WorkloadReplicaSetList
+
+
+
+WorkloadReplicaSetList contains a list of WorkloadReplicaSet.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `runtime.wasmcloud.dev/v1alpha1` | | |
+| `kind` _string_ | `WorkloadReplicaSetList` | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[WorkloadReplicaSet](#workloadreplicaset) array_ |  |  |  |
+
+
+#### WorkloadReplicaSetSpec
+
+
+
+WorkloadReplicaSetSpec defines the desired state of WorkloadReplicaSet.
+
+
+
+_Appears in:_
+- [WorkloadDeploymentSpec](#workloaddeploymentspec)
+- [WorkloadReplicaSet](#workloadreplicaset)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `replicas` _integer_ |  |  | Optional: \{\} <br /> |
+| `template` _[WorkloadReplicaTemplate](#workloadreplicatemplate)_ |  |  | Required: \{\} <br /> |
+
+
+
+
+#### WorkloadReplicaTemplate
+
+
+
+
+
+
+
+_Appears in:_
+- [WorkloadDeploymentSpec](#workloaddeploymentspec)
+- [WorkloadReplicaSetSpec](#workloadreplicasetspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `annotations` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `labels` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `spec` _[WorkloadSpec](#workloadspec)_ |  |  | Required: \{\} <br /> |
+
+
+#### WorkloadService
+
+
+
+WorkloadService represents a long-running service that is part of the workload.
+It is also sometimes referred to as a "sidecar" and is optional.
+A Service differs from a Component in that it is long-running and represents the Workload's "localhost".
+Services can bind to TCP & UDP ports, which are accessible by Components within the same workload via "localhost" or "127.0.0.1".
+Services export a single WIT interface, shaped as wasi:cli/run.
+Services can import interfaces from any Component within the same workload, or from the Host.
+
+
+
+_Appears in:_
+- [WorkloadSpec](#workloadspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ |  |  | Required: \{\} <br /> |
+| `imagePullSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core)_ |  |  | Optional: \{\} <br /> |
+| `maxRestarts` _integer_ |  |  | Optional: \{\} <br /> |
+| `localResources` _[LocalResources](#localresources)_ |  |  | Optional: \{\} <br /> |
+
+
+#### WorkloadSpec
+
+
+
+WorkloadSpec defines the desired state of Workload.
+
+
+
+_Appears in:_
+- [Workload](#workload)
+- [WorkloadReplicaTemplate](#workloadreplicatemplate)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `hostSelector` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
+| `hostId` _string_ |  |  | Optional: \{\} <br /> |
+| `components` _[WorkloadComponent](#workloadcomponent) array_ |  |  | Optional: \{\} <br /> |
+| `hostInterfaces` _[HostInterface](#hostinterface) array_ |  |  | Optional: \{\} <br /> |
+| `service` _[WorkloadService](#workloadservice)_ |  |  | Optional: \{\} <br /> |
+| `volumes` _[Volume](#volume) array_ |  |  | Optional: \{\} <br /> |
+
+
+
+

--- a/versioned_docs/version-next/kubernetes-operator/crds.mdx
+++ b/versioned_docs/version-next/kubernetes-operator/crds.mdx
@@ -1,0 +1,202 @@
+---
+title: "Custom Resource Definitions (CRDs)"
+sidebar_position: 1
+---
+
+When deployed to Kubernetes, the core primitives of wasmCloud are represented by [**custom resources definitions (CRDs)**](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+
+wasmCloud uses CRDs from the [`runtime.wasmcloud.dev/v1alpha1`](./api-reference.md) API package:
+
+- [Artifact](#artifact) - `runtime.wasmcloud.dev/v1alpha1`
+- [Host](#host) - `runtime.wasmcloud.dev/v1alpha1`
+- [Workload](#workload) - `runtime.wasmcloud.dev/v1alpha1`
+- [WorkloadDeployment](#workloaddeployment) - `runtime.wasmcloud.dev/v1alpha1`
+- [WorkloadReplicaSet](#workloadreplicaset) - `runtime.wasmcloud.dev/v1alpha1`
+
+This document explains each of these custom resources at a high level. For a complete API specification, see the [API reference](./api-reference.md).
+
+:::note[]
+[`WorkloadDeployment`](#workloaddeployment) is the resource used to deploy Wasm workloads&mdash;if you're looking to quickly deploy a component, [start there](#workloaddeployment).  
+:::
+
+## Artifact
+
+An [Artifact](./api-reference.md#artifact) represents a Wasm component that can be referenced by Workloads. Artifacts define the image location and optional image pull secrets for accessing private registries. This can be used to fetch an OCI image and store its contents in a [NATS JetStream Object Store](https://docs.nats.io/nats-concepts/jetstream/obj_store). 
+
+The `Artifact` resource tracks individual revisions, publishing the artifact's location under `Status.ArtifactURL`. A [`WorkloadDeployment`](#workloaddeployment) can reference an Artifact as its component image. A new deployment will be automatically rolled out when a new image is detected.
+
+Example manifest:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: Artifact
+metadata:
+  name: http-hello-world
+  namespace: default
+spec:
+  image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+  imagePullSecret:
+    name: ghcr-secret
+```
+
+## Host
+
+A [Host](./api-reference.md#host) resource defines a wasmCloud runtime environment, or **host**, which has a unique ID and can run Wasm workloads.
+
+Example manifest:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: Host
+metadata:
+  name: host-sample
+  namespace: default
+  labels:
+    hostgroup: default
+spec:
+  hostId: NABCDEFGHIJKLMNOPQRSTUVWXYZ234567
+  hostname: host-sample.default
+  httpPort: 4000
+```
+
+## Workload
+
+A [Workload](./api-reference.md#workload) represents an application composed of one or more WebAssembly components and optional services. Workloads define the components, their configurations, volume mounts, and host interfaces they consume.
+
+Workloads are analogous to Kubernetes Pods in that they typically are not managed individually, but are instead owned by a [WorkloadDeployment](#workloaddeployment), much as a Pod is owned by a Deployment.
+
+Example manifest:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: Workload
+metadata:
+  name: hello-world
+  namespace: default
+spec:
+  hostSelector:
+    hostgroup: default
+  components:
+    - name: http-component
+      image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+      poolSize: 10
+      maxInvocations: 1000
+      localResources:
+        environment:
+          config:
+            LOG_LEVEL: info
+        allowedHosts:
+          - https://api.example.com
+  hostInterfaces:
+    - namespace: wasi
+      package: http
+      interfaces:
+        - incoming-handler
+      config:
+        address: '0.0.0.0:8080'
+  volumes:
+    - name: cache
+      ephemeral: {}
+```
+
+## WorkloadDeployment
+
+A [WorkloadDeployment](./api-reference.md#workloaddeployment) defines the deployment and scaling of Workloads across hosts. It creates and manages WorkloadReplicaSets to ensure the desired number of workload replicas are running.
+
+Example manifest:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: hello-world
+  namespace: default
+spec:
+  replicas: 3
+  deployPolicy: RollingUpdate
+  artifacts:
+    - name: http-component
+      artifactFrom:
+        name: http-hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: http-component
+          image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+          poolSize: 10
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            address: '0.0.0.0:8080'
+```
+
+### Host Interfaces
+
+Use the `hostInterfaces` field to define host interfaces used by the workload. This field requires the `namespace`, `package`, and `interfaces` fields, and may optionally take a `config`.
+
+### Runtime Configuration
+
+Runtime configuration values (such as environment variables) may be supplied via the optional `localResources` subfield of the `component` field. 
+
+```yaml
+localResources:
+  environment:
+    config:
+      some_key: some_value
+```
+
+Environmental values may also come from ConfigMaps or Secrets. The following approaches are also valid: 
+
+```yaml
+localResources:
+  environment:
+    configFrom:
+      - name: my-configmap
+    secretFrom:
+      - name: my-secret
+    config:
+      literal_key: literal_value
+```
+
+## WorkloadReplicaSet
+
+A [WorkloadReplicaSet](./api-reference.md#workloadreplicaset) ensures that a given number of Workload replicas are running at once. It is typically managed by a WorkloadDeployment but can be used directly for more granular control.
+
+Example manifest:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadReplicaSet
+metadata:
+  name: hello-world-v1
+  namespace: default
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: hello-world
+        version: v1
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: http-component
+          image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+          poolSize: 10
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            address: '0.0.0.0:8080'
+```

--- a/versioned_docs/version-next/kubernetes-operator/index.mdx
+++ b/versioned_docs/version-next/kubernetes-operator/index.mdx
@@ -1,0 +1,7 @@
+---
+title: "Kubernetes Operator"
+---
+
+:::warning[Under construction]
+This section is under active development&mdash;please check back soon for a more complete reference.
+:::

--- a/versioned_docs/version-next/wash/_category_.json
+++ b/versioned_docs/version-next/wash/_category_.json
@@ -1,5 +1,6 @@
 {
-  "label": "Wasm Shell (wash) CLI"
+  "label": "Wasm Shell (wash) CLI",
+  "position": 1 
 }
 
 


### PR DESCRIPTION
Adds CRDs and API reference for next version under a new Kubernetes Operator section. 