### PR TITLE
Fix namespacePrefix in registry.json

### DIFF
--- a/static/.well-known/wasm-pkg/registry.json
+++ b/static/.well-known/wasm-pkg/registry.json
@@ -1,4 +1,4 @@
 {
   "preferredProtocol":"oci",
-  "oci": {"registry": "ghcr.io", "namespacePrefix": "wasmcloud/components"}
+  "oci": {"registry": "ghcr.io", "namespacePrefix": "wasmcloud/components/"}
 }


### PR DESCRIPTION
## Feature or Problem
Recent change to the well-known wkg file has broken references to existing packages.

Without the trailing slash, the `oci.namespacePrefix` joins to the package name as `wasmcloud/componentswasmcloud/<pkg>` which isn't quite right.

## Related Issues
wasmcloud/typescript#466

## Testing
Tested locally by changing `~/.wash/package_config.toml`
