### PR TITLE
chore(docs): update v2 glossary

### DIFF
--- a/versioned_docs/version-next/glossary.mdx
+++ b/versioned_docs/version-next/glossary.mdx
@@ -14,11 +14,13 @@ An abstraction for a given functionality (such as key-value storage or connectio
 
 ### Component
 
-Components are portable, interoperable WebAssembly binaries that implement stateless logic. Components are `.wasm` files that include [interface](#interface) definitions which define the contracts through which they may relate to other entities.
+Components are sandboxed, interoperable [WebAssembly](#webassembly) binaries that can be compiled from various programming languages such as Rust, Go, and JavaScript. Components are `.wasm` files that include [interface](#interface) definitions which define the contracts through which they may relate to other entities.
+
+In a wasmCloud workload, we use "component" to refer to the binary that implements stateless logic and typically enacts the core logic of an application, but it is important to note that [services](#service) are implemented as Wasm components as well. For more information, see [Workloads](./overview/workloads/index.mdx).
 
 ### Host
 
-A wasmCloud host is a runtime environment node consisting of a WebAssembly runtime ([Wasmtime](#wasmtime)) and additional layers of security and functionality. Multiple hosts may run on a single machine and hosts are meant to be ephemeral.
+A wasmCloud host is a process consisting of a WebAssembly runtime ([Wasmtime](#wasmtime)) and additional layers of security and functionality. Multiple hosts may run on a single machine and can be ephemeral.
 
 ### Host Group
 
@@ -28,15 +30,23 @@ A host group is a set of wasmCloud hosts.
 
 Host plugins extend a [wasmCloud host](#host) with a specific implementation of a given [capability](#capability) according to an [interface](#interface), and may optionally serve as shared resources, providing functionality to many different components for many different applications.
 
+You can find several examples of host plugins in the [`wash-runtime/src/plugin`](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime/src/plugin) directory of the `wash` repository. (Note that these plugins are built-in by default.)
+
 ### Interface
 
 Interfaces are contracts that define the relationships between entities like components and providers, often defining functionalities like HTTP or key-value storage at a high and vendor-agnostic level. Interfaces describe a component or provider's requirements ("imports") and exposed functions that may be used by other entities ("exports"). Interfaces are defined in [WebAssembly Interface Type (WIT)](#webassembly-interface-type-wit) files.
 
+See the [WebAssembly System Interface (WASI) API proposals](https://github.com/WebAssembly/WASI/tree/main/proposals) for examples of interfaces defined in WIT. 
+
 ### NATS
 
-NATS is a connective technology for distributed systems used as a transport in production wasmCloud deployments. NATS is governed by the Cloud Native Computing Foundation.
+NATS is a connective technology for distributed systems that can be used as a transport in production wasmCloud deployments. NATS is governed by the Cloud Native Computing Foundation.
 
 For more information, see the [**NATS documentation**](https://docs.nats.io/).
+
+### Service
+
+In a wasmCloud workload, "service" refers to a WebAssembly binary that acts as a persistent, stateful companion to stateless components in the same workload. For more information, see [Workloads](./overview/workloads/index.mdx).
 
 ### `wash`
 
@@ -83,3 +93,7 @@ For more information, see [**WASI.dev**](https://wasi.dev/).
 WIT stands for "**WebAssembly Interface Type**." WIT is an [interface description language](https://en.wikipedia.org/wiki/Interface_description_language) used to define the high-level interfaces used by components, such as the APIs included in [WASI](#webassembly-system-interface-wasi). In wasmCloud, all interfaces are defined in WIT.
 
 For more information on WIT, see the [**Component Model documentation**](https://component-model.bytecodealliance.org/design/wit.html).
+
+### Workload
+
+A wasmCloud **workload** is an application-level abstraction that consists of one or more [components](#component) and optionally a [service](#service). For more information, see [Workloads](./overview/workloads/index.mdx).


### PR DESCRIPTION
Updates several entries for accuracy, adds interface and host plugin examples, and adds entries for "Service" and "Workload"