### PR TITLE
chore(docs): add example repos for component and service in Workloads

### DIFF
--- a/versioned_docs/version-next/overview/workloads/index.mdx
+++ b/versioned_docs/version-next/overview/workloads/index.mdx
@@ -12,8 +12,10 @@ A wasmCloud **workload** is an application-level abstraction that consists of on
 ![Workload diagram](../../images/workload-diagram.png)
 
 - **Components** are portable, interoperable binaries (`.wasm` files) that implement stateless logic, typically enacting the core logic of an application (for example, the API for a web application), while leaving stateful or reusable functionality (e.g., key-value storage or HTTP) to [services](./services.mdx), [hosts](../hosts/index.mdx), and [host plugins](../hosts/plugins.mdx).
+  * You can find a simple example of a Rust-based "Hello world!" component in [`wash/examples`](https://github.com/wasmCloud/wash/tree/main/examples/http-hello-world).
 
 - **Services** are persistent, stateful Wasm binaries that can act as `localhost` within the workload boundary and provide long-running processes.
+  * You can find a simple example of a Rust-based cron service in [`wash/examples`](https://github.com/wasmCloud/wash/tree/main/examples/cron-service).
 
 The [wasmCloud host](../hosts/index.mdx) runs workloads in cloud and edge environments, while the [Wasm Shell (`wash`) CLI](../../wash/index.mdx) helps developers build and publish components and services. 
 


### PR DESCRIPTION
Adds links to example repos for component and service in Overview -> Workloads