### PR TITLE
chore(docs): clarify service-component communication in Transport

### DIFF
--- a/versioned_docs/version-next/overview/transport.mdx
+++ b/versioned_docs/version-next/overview/transport.mdx
@@ -12,6 +12,8 @@ In wasmCloud, transport between hosts and the operator is handled by [**NATS**](
 
 NATS is designed to provide seamless connectivity tailored specifically to distributed systems, avoiding the complexities and limitations of 1:1 communication frameworks like HTTP or gRPC in distributed use cases. 
 
+**Note**: Calls between [services](./workloads/services.mdx) and [components](./workloads/components.mdx) **do not** use NATS. See [Workloads](./workloads/index.mdx) for more information.
+
 ## Essential NATS concepts
 
 NATS conceptualizes communications as **messages**. Applications send and receive messages identified by **subject** strings. In addition to the subject, messages contain a byte array payload and any number of header fields.


### PR DESCRIPTION
Clarifies that calls between services and components do not use NATS in v2 Overview -> Transport