### PR TITLE
fix(docs): update deployment instructions for rc.7

### DIFF
--- a/versioned_docs/version-next/installation.mdx
+++ b/versioned_docs/version-next/installation.mdx
@@ -18,7 +18,7 @@ Install the parts of the [wasmCloud platform](./overview/index.mdx) that you nee
 <Tabs groupId="os" queryString>
   <TabItem value="macoslinux" label="macOS and Linux" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash`:
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.0-rc.6`**):
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/wasmcloud/wash/refs/heads/main/install.sh | bash
@@ -84,14 +84,11 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-Verify that `wash` is properly installed with:
+Verify that `wash` is properly installed and check your version for **`2.0.0-rc.6`** with:
 
 ```bash
-wash --help
+wash -V
 ```
-
-If `wash` is installed correctly, you will see a printout of all available commands and short descriptions for each.
-If you ever need more detail on a specific command or sub-command just run `wash <command> --help`.
 
 Now that `wash` is installed, the next step is to [build and publish a Wasm application](./wash/developer-guide/build-and-publish.mdx).
 
@@ -117,7 +114,7 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/kind-
 Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml):
 
 ```shell
-helm install wasmcloud --version 0.1.0 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml
+helm install wasmcloud --version v2-canary oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
 ### Deploy a Wasm workload

--- a/versioned_docs/version-next/installation.mdx
+++ b/versioned_docs/version-next/installation.mdx
@@ -84,7 +84,7 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-Verify that `wash` is properly installed and check your version for **`2.0.0-rc.6`** with:
+Verify that `wash` is properly installed and check your version for **`2.0.0-rc.7`** with:
 
 ```bash
 wash -V

--- a/versioned_docs/version-next/installation.mdx
+++ b/versioned_docs/version-next/installation.mdx
@@ -18,7 +18,7 @@ Install the parts of the [wasmCloud platform](./overview/index.mdx) that you nee
 <Tabs groupId="os" queryString>
   <TabItem value="macoslinux" label="macOS and Linux" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.0-rc.6`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.0-rc.7`**):
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/wasmcloud/wash/refs/heads/main/install.sh | bash

--- a/versioned_docs/version-next/kubernetes-operator/index.mdx
+++ b/versioned_docs/version-next/kubernetes-operator/index.mdx
@@ -68,14 +68,10 @@ kind create cluster --config=kind-config.yaml
 Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml):
 
 ```shell
-helm install wasmcloud --version 0.1.0 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml
+helm install wasmcloud --version v2-canary oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
-Along with the wasmCloud operator, wasmCloud CRDs, and NATS, the Helm chart will deploy **three wasmCloud hosts** using the [`wasmcloud/wash`](https://github.com/wasmCloud/wasmCloud/pkgs/container/wash) container image:
-
-* `default`: A simple default host
-* `public-ingress`: A host with ingress via [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) from outside your local Kubernetes environment (when using the `kind` configuration above)
-* `private-ingress`: A host with cluster-internal ingress via [ClusterIP](https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip) 
+Along with the wasmCloud operator, wasmCloud CRDs, and NATS, the Helm chart will deploy **three wasmCloud hosts** using the [`wasmcloud/wash`](https://github.com/wasmCloud/wasmCloud/pkgs/container/wash) container image.
 
 You can build your own hosts that provide extended capabilities via [host plugins](../glossary.mdx#host-plugin). 
 
@@ -97,7 +93,7 @@ spec:
   template:
     spec:
       hostSelector:
-        hostgroup: public-ingress
+        hostgroup: default
       components:
         - name: hello-world
           image: ghcr.io/wasmcloud/components/hello-world:0.1.0
@@ -110,7 +106,7 @@ spec:
             host: localhost
 ```
 
-This manifest deploys a simple "Hello world!" component that uses the `wasi:http` interface to the `public-ingress` hostgroup, making it available to call via HTTP from outside the cluster. 
+This manifest deploys a simple "Hello world!" component that uses the `wasi:http` interface to the `default` hostgroup, making it available to call via HTTP from outside the cluster. 
 
 You can deploy from the wasmCloud-hosted manifest with this `kubectl` command:
 

--- a/versioned_docs/version-next/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
+++ b/versioned_docs/version-next/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
@@ -20,26 +20,26 @@ In this section of the Operator Manual, you'll learn how to:
 
 When deploying components that require filesystem resources, you first need to create the volume and make the volume available to the wasmCloud host. 
 
-The sample host configuration excerpt below makes a volume called `wasmcloud-data` available to a host with the `public-ingress` label. (We use this hostgroup for simple local testing in our [default operator deployment](../index.mdx), but you could use any hostgroup.)
+The sample host configuration excerpt below makes a volume called `wasmcloud-data` available to a host with the `default` label. (We use this hostgroup for simple local testing in our [default operator deployment](../index.mdx), but you could use any hostgroup.)
 
 ```yaml {20-23}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    wasmcloud.com/hostgroup: public-ingress
+    wasmcloud.com/hostgroup: default
     wasmcloud.com/name: hostgroup
-  name: hostgroup-public-ingress
+  name: hostgroup-default
   namespace: default
 spec:
   selector:
     matchLabels:
-      wasmcloud.com/hostgroup: public-ingress
+      wasmcloud.com/hostgroup: default
       wasmcloud.com/name: hostgroup
   template:
     metadata:
       labels:
-        wasmcloud.com/hostgroup: public-ingress
+        wasmcloud.com/hostgroup: default
         wasmcloud.com/name: hostgroup
     spec:
       volumes:
@@ -78,7 +78,7 @@ spec:
   template:
     spec:
       hostSelector:
-        hostgroup: public-ingress
+        hostgroup: default
       volumes:
         - name: wasmcloud-data
           hostPath:


### PR DESCRIPTION
Updates Helm chart version in deployment instructions to make them work with updated local values file, along with related adjustments and version specifications. 