### PR TITLE
chore(docs): link to Wasm OCI format

### DIFF
--- a/versioned_docs/version-next/overview/packaging.mdx
+++ b/versioned_docs/version-next/overview/packaging.mdx
@@ -8,7 +8,7 @@ toc_max_heading_level: 2
 ---
 ### Components and interfaces are packaged as OCI artifacts.
 
-The wasmCloud ecosystem uses the [Open Container Initiative (OCI) image specification](https://github.com/opencontainers/image-spec) to package components and interfaces as OCI artifacts.
+The wasmCloud ecosystem uses the [Open Container Initiative (OCI) image specification](https://github.com/opencontainers/image-spec) to package components and interfaces as OCI artifacts according to the [standard OCI artifact format for Wasm](https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/).
 
 While we sometimes refer to them as "images," these artifacts **are not *container* images**—nonetheless, they conform to OCI standards and may be stored on any OCI-compatible registry. You can think of the OCI artifact layer as a thin shell of metadata wrapped around the component or interface.
 


### PR DESCRIPTION
Links to Wasm OCI format in v2 Overview -> Packaging page.