### PR TITLE
fix: wkg registry configuration trailing slash

### DIFF
--- a/static/.well-known/wasm-pkg/registry.json
+++ b/static/.well-known/wasm-pkg/registry.json
@@ -1,4 +1,4 @@
 {
-  "preferredProtocol":"oci",
-  "oci": {"registry": "ghcr.io", "namespacePrefix": "wasmcloud/components"}
+  "preferredProtocol": "oci",
+  "oci": { "registry": "ghcr.io", "namespacePrefix": "wasmcloud/components/" }
 }


### PR DESCRIPTION
We missed a trailing slash in https://github.com/wasmCloud/wasmcloud.com/pull/1019

This is causing wkg to fail with

```

Caused by:
    Registry error: url https://ghcr.io/v2/wasmcloud/componentswasmcloud/component-go/tags/list, envelope: OCI API errors: [OCI API error: repository name not known to registry]
```

