### PR TITLE
Rolling back wkg prefix

### DIFF
--- a/static/.well-known/wasm-pkg/registry.json
+++ b/static/.well-known/wasm-pkg/registry.json
@@ -1,4 +1,4 @@
 {
   "preferredProtocol": "oci",
-  "oci": { "registry": "ghcr.io", "namespacePrefix": "wasmcloud/components/" }
+  "oci": { "registry": "ghcr.io", "namespacePrefix": "wasmcloud/interfaces/" }
 }


### PR DESCRIPTION
Rollback https://github.com/wasmCloud/wasmcloud.com/pull/1019 & https://github.com/wasmCloud/wasmcloud.com/pull/1043

as CI is failing for both Go & Typescript due to missing interfaces.

