### PR TITLE
feat(docs): add v2 installation page

### DIFF
--- a/versioned_docs/version-next/faq.mdx
+++ b/versioned_docs/version-next/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: "FAQ"
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 This page includes frequently asked questions on wasmCloud v2, including common questions about [migration from wasmCloud v1](#migrating-from-wasmcloud-v1).

--- a/versioned_docs/version-next/glossary.mdx
+++ b/versioned_docs/version-next/glossary.mdx
@@ -2,7 +2,7 @@
 title: 'Glossary'
 date: 2025-11-01T00:00:00+00:00
 description: 'Glossary'
-sidebar_position: 1
+sidebar_position: 6
 type: 'docs'
 ---
 

--- a/versioned_docs/version-next/installation.mdx
+++ b/versioned_docs/version-next/installation.mdx
@@ -1,0 +1,140 @@
+---
+title: 'Installation'
+sidebar_position: 1
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Install wasmCloud
+
+Install the parts of the [wasmCloud platform](./overview/index.mdx) that you need depending on what you want to accomplish:
+
+* If you want to **develop and publish Wasm applications**, [install the Wasm Shell (`wash`) CLI](#install-wash).  
+* If you want to **run Wasm workloads on Kubernetes**, [install wasmCloud on Kubernetes](#install-wasmcloud-on-kubernetes).
+
+## Install `wash`
+
+<Tabs groupId="os" queryString>
+  <TabItem value="macoslinux" label="macOS and Linux" default>
+
+In your terminal, run the installation script to download and install the latest version of `wash`:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/wasmcloud/wash/refs/heads/main/install.sh | bash
+```
+
+On a successful installation, the script will return:
+
+```shell
+[INFO] Next steps:
+  1. Add /path/to to your PATH if not already included
+  2. Run 'wash --help' to see available commands
+  3. Run 'wash doctor' to verify your environment
+  4. Run 'wash new' to create your first WebAssembly component
+```
+
+Add `wash` to your PATH with the filepath listed in Step 1, replacing `/path/to` with your local filepath:
+
+```shell
+export PATH="$PATH:/path/to/wash"
+```
+
+  </TabItem>
+
+  <TabItem value="windows" label="Windows">
+
+In PowerShell, run the installation script to download and install the latest version of `wash`:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/wasmcloud/wash/refs/heads/main/install.ps1 | iex
+```
+
+```powershell
+Next steps:
+  1. Add /path/to to your PATH if not already included
+  2. Run 'wash --help' to see available commands
+  3. Run 'wash doctor' to verify your environment
+  4. Run 'wash new' to create your first WebAssembly component
+```
+
+To add `wash` to your PATH by updating your PowerShell profile, add the filepath for `wash` returned above to your profile, replacing `/path/to` with your local filepath:
+
+```powershell
+notepad $PROFILE
+```
+```powershell
+$env:Path += ";C:\path\to\wash"
+```
+
+  </TabItem>
+
+  <TabItem value="source" label="Source">
+
+You will need [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html) to install from source.
+
+```shell
+git clone https://github.com/wasmcloud/wash.git
+cd wash
+cargo install --path .
+```
+
+Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https://github.com/wasmcloud/wash/releases).
+
+  </TabItem>
+</Tabs>
+
+Verify that `wash` is properly installed with:
+
+```bash
+wash --help
+```
+
+If `wash` is installed correctly, you will see a printout of all available commands and short descriptions for each.
+If you ever need more detail on a specific command or sub-command just run `wash <command> --help`.
+
+Now that `wash` is installed, the next step is to [build and publish a Wasm application](./wash/developer-guide/build-and-publish.mdx).
+
+## Install wasmCloud on Kubernetes
+
+Installation requires the following tools:
+
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [Helm](https://helm.sh/docs) v3.8.0+
+
+You'll also need a Kubernetes environment. We recommend [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) for the best local Kubernetes experience.
+
+### Local Kubernetes environment
+
+You can use the one-liner below to start a `kind` cluster with a configuration from the [`wasmcloud/wash`](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/kind-config.yaml) repository. 
+
+```shell
+curl -fLO https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/kind-config.yaml && kind create cluster --config=kind-config.yaml && rm kind-config.yaml
+```
+
+### Install the wasmCloud operator
+
+Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml):
+
+```shell
+helm install wasmcloud --version 0.1.0 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml
+```
+
+### Deploy a Wasm workload
+
+You can deploy a "Hello world" Wasm workload from a [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) with this `kubectl` command:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml
+```
+
+Use `curl` to invoke the Wasm workload with an HTTP request:
+
+```shell
+curl localhost -i
+```
+```text
+Hello from wasmCloud!
+```
+
+For more information on each of these steps, see [Kubernetes Operator](./kubernetes-operator/index.mdx).


### PR DESCRIPTION
Adds a top-level, platform-level installation page (and reorganizes the sidebar nav a bit).