### PR TITLE
fix(docs): update wash build for go in dev guide

### DIFF
--- a/versioned_docs/version-next/wash/developer-guide/build-and-publish.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/build-and-publish.mdx
@@ -21,23 +21,33 @@ If you haven't completed the previous section on installing `wash`, creating a p
 
 ## Building WebAssembly components
 
-Use the `wash build` command from the root of a project directory to compile the component into a `.wasm` binary:
-
-```shell
-wash build
-```
-
-The output path for the compiled `.wasm` binary varies by language toolchain and [can be configured via `wash`'s `config.json` file](../config.mdx).
-
 <Tabs groupId="lang" queryString>
   <TabItem value="rust" label="Rust" default>
-  By default, the compiled `.wasm` binary for a Rust project is generated at `/target/wasm32-wasip2/debug/`.
+  Use the `wash build` command from the root of a project directory to compile the component into a `.wasm` binary:
+
+  ```shell
+  wash build
+  ```
+
+  By default, the compiled `.wasm` binary for a Rust project is generated at `/target/wasm32-wasip2/debug/`. The output path for the compiled `.wasm` binary [can be configured via `wash`'s `config.json` file](../config.mdx).
   </TabItem>
   <TabItem value="tinygo" label="TinyGo">
-  By default, the compiled `.wasm` binary for a TinyGo project is generated at `/build/`.
+  Use the `wash build` command from the root of a project directory to compile the component into a `.wasm` binary:
+
+  ```shell
+  wash build --skip-fetch
+  ```
+
+  By default, the compiled `.wasm` binary for a TinyGo project is generated at `/build/`. The output path for the compiled `.wasm` binary [can be configured via `wash`'s `config.json` file](../config.mdx).
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
-  By default, the compiled `.wasm` binary for a TypeScript project is generated at `/dist/`.
+  Use the `wash build` command from the root of a project directory to compile the component into a `.wasm` binary:
+
+  ```shell
+  wash build
+  ```
+
+  By default, the compiled `.wasm` binary for a TypeScript project is generated at `/dist/`. The output path for the compiled `.wasm` binary [can be configured via `wash`'s `config.json` file](../config.mdx).
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Currently the `wash build` command requires the `--skip-fetch` flag to successfully build the TinyGo example component. Updates developer guide accordingly.