### PR TITLE
feat(docs): add custom host and host plugin docs

### DIFF
--- a/versioned_docs/version-next/kubernetes-operator/index.mdx
+++ b/versioned_docs/version-next/kubernetes-operator/index.mdx
@@ -17,7 +17,7 @@ By aligning to Kubernetes, teams can adopt WebAssembly (Wasm) progressively&mdas
 Along with the wasmCloud operator, the wasmCloud platform on Kubernetes consists of these core parts:
 
 * [**Custom resource definitions (CRDs)**](crds.mdx) for wasmCloud infrastructure and Wasm workloads.
-* [**wasmCloud host(s)**](../glossary.mdx#host) - Sandboxed runtime environments for WebAssembly components. (By default, these are `wash` binaries using the `wash host` command to surface the `wash-runtime` API.)
+* [**wasmCloud host(s)**](../glossary.mdx#host) - Sandboxed runtime environments for WebAssembly components. (By default, these are `wash` binaries using the `wash host` command to run a [cluster host (washlet)](../runtime/washlet.mdx) that surfaces the `wash-runtime` API over NATS.)
 * [**NATS with Jetstream**](../glossary.mdx#nats) - CNCF project that provides a connective layer for transport between operator and hosts, along with built-in object storage through Jetstream.
 
 The entire platform can be deployed with [Helm](https://helm.sh/docs) using the [**wasmCloud operator Helm chart**](https://github.com/wasmCloud/wash/tree/main/charts/runtime-operator). (NATS and hosts can also be installed separately, if you wish.)

--- a/versioned_docs/version-next/overview/hosts/index.mdx
+++ b/versioned_docs/version-next/overview/hosts/index.mdx
@@ -4,6 +4,7 @@ icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'The runtime environment for components and capability providers'
 sidebar_position: 4
 type: 'docs'
+toc_max_heading_level: 2
 ---
 
 ### The wasmCloud host is a runtime environment for WebAssembly (Wasm) workloads. 
@@ -12,8 +13,17 @@ WebAssembly components require a runtime to execute. The wasmCloud host provides
 
 Users can build [**host plugins**](./plugins.mdx) to customize wasmCloud hosts with extended capabilities using the [runtime library](../../runtime/index.mdx).
 
-### Hosts as commodity
+## Hosts as commodity
 
 A core design principle of wasmCloud is that the health of applications should not be dependent on any particular host. Hosts are designed to be operated in **host groups**, such that they are interchangeable and should be able to start and stop without causing downtime. 
 
 While it is possible to run a single host, it's also possible for workloads to be distributed across many hosts, and for those hosts to dynamically scale in response to changing demand.
+
+## Usage
+
+The wasmCloud host is designed for flexibility and may be used in a variety of ways:
+
+- **Edge computing**: Run lightweight hosts on edge devices (IoT gateways, retail kiosks, factory equipment) to process data locally with minimal latency.
+- **Multi-cloud deployments**: Deploy hosts across AWS, Azure, and GCP to run the same workloads without vendor-specific modifications.
+- **Kubernetes clusters**: Run hosts as pods in Kubernetes, managed by the [wasmCloud operator](../../kubernetes-operator/index.mdx) for automatic scaling and orchestration.
+- **Development environments**: Run a local host on your laptop for testing and debugging before deploying to production.

--- a/versioned_docs/version-next/overview/hosts/plugins.mdx
+++ b/versioned_docs/version-next/overview/hosts/plugins.mdx
@@ -22,14 +22,14 @@ The [`wash-runtime`](https://github.com/wasmCloud/wash/tree/main/crates/wash-run
 | **Messaging** | `wasmcloud:messaging` | Message passing and pub/sub communication |
 
 :::note
-HTTP is handled by `HttpServer`, which implements the `HostHandler` trait and is registered separately via `with_http_handler()` rather than `with_plugin()`. Filesystem support is built into the host core via `wasmtime-wasi` and is always available without registration.
+HTTP is handled by `HttpServer`, which implements the `HostHandler` trait and is registered separately via `with_http_handler()` rather than `with_plugin()`. In addition, all [WASI P2 interfaces](https://docs.wasmtime.dev/api/wasmtime_wasi/p2/index.html#wasip2-interfaces) provided by `wasmtime-wasi`—including `wasi:filesystem`, `wasi:clocks`, `wasi:random`, `wasi:io`, `wasi:sockets`, and the `wasi:cli` suite—are built into the host core and always available without registration.
 :::
 
 Messaging is always available. The remaining plugins can be enabled or disabled via Cargo feature flags when building your host:
 
 ```toml
 [dependencies]
-wash-runtime = { version = "0.1", features = ["wasi-keyvalue", "wasi-config", "wasi-logging", "wasi-blobstore"] }
+wash-runtime = { version = "*", features = ["wasi-keyvalue", "wasi-config", "wasi-logging", "wasi-blobstore"] }
 ```
 
 ## Using plugins

--- a/versioned_docs/version-next/overview/hosts/plugins.mdx
+++ b/versioned_docs/version-next/overview/hosts/plugins.mdx
@@ -5,10 +5,100 @@ toc_max_heading_level: 2
 
 ### Host plugins extend hosts with additional capabilities.
 
-:::warning[Under construction]
-This section is under active development&mdash;please check back soon for a more complete reference.
+Plugins provide capabilities at the host level, extending a wasmCloud host with specific implementations of [interfaces](../interfaces.mdx). Each plugin implements a **WIT world**—a collection of imports and exports that are directly linked to workloads at runtime.
+
+Plugins allow you to customize how your host handles common operations like HTTP requests, key-value storage, configuration, and logging. You can use the built-in plugins provided by `wash-runtime`, or implement custom plugins for specialized requirements.
+
+## Built-in plugins
+
+The [`wash-runtime`](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime) crate includes built-in plugins for common WASI interfaces. These plugins come in two variants: in-memory implementations for local development (used by `wash dev`), and NATS-backed implementations for production deployments.
+
+| Plugin | Interface | Description |
+|--------|-----------|-------------|
+| **HTTP** | `wasi:http` | HTTP client and server capabilities |
+| **Key-Value** | `wasi:keyvalue` | Key-value storage operations |
+| **Blobstore** | `wasi:blobstore` | Blob/object storage operations |
+| **Config** | `wasi:config` | Runtime configuration access |
+| **Logging** | `wasi:logging` | Structured logging output |
+| **Filesystem** | `wasi:filesystem` | File system access within workload boundaries |
+| **Messaging** | `wasmcloud:messaging` | Message passing and pub/sub communication |
+
+Filesystem and Messaging are always available. The remaining plugins can be enabled or disabled via Cargo feature flags when building your host:
+
+```toml
+[dependencies]
+wash-runtime = { version = "0.1", features = ["wasi-http", "wasi-keyvalue", "wasi-config"] }
+```
+
+## Using plugins
+
+Plugins are registered with the host using the `HostBuilder` API. The following example demonstrates how to configure a host with HTTP and configuration plugins:
+
+```rust
+use std::sync::Arc;
+use std::collections::HashMap;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{HostBuilder, HostApi},
+    plugin::wasi_http::HttpServer,
+    plugin::wasi_config::RuntimeConfig,
+    types::{WorkloadStartRequest, Workload},
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Create a Wasmtime engine
+    let engine = Engine::builder().build()?;
+
+    // Configure plugins
+    let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
+    let config_plugin = RuntimeConfig::default();
+
+    // Build and start the host with plugins
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_plugin(Arc::new(http_plugin))?
+        .with_plugin(Arc::new(config_plugin))?
+        .build()?;
+
+    let host = host.start().await?;
+
+    // Start a workload (components will have access to plugin capabilities)
+    let req = WorkloadStartRequest {
+        workload: Workload {
+            namespace: "example".to_string(),
+            name: "my-workload".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    };
+
+    host.workload_start(req).await?;
+
+    Ok(())
+}
+```
+
+:::info[Default behavior]
+If a handler is not provided for a particular capability, a "deny all" implementation is used. This ensures that components cannot access capabilities unless explicitly configured.
 :::
 
-Plugins provide capabilities at the host level, extending a wasmCloud host with a specific implementation of a given capability according to an interface.
+## Custom plugins
 
-Plugins are built into the host before deployment; you can find a [basic example](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime#usage) in the `wash-runtime` repository, or see this [discussion of host plugin implementation in a wasmCloud community call](https://www.youtube.com/live/3DlUjl8gQVs?si=MbTz4MohjYDmE8fI&t=731). 
+You can create custom plugins by implementing the `HostPlugin` trait. See [Creating Host Plugins](../../runtime/creating-host-plugins.mdx) for more information.
+
+Custom plugins are useful when you need to:
+
+- **Integrate with proprietary systems**: Connect components to internal APIs, databases, or services that don't have standard WASI interfaces.
+- **Add security layers**: Implement custom authentication, authorization, or audit logging for capability access.
+- **Provide specialized hardware access**: Expose GPUs or other specialized hardware to components.
+
+## Keep reading
+
+- Learn more about the [wasmCloud runtime](../../runtime/index.mdx).
+- See the [wash-runtime source code](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime) for implementation details.
+- Watch a [discussion of host plugin implementation](https://www.youtube.com/live/3DlUjl8gQVs?si=MbTz4MohjYDmE8fI&t=731) from a wasmCloud community call.

--- a/versioned_docs/version-next/overview/hosts/plugins.mdx
+++ b/versioned_docs/version-next/overview/hosts/plugins.mdx
@@ -15,24 +15,26 @@ The [`wash-runtime`](https://github.com/wasmCloud/wash/tree/main/crates/wash-run
 
 | Plugin | Interface | Description |
 |--------|-----------|-------------|
-| **HTTP** | `wasi:http` | HTTP client and server capabilities |
 | **Key-Value** | `wasi:keyvalue` | Key-value storage operations |
 | **Blobstore** | `wasi:blobstore` | Blob/object storage operations |
 | **Config** | `wasi:config` | Runtime configuration access |
 | **Logging** | `wasi:logging` | Structured logging output |
-| **Filesystem** | `wasi:filesystem` | File system access within workload boundaries |
 | **Messaging** | `wasmcloud:messaging` | Message passing and pub/sub communication |
 
-Filesystem and Messaging are always available. The remaining plugins can be enabled or disabled via Cargo feature flags when building your host:
+:::note
+HTTP is handled by `HttpServer`, which implements the `HostHandler` trait and is registered separately via `with_http_handler()` rather than `with_plugin()`. Filesystem support is built into the host core via `wasmtime-wasi` and is always available without registration.
+:::
+
+Messaging is always available. The remaining plugins can be enabled or disabled via Cargo feature flags when building your host:
 
 ```toml
 [dependencies]
-wash-runtime = { version = "0.1", features = ["wasi-http", "wasi-keyvalue", "wasi-config"] }
+wash-runtime = { version = "0.1", features = ["wasi-keyvalue", "wasi-config", "wasi-logging", "wasi-blobstore"] }
 ```
 
 ## Using plugins
 
-Plugins are registered with the host using the `HostBuilder` API. The following example demonstrates how to configure a host with HTTP and configuration plugins:
+Plugins are registered with the host using the `HostBuilder` API. HTTP is handled separately via `with_http_handler()` because `HttpServer` implements the `HostHandler` trait rather than `HostPlugin`. The following example demonstrates how to configure a host with an HTTP handler and a configuration plugin:
 
 ```rust
 use std::sync::Arc;
@@ -40,9 +42,8 @@ use std::collections::HashMap;
 
 use wash_runtime::{
     engine::Engine,
-    host::{HostBuilder, HostApi},
-    plugin::wasi_http::HttpServer,
-    plugin::wasi_config::RuntimeConfig,
+    host::{HostBuilder, HostApi, http::{HttpServer, DevRouter}},
+    plugin::wasi_config::DynamicConfig,
     types::{WorkloadStartRequest, Workload},
 };
 
@@ -51,14 +52,15 @@ async fn main() -> anyhow::Result<()> {
     // Create a Wasmtime engine
     let engine = Engine::builder().build()?;
 
-    // Configure plugins
-    let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
-    let config_plugin = RuntimeConfig::default();
+    // Configure HTTP handler and plugins
+    // DevRouter routes all requests to the most recently resolved workload
+    let http_handler = HttpServer::new(DevRouter::default(), "127.0.0.1:8080".parse()?).await?;
+    let config_plugin = DynamicConfig::new(false);
 
-    // Build and start the host with plugins
+    // Build and start the host
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_plugin(Arc::new(http_plugin))?
+        .with_http_handler(Arc::new(http_handler))
         .with_plugin(Arc::new(config_plugin))?
         .build()?;
 
@@ -66,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Start a workload (components will have access to plugin capabilities)
     let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
             namespace: "example".to_string(),
             name: "my-workload".to_string(),

--- a/versioned_docs/version-next/overview/interfaces.mdx
+++ b/versioned_docs/version-next/overview/interfaces.mdx
@@ -5,6 +5,7 @@ icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'A quick guide to wasmCloud interfaces'
 sidebar_position: 3
 type: 'docs'
+toc_max_heading_level: 2
 ---
 
 ### Interfaces are contracts that define the relationships between entities.

--- a/versioned_docs/version-next/overview/workloads/index.mdx
+++ b/versioned_docs/version-next/overview/workloads/index.mdx
@@ -3,6 +3,7 @@ title: 'Workloads'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'Portable, sandboxed, polyglot workloads'
 type: 'docs'
+toc_max_heading_level: 2
 ---
 
 ### Workloads are composed of one or more WebAssembly (Wasm) components and an optional service. 
@@ -21,7 +22,16 @@ The [wasmCloud host](../hosts/index.mdx) runs workloads in cloud and edge enviro
 
 Workloads are defined according to the [wasmCloud runtime's Workload API](https://github.com/wasmCloud/wash/blob/main/proto/wasmcloud/runtime/v2/workload.proto). For most users, this means defining the workload in a Kubernetes manifest with the [`WorkloadDeployment` custom resource](../../kubernetes-operator/crds.mdx#workloaddeployment). 
 
-### Components vs Services
+## Usage
+
+Workloads are application-level units that combine components and services. Example use cases include:
+
+- **Microservices**: Deploy a workload as a single microservice—for example, an order processing service with a component handling business logic and a service maintaining database connections.
+- **API backends**: Build HTTP APIs where components handle request routing and response generation while services manage authentication state or connection pools.
+- **Event processors**: Create workloads that respond to events from message queues, with components processing messages and services maintaining connections to the queue.
+- **Scheduled jobs**: Run batch processing workloads where a cron service triggers component invocations on a schedule.
+
+## Components vs Services
 
 | Feature | Components | Services |
 |---------|------------|----------|
@@ -32,8 +42,6 @@ Workloads are defined according to the [wasmCloud runtime's Workload API](https:
 | **Execution Model** | Invoked per request | Runs continuously (like traditional binaries) |
 | **WASI Interface** | Component model | `wasi:cli/run` |
 | **Restart Policy** | N/A (invoked as needed) | Automatically restarted on crash |
-
-## When to use components and services
 
 **Use a component when you need:**
 - Stateless request/response patterns

--- a/versioned_docs/version-next/runtime/building-custom-hosts.mdx
+++ b/versioned_docs/version-next/runtime/building-custom-hosts.mdx
@@ -17,7 +17,7 @@ Custom hosts are useful when you need to:
 - **Integrate with proprietary systems** that require custom plugins or configurations
 - **Build specialized tooling** around WebAssembly workloads
 
-For most production deployments, the standard wasmCloud host managed by the [Kubernetes operator](../kubernetes-operator/index.mdx) is recommended. Build a custom host only when you have specific requirements that can't be met by the standard deployment model.
+For most production deployments, the standard wasmCloud host managed by the [Kubernetes operator](../kubernetes-operator/index.mdx) is recommended—this runs as a [cluster host (washlet)](./washlet.mdx) that receives workload commands over NATS. Build a custom host only when you have specific requirements that can't be met by the standard deployment model.
 
 ## Prerequisites
 
@@ -370,6 +370,7 @@ match host.workload_start(request).await {
 
 ## Keep reading
 
+- [Cluster Hosts (Washlet)](./washlet.mdx) - Run a cluster-connected host managed by the operator
 - [Creating Host Plugins](./creating-host-plugins.mdx) - Build custom plugins for your host
 - [Host Plugins Overview](../overview/hosts/plugins.mdx) - Understand the plugin architecture
 - [wash-runtime source code](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime) - Explore the implementation

--- a/versioned_docs/version-next/runtime/building-custom-hosts.mdx
+++ b/versioned_docs/version-next/runtime/building-custom-hosts.mdx
@@ -1,0 +1,369 @@
+---
+title: "Building Custom Hosts"
+sidebar_position: 3
+toc_max_heading_level: 2
+---
+
+### Build custom wasmCloud hosts for specialized deployment scenarios.
+
+The `wash-runtime` crate provides a Rust library for embedding wasmCloud host functionality in your own applications. This enables you to create custom hosts tailored to specific requirements—whether for edge deployments, specialized hardware, or integration with existing systems.
+
+## When to build a custom host
+
+Custom hosts are useful when you need to:
+
+- **Embed WebAssembly execution** in an existing Rust application
+- **Deploy to constrained environments** where the full wasmCloud stack is too heavy
+- **Integrate with proprietary systems** that require custom plugins or configurations
+- **Build specialized tooling** around WebAssembly workloads
+
+For most production deployments, the standard wasmCloud host managed by the [Kubernetes operator](../kubernetes-operator/index.mdx) is recommended. Build a custom host only when you have specific requirements that can't be met by the standard deployment model.
+
+## Prerequisites
+
+Add `wash-runtime` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+wash-runtime = "0.1"
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
+tracing-subscriber = "0.3"
+```
+
+Enable only the features you need to minimize binary size:
+
+```toml
+[dependencies]
+wash-runtime = { version = "0.1", default-features = false, features = [
+    "wasi-http",
+    "wasi-keyvalue",
+    "wasi-config",
+] }
+```
+
+### Available features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `wasi-http` | Yes | HTTP client and server support via `wasmtime-wasi-http` |
+| `wasi-config` | Yes | Runtime configuration interface |
+| `wasi-logging` | Yes | Logging interface |
+| `wasi-blobstore` | Yes | Blob storage interface |
+| `wasi-keyvalue` | Yes | Key-value storage interface |
+| `oci` | No | OCI registry integration for pulling components |
+
+## Architecture overview
+
+A typical custom host architecture includes:
+
+1. **Engine**: Configures and manages the underlying Wasmtime runtime
+2. **Plugins**: The host is built with plugins to enable capabilities
+3. **Workloads**: Units of execution containing components and optional services
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Custom Host                    │
+│  ┌───────────┐  ┌───────────┐  ┌───────────┐    │
+│  │  Engine   │  │  Plugins  │  │ Workloads │    │
+│  │           │  │           │  │           │    │
+│  │ Wasmtime  │  │ HTTP      │  │ Component │    │
+│  │ Config    │  │ KeyValue  │  │ Component │    │
+│  │ Pooling   │  │ Config    │  │ Service   │    │
+│  └───────────┘  └───────────┘  └───────────┘    │
+└─────────────────────────────────────────────────┘
+```
+
+## Creating an Engine
+
+The `Engine` wraps Wasmtime and handles WebAssembly compilation. Use `Engine::builder()` to configure it:
+
+```rust
+use wash_runtime::engine::Engine;
+
+// Default configuration
+let engine = Engine::builder().build()?;
+
+// With pooling allocator enabled
+let engine = Engine::builder()
+    .with_pooling_allocator(true)
+    .build()?;
+
+// With a fully custom wasmtime configuration
+// (wasmtime is re-exported by wash-runtime)
+let mut config = wash_runtime::wasmtime::Config::new();
+config.cranelift_opt_level(wash_runtime::wasmtime::OptLevel::Speed);
+let engine = Engine::builder()
+    .with_config(config)
+    .build()?;
+```
+
+### Engine configuration options
+
+| Method | Description |
+|--------|-------------|
+| `with_pooling_allocator(bool)` | Enable/disable instance pooling for better performance with many short-lived instances |
+| `with_config(wasmtime::Config)` | Provide a fully custom Wasmtime configuration for advanced use cases |
+
+:::info[Pooling allocator]
+The pooling allocator is automatically enabled on machines with sufficient virtual memory. You can override this behavior with the `with_pooling_allocator()` method.
+:::
+
+## Building the Host
+
+Use `HostBuilder` to construct a host with your desired configuration. All capabilities (HTTP, key-value, configuration, etc.) are provided as plugins:
+
+```rust
+use std::sync::Arc;
+use wash_runtime::{
+    engine::Engine,
+    host::{HostBuilder, HostApi},
+    plugin::wasi_http::HttpServer,
+    plugin::wasi_config::RuntimeConfig,
+};
+
+let engine = Engine::builder().build()?;
+
+// Configure plugins
+let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
+// For HTTPS, use HttpServer::new_with_tls() with cert, key, and optional CA paths
+let config_plugin = RuntimeConfig::default();
+
+// Build the host
+let host = HostBuilder::new()
+    .with_engine(engine)
+    .with_hostname("my-custom-host")
+    .with_friendly_name("My Custom Host")
+    .with_label("environment", "production")
+    .with_label("region", "us-west-2")
+    .with_plugin(Arc::new(http_plugin))?
+    .with_plugin(Arc::new(config_plugin))?
+    .build()?;
+
+// Start the host (initializes all plugins)
+let host = host.start().await?;
+```
+
+### HostBuilder methods
+
+| Method | Description |
+|--------|-------------|
+| `with_engine(Engine)` | Set the WebAssembly engine (creates default if not set) |
+| `with_hostname(str)` | Set the system hostname (defaults to OS hostname) |
+| `with_friendly_name(str)` | Set a human-readable name (auto-generated if not set) |
+| `with_label(key, value)` | Add metadata labels for identification |
+| `with_plugin(Arc<dyn HostPlugin>)` | Register a plugin (can be called multiple times; IDs must be unique) |
+
+## Managing workloads
+
+Once the host is running, use the `HostApi` trait to manage workloads. The host generates unique IDs for each workload automatically.
+
+### Starting a workload
+
+```rust
+use std::collections::HashMap;
+use wash_runtime::types::{Workload, WorkloadStartRequest, Component, LocalResources};
+
+let component_bytes = std::fs::read("./my-component.wasm")?;
+
+let request = WorkloadStartRequest {
+    workload: Workload {
+        namespace: "my-app".to_string(),
+        name: "http-handler".to_string(),
+        annotations: HashMap::from([
+            ("version".to_string(), "1.0.0".to_string()),
+        ]),
+        service: None,
+        components: vec![
+            Component {
+                bytes: component_bytes.into(),
+                local_resources: LocalResources {
+                    memory_limit_mb: 64,  // In megabytes; -1 = unlimited
+                    cpu_limit: -1,        // In millicores; -1 = unlimited
+                    config: HashMap::new(),
+                    environment: HashMap::from([
+                        ("LOG_LEVEL".to_string(), "info".to_string()),
+                    ]),
+                    volume_mounts: vec![],
+                    allowed_hosts: vec!["api.example.com".to_string()],
+                },
+                pool_size: 10,
+                max_invocations: 0,  // 0 = unlimited
+            },
+        ],
+        host_interfaces: vec![],
+        volumes: vec![],
+    },
+};
+
+let response = host.workload_start(request).await?;
+let workload_id = response.workload_status.workload_id;
+println!("Workload started with ID: {}", workload_id);
+```
+
+### Checking workload status
+
+```rust
+use wash_runtime::types::{WorkloadStatusRequest, WorkloadState};
+
+let status = host.workload_status(WorkloadStatusRequest {
+    workload_id: workload_id.clone(),
+}).await?;
+
+match status.workload_status.workload_state {
+    WorkloadState::Running => println!("Workload is running"),
+    WorkloadState::Error => println!("Workload encountered an error"),
+    WorkloadState::Completed => println!("Workload completed"),
+    state => println!("Workload state: {:?}", state),
+}
+```
+
+### Stopping a workload
+
+```rust
+use wash_runtime::types::WorkloadStopRequest;
+
+host.workload_stop(WorkloadStopRequest {
+    workload_id: workload_id.clone(),
+}).await?;
+```
+
+### Host heartbeat
+
+You can query the host for system information and current workload counts:
+
+```rust
+let heartbeat = host.heartbeat().await?;
+println!("Host: {} ({})", heartbeat.friendly_name, heartbeat.id);
+println!("CPU: {:.1}%, Memory: {} MB free / {} MB total",
+    heartbeat.system_cpu_usage,
+    heartbeat.system_memory_free / 1024 / 1024,
+    heartbeat.system_memory_total / 1024 / 1024,
+);
+println!("Workloads: {}, Components: {}",
+    heartbeat.workload_count, heartbeat.component_count);
+```
+
+## Complete example
+
+Here's a complete example that creates a custom host with HTTP and config plugins:
+
+```rust
+use std::sync::Arc;
+use std::collections::HashMap;
+use wash_runtime::{
+    engine::Engine,
+    host::{HostBuilder, HostApi},
+    plugin::wasi_http::HttpServer,
+    plugin::wasi_config::RuntimeConfig,
+    types::{Workload, WorkloadStartRequest, Component, LocalResources},
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing for observability
+    tracing_subscriber::fmt::init();
+
+    // Create the engine with pooling enabled
+    let engine = Engine::builder()
+        .with_pooling_allocator(true)
+        .build()?;
+
+    // Configure plugins
+    let http_plugin = HttpServer::new("0.0.0.0:8080".parse()?);
+    let config_plugin = RuntimeConfig::default();
+
+    // Build and start the host
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_friendly_name("my-custom-host")
+        .with_plugin(Arc::new(http_plugin))?
+        .with_plugin(Arc::new(config_plugin))?
+        .build()?;
+
+    let host = host.start().await?;
+    println!("Host started: {}", host.friendly_name());
+
+    // Load a component from disk
+    let component_bytes = std::fs::read("./my-component.wasm")?;
+
+    // Create and start a workload
+    let request = WorkloadStartRequest {
+        workload: Workload {
+            namespace: "default".to_string(),
+            name: "my-component".to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                bytes: component_bytes.into(),
+                local_resources: LocalResources::default(),
+                pool_size: 5,
+                max_invocations: 0,
+            }],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    };
+
+    let response = host.workload_start(request).await?;
+    let workload_id = response.workload_status.workload_id.clone();
+    println!("Workload started: {}", workload_id);
+
+    // Keep the host running
+    println!("Host listening on http://0.0.0.0:8080");
+    tokio::signal::ctrl_c().await?;
+
+    // Clean shutdown
+    host.workload_stop(wash_runtime::types::WorkloadStopRequest {
+        workload_id,
+    }).await?;
+
+    host.stop().await?;
+    println!("Host shutdown complete");
+    Ok(())
+}
+```
+
+## Adding custom plugins
+
+For specialized requirements, you can create custom plugins that implement the `HostPlugin` trait. See [Creating Host Plugins](./creating-host-plugins.mdx) for detailed instructions.
+
+```rust
+use std::sync::Arc;
+use wash_runtime::host::HostBuilder;
+
+// Create your custom plugin
+let my_plugin = MyCustomPlugin::new();
+
+// Register it with the host
+let host = HostBuilder::new()
+    .with_engine(engine)
+    .with_plugin(Arc::new(my_plugin))?
+    .build()?;
+```
+
+## Error handling
+
+The `wash-runtime` APIs return `anyhow::Result` for flexible error handling. Common error scenarios include:
+
+- **Engine build failures**: Invalid Wasmtime configuration
+- **Plugin registration**: Duplicate plugin IDs
+- **Workload start**: Invalid component bytes or missing interface dependencies
+- **Resource limits**: Exceeded memory or instance limits
+
+```rust
+match host.workload_start(request).await {
+    Ok(response) => {
+        println!("Started workload: {}", response.workload_status.workload_id);
+    }
+    Err(e) => {
+        eprintln!("Failed to start workload: {}", e);
+    }
+}
+```
+
+## Keep reading
+
+- [Creating Host Plugins](./creating-host-plugins.mdx) - Build custom plugins for your host
+- [Host Plugins Overview](../overview/hosts/plugins.mdx) - Understand the plugin architecture
+- [wash-runtime source code](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime) - Explore the implementation

--- a/versioned_docs/version-next/runtime/building-custom-hosts.mdx
+++ b/versioned_docs/version-next/runtime/building-custom-hosts.mdx
@@ -25,7 +25,7 @@ Add `wash-runtime` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-wash-runtime = "0.1"
+wash-runtime = "*"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 tracing-subscriber = "0.3"
@@ -35,8 +35,7 @@ Enable only the features you need to minimize binary size:
 
 ```toml
 [dependencies]
-wash-runtime = { version = "0.1", default-features = false, features = [
-    "wasi-http",
+wash-runtime = { version = "*", default-features = false, features = [
     "wasi-keyvalue",
     "wasi-config",
 ] }
@@ -46,11 +45,13 @@ wash-runtime = { version = "0.1", default-features = false, features = [
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `wasi-http` | Yes | HTTP client and server support via `wasmtime-wasi-http` |
 | `wasi-config` | Yes | Runtime configuration interface |
 | `wasi-logging` | Yes | Logging interface |
 | `wasi-blobstore` | Yes | Blob storage interface |
 | `wasi-keyvalue` | Yes | Key-value storage interface |
+| `wasmcloud-postgres` | Yes | PostgreSQL-backed implementations for keyvalue and blobstore |
+| `washlet` | Yes | Washlet support (depends on `oci`) |
+| `wasi-webgpu` | No | WebGPU interface |
 | `oci` | No | OCI registry integration for pulling components |
 
 ## Architecture overview
@@ -117,17 +118,16 @@ Use `HostBuilder` to construct a host with your desired configuration. All capab
 use std::sync::Arc;
 use wash_runtime::{
     engine::Engine,
-    host::{HostBuilder, HostApi},
-    plugin::wasi_http::HttpServer,
-    plugin::wasi_config::RuntimeConfig,
+    host::{HostBuilder, HostApi, http::{HttpServer, DevRouter}},
+    plugin::wasi_config::DynamicConfig,
 };
 
 let engine = Engine::builder().build()?;
 
-// Configure plugins
-let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
+// Configure HTTP handler and plugins
+let http_handler = HttpServer::new(DevRouter::default(), "127.0.0.1:8080".parse()?).await?;
 // For HTTPS, use HttpServer::new_with_tls() with cert, key, and optional CA paths
-let config_plugin = RuntimeConfig::default();
+let config_plugin = DynamicConfig::new(false);
 
 // Build the host
 let host = HostBuilder::new()
@@ -136,7 +136,7 @@ let host = HostBuilder::new()
     .with_friendly_name("My Custom Host")
     .with_label("environment", "production")
     .with_label("region", "us-west-2")
-    .with_plugin(Arc::new(http_plugin))?
+    .with_http_handler(Arc::new(http_handler))
     .with_plugin(Arc::new(config_plugin))?
     .build()?;
 
@@ -152,11 +152,12 @@ let host = host.start().await?;
 | `with_hostname(str)` | Set the system hostname (defaults to OS hostname) |
 | `with_friendly_name(str)` | Set a human-readable name (auto-generated if not set) |
 | `with_label(key, value)` | Add metadata labels for identification |
+| `with_http_handler(Arc<dyn HostHandler>)` | Register the HTTP handler (`HttpServer` implements `HostHandler`, not `HostPlugin`) |
 | `with_plugin(Arc<dyn HostPlugin>)` | Register a plugin (can be called multiple times; IDs must be unique) |
 
 ## Managing workloads
 
-Once the host is running, use the `HostApi` trait to manage workloads. The host generates unique IDs for each workload automatically.
+Once the host is running, use the `HostApi` trait to manage workloads. Each `WorkloadStartRequest` requires a caller-supplied `workload_id` string.
 
 ### Starting a workload
 
@@ -167,6 +168,7 @@ use wash_runtime::types::{Workload, WorkloadStartRequest, Component, LocalResour
 let component_bytes = std::fs::read("./my-component.wasm")?;
 
 let request = WorkloadStartRequest {
+    workload_id: uuid::Uuid::new_v4().to_string(),
     workload: Workload {
         namespace: "my-app".to_string(),
         name: "http-handler".to_string(),
@@ -176,7 +178,9 @@ let request = WorkloadStartRequest {
         service: None,
         components: vec![
             Component {
+                name: "my-handler".to_string(),
                 bytes: component_bytes.into(),
+                digest: None,
                 local_resources: LocalResources {
                     memory_limit_mb: 64,  // In megabytes; -1 = unlimited
                     cpu_limit: -1,        // In millicores; -1 = unlimited
@@ -253,9 +257,8 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use wash_runtime::{
     engine::Engine,
-    host::{HostBuilder, HostApi},
-    plugin::wasi_http::HttpServer,
-    plugin::wasi_config::RuntimeConfig,
+    host::{HostBuilder, HostApi, http::{HttpServer, DevRouter}},
+    plugin::wasi_config::DynamicConfig,
     types::{Workload, WorkloadStartRequest, Component, LocalResources},
 };
 
@@ -269,15 +272,15 @@ async fn main() -> anyhow::Result<()> {
         .with_pooling_allocator(true)
         .build()?;
 
-    // Configure plugins
-    let http_plugin = HttpServer::new("0.0.0.0:8080".parse()?);
-    let config_plugin = RuntimeConfig::default();
+    // Configure HTTP handler and plugins
+    let http_handler = HttpServer::new(DevRouter::default(), "0.0.0.0:8080".parse()?).await?;
+    let config_plugin = DynamicConfig::new(false);
 
     // Build and start the host
     let host = HostBuilder::new()
         .with_engine(engine)
         .with_friendly_name("my-custom-host")
-        .with_plugin(Arc::new(http_plugin))?
+        .with_http_handler(Arc::new(http_handler))
         .with_plugin(Arc::new(config_plugin))?
         .build()?;
 
@@ -289,13 +292,16 @@ async fn main() -> anyhow::Result<()> {
 
     // Create and start a workload
     let request = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
             namespace: "default".to_string(),
             name: "my-component".to_string(),
             annotations: HashMap::new(),
             service: None,
             components: vec![Component {
+                name: "my-component".to_string(),
                 bytes: component_bytes.into(),
+                digest: None,
                 local_resources: LocalResources::default(),
                 pool_size: 5,
                 max_invocations: 0,

--- a/versioned_docs/version-next/runtime/creating-host-plugins.mdx
+++ b/versioned_docs/version-next/runtime/creating-host-plugins.mdx
@@ -1,0 +1,177 @@
+---
+title: "Creating Host Plugins"
+sidebar_position: 2
+toc_max_heading_level: 2
+---
+
+### Extend wasmCloud hosts with additional capabilities.
+
+The `wash-runtime` crate includes [built-in plugins](../overview/hosts/plugins.mdx) for common WASI interfaces like HTTP, key-value, and configuration. When you need to provide capabilities that aren't covered by the built-ins—such as integrating with a proprietary database, exposing specialized hardware, or implementing a custom protocol—you can create a custom plugin.
+
+A host plugin is primarily responsible for implementing a specific WIT world as a collection of imports and exports that will be directly linked to the workload's `wasmtime::component::Linker`.
+
+### The `HostPlugin` trait
+
+```rust
+#[async_trait]
+pub trait HostPlugin: Any + Send + Sync + 'static {
+    /// Returns a unique identifier for the plugin.
+    /// Plugin IDs must be unique across all registered plugins.
+    fn id(&self) -> &'static str;
+
+    /// Returns the WIT world this plugin implements.
+    /// The binding process only occurs if workloads require these interfaces.
+    fn world(&self) -> WitWorld;
+
+    /// Called during host initialization before accepting workloads.
+    /// Use this for setup tasks like establishing connections.
+    async fn start(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Called when a workload begins binding to the plugin.
+    /// Enables pre-binding validation and setup.
+    async fn on_workload_bind(
+        &self,
+        workload: &UnresolvedWorkload,
+        interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Called when configuring a specific component's linker.
+    /// This is where you add your implementations to the linker.
+    async fn on_component_bind(
+        &self,
+        component: &mut WorkloadComponent,
+        interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Called after successful workload binding and resolution.
+    async fn on_workload_resolved(
+        &self,
+        workload: &ResolvedWorkload,
+        component_id: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Called during unbinding or shutdown for cleanup.
+    async fn on_workload_unbind(
+        &self,
+        workload: &ResolvedWorkload,
+        interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Called during host shutdown for final cleanup.
+    async fn stop(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+```
+
+### Plugin lifecycle
+
+Plugins follow a defined lifecycle within the host:
+
+1. **Registration**: Plugins are registered via `HostBuilder::with_plugin()`. Each plugin must have a unique ID.
+2. **Start**: When the host starts, all plugins' `start()` methods are called. If any plugin fails to start, the host startup fails.
+3. **Workload binding**: When a workload starts, the host calls `on_workload_bind()` and `on_component_bind()` for each plugin that provides interfaces the workload requires.
+4. **Resolution**: After successful binding, `on_workload_resolved()` is called.
+5. **Unbinding**: When workloads stop, `on_workload_unbind()` is called for cleanup.
+6. **Stop**: During host shutdown, all plugins' `stop()` methods are called (with a 3-second timeout per plugin).
+
+### Key types
+
+The `HostPlugin` trait uses several types from the `wash_runtime` crate:
+
+- **`WitWorld`** - Contains `imports` and `exports` as `HashSet<WitInterface>`, representing the WIT interfaces the plugin provides.
+- **`WitInterface`** - Describes a specific interface with `namespace`, `package`, `interfaces` (a set of interface names), an optional `version`, and a `config` map.
+- **`UnresolvedWorkload`** - A workload that has been initialized but not yet bound to plugins.
+- **`WorkloadComponent`** - A component within a workload, providing access to its `wasmtime::component::Linker` for binding implementations.
+- **`ResolvedWorkload`** - A fully bound workload ready for execution.
+
+### Example: Custom logging plugin
+
+Here's a simplified example of a custom plugin that implements logging:
+
+```rust
+use std::collections::HashSet;
+use async_trait::async_trait;
+use wash_runtime::{
+    engine::workload::WorkloadComponent,
+    plugin::HostPlugin,
+    wit::{WitInterface, WitWorld},
+};
+
+pub struct CustomLogger {
+    prefix: String,
+}
+
+impl CustomLogger {
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self { prefix: prefix.into() }
+    }
+}
+
+#[async_trait]
+impl HostPlugin for CustomLogger {
+    fn id(&self) -> &'static str {
+        "custom-logger"
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::new(),
+            exports: HashSet::from([WitInterface {
+                namespace: "wasi".to_string(),
+                package: "logging".to_string(),
+                interfaces: HashSet::from(["logging".to_string()]),
+                version: None,
+                config: std::collections::HashMap::new(),
+            }]),
+        }
+    }
+
+    async fn start(&self) -> anyhow::Result<()> {
+        println!("[{}] Logger plugin started", self.prefix);
+        Ok(())
+    }
+
+    async fn on_component_bind(
+        &self,
+        component: &mut WorkloadComponent,
+        interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        // Add logging implementation to the component's linker
+        // component.linker_mut().func_wrap(...)?;
+        Ok(())
+    }
+
+    async fn stop(&self) -> anyhow::Result<()> {
+        println!("[{}] Logger plugin stopped", self.prefix);
+        Ok(())
+    }
+}
+```
+
+Register the custom plugin with your host:
+
+```rust
+let logger = CustomLogger::new("my-app");
+
+let host = HostBuilder::new()
+    .with_engine(engine)
+    .with_plugin(Arc::new(logger))?
+    .build()?;
+```
+
+## Keep reading
+
+- [Building Custom Hosts](./building-custom-hosts.mdx) - Embed the wasmCloud runtime in your own application
+- [Host Plugins Overview](../overview/hosts/plugins.mdx) - Built-in plugins and plugin architecture
+- [wash-runtime source code](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime/src/plugin) - Reference implementations of built-in plugins

--- a/versioned_docs/version-next/runtime/creating-host-plugins.mdx
+++ b/versioned_docs/version-next/runtime/creating-host-plugins.mdx
@@ -81,7 +81,7 @@ Plugins follow a defined lifecycle within the host:
 
 1. **Registration**: Plugins are registered via `HostBuilder::with_plugin()`. Each plugin must have a unique ID.
 2. **Start**: When the host starts, all plugins' `start()` methods are called. If any plugin fails to start, the host startup fails.
-3. **Workload binding**: When a workload starts, the host calls `on_workload_bind()` and `on_workload_item_bind()` for each plugin that provides interfaces the workload requires.
+3. **Workload binding**: When a workload starts, the host calls `on_workload_bind()` once per plugin, then calls `on_workload_item_bind()` for each component and service in that workload.
 4. **Resolution**: After successful binding, `on_workload_resolved()` is called.
 5. **Unbinding**: When workloads stop, `on_workload_unbind()` is called for cleanup.
 6. **Stop**: During host shutdown, all plugins' `stop()` methods are called (with a 3-second timeout per plugin).
@@ -93,7 +93,7 @@ The `HostPlugin` trait uses several types from the `wash_runtime` crate:
 - **`WitWorld`** - Contains `imports` and `exports` as `HashSet<WitInterface>`, representing the WIT interfaces the plugin provides.
 - **`WitInterface`** - Describes a specific interface with `namespace`, `package`, `interfaces` (a set of interface names), an optional `version`, and a `config` map.
 - **`UnresolvedWorkload`** - A workload that has been initialized but not yet bound to plugins.
-- **`WorkloadItem<'a>`** - An enum passed to `on_workload_item_bind`. Variants are `WorkloadItem::Component(&mut WorkloadComponent)` and `WorkloadItem::Service(&mut WorkloadService)`. Match on the variant to access the linker.
+- **`WorkloadItem<'a>`** - An enum passed to `on_workload_item_bind`. Variants are `WorkloadItem::Component(&mut WorkloadComponent)` and `WorkloadItem::Service(&mut WorkloadService)`. Implements `Deref<Target = WorkloadMetadata>`, so `item.linker()` is accessible directly without pattern matching. Use `item.is_component()` / `item.is_service()` when you need to handle the two variants differently.
 - **`ResolvedWorkload`** - A fully bound workload ready for execution.
 
 ### Example: Custom logging plugin
@@ -148,10 +148,12 @@ impl HostPlugin for CustomLogger {
         item: &mut WorkloadItem<'a>,
         interfaces: HashSet<WitInterface>,
     ) -> anyhow::Result<()> {
-        // Match on the variant to access the linker
-        // if let WorkloadItem::Component(component) = item {
-        //     component.linker_mut().func_wrap(...)?;
-        // }
+        // WorkloadItem implements Deref<Target = WorkloadMetadata>, so linker()
+        // is accessible directly without pattern matching:
+        // item.linker().func_wrap(...)?;
+        //
+        // Use item.is_component() / item.is_service() if you need to
+        // handle components and services differently.
         Ok(())
     }
 

--- a/versioned_docs/version-next/runtime/creating-host-plugins.mdx
+++ b/versioned_docs/version-next/runtime/creating-host-plugins.mdx
@@ -6,7 +6,7 @@ toc_max_heading_level: 2
 
 ### Extend wasmCloud hosts with additional capabilities.
 
-The `wash-runtime` crate includes [built-in plugins](../overview/hosts/plugins.mdx) for common WASI interfaces like HTTP, key-value, and configuration. When you need to provide capabilities that aren't covered by the built-ins—such as integrating with a proprietary database, exposing specialized hardware, or implementing a custom protocol—you can create a custom plugin.
+The `wash-runtime` crate includes [built-in support](../overview/hosts/plugins.mdx) for common WASI interfaces like HTTP, key-value, and configuration. When you need to provide capabilities that aren't covered by the built-ins—such as integrating with a proprietary database, exposing specialized hardware, or implementing a custom protocol—you can create a custom plugin.
 
 A host plugin is primarily responsible for implementing a specific WIT world as a collection of imports and exports that will be directly linked to the workload's `wasmtime::component::Linker`.
 
@@ -39,11 +39,12 @@ pub trait HostPlugin: Any + Send + Sync + 'static {
         Ok(())
     }
 
-    /// Called when configuring a specific component's linker.
+    /// Called when configuring a specific component or service's linker.
+    /// `item` is an enum — match on `WorkloadItem::Component` or `WorkloadItem::Service`.
     /// This is where you add your implementations to the linker.
-    async fn on_component_bind(
+    async fn on_workload_item_bind<'a>(
         &self,
-        component: &mut WorkloadComponent,
+        item: &mut WorkloadItem<'a>,
         interfaces: HashSet<WitInterface>,
     ) -> anyhow::Result<()> {
         Ok(())
@@ -61,7 +62,7 @@ pub trait HostPlugin: Any + Send + Sync + 'static {
     /// Called during unbinding or shutdown for cleanup.
     async fn on_workload_unbind(
         &self,
-        workload: &ResolvedWorkload,
+        workload_id: &str,
         interfaces: HashSet<WitInterface>,
     ) -> anyhow::Result<()> {
         Ok(())
@@ -80,7 +81,7 @@ Plugins follow a defined lifecycle within the host:
 
 1. **Registration**: Plugins are registered via `HostBuilder::with_plugin()`. Each plugin must have a unique ID.
 2. **Start**: When the host starts, all plugins' `start()` methods are called. If any plugin fails to start, the host startup fails.
-3. **Workload binding**: When a workload starts, the host calls `on_workload_bind()` and `on_component_bind()` for each plugin that provides interfaces the workload requires.
+3. **Workload binding**: When a workload starts, the host calls `on_workload_bind()` and `on_workload_item_bind()` for each plugin that provides interfaces the workload requires.
 4. **Resolution**: After successful binding, `on_workload_resolved()` is called.
 5. **Unbinding**: When workloads stop, `on_workload_unbind()` is called for cleanup.
 6. **Stop**: During host shutdown, all plugins' `stop()` methods are called (with a 3-second timeout per plugin).
@@ -92,7 +93,7 @@ The `HostPlugin` trait uses several types from the `wash_runtime` crate:
 - **`WitWorld`** - Contains `imports` and `exports` as `HashSet<WitInterface>`, representing the WIT interfaces the plugin provides.
 - **`WitInterface`** - Describes a specific interface with `namespace`, `package`, `interfaces` (a set of interface names), an optional `version`, and a `config` map.
 - **`UnresolvedWorkload`** - A workload that has been initialized but not yet bound to plugins.
-- **`WorkloadComponent`** - A component within a workload, providing access to its `wasmtime::component::Linker` for binding implementations.
+- **`WorkloadItem<'a>`** - An enum passed to `on_workload_item_bind`. Variants are `WorkloadItem::Component(&mut WorkloadComponent)` and `WorkloadItem::Service(&mut WorkloadService)`. Match on the variant to access the linker.
 - **`ResolvedWorkload`** - A fully bound workload ready for execution.
 
 ### Example: Custom logging plugin
@@ -103,7 +104,7 @@ Here's a simplified example of a custom plugin that implements logging:
 use std::collections::HashSet;
 use async_trait::async_trait;
 use wash_runtime::{
-    engine::workload::WorkloadComponent,
+    engine::workload::WorkloadItem,
     plugin::HostPlugin,
     wit::{WitInterface, WitWorld},
 };
@@ -142,13 +143,15 @@ impl HostPlugin for CustomLogger {
         Ok(())
     }
 
-    async fn on_component_bind(
+    async fn on_workload_item_bind<'a>(
         &self,
-        component: &mut WorkloadComponent,
+        item: &mut WorkloadItem<'a>,
         interfaces: HashSet<WitInterface>,
     ) -> anyhow::Result<()> {
-        // Add logging implementation to the component's linker
-        // component.linker_mut().func_wrap(...)?;
+        // Match on the variant to access the linker
+        // if let WorkloadItem::Component(component) = item {
+        //     component.linker_mut().func_wrap(...)?;
+        // }
         Ok(())
     }
 

--- a/versioned_docs/version-next/runtime/index.mdx
+++ b/versioned_docs/version-next/runtime/index.mdx
@@ -26,17 +26,21 @@ The runtime provides three primary abstractions:
 
 ## WASI Interface Support
 
-The crate includes two sets of built-in plugins, one working in-memory for development with `wash dev`, and the other backed by NATS for production deployment. Some plugins can be enabled or disabled via Cargo feature flags. Both sets of plugins support the following interfaces:
+The runtime provides WASI interface support through three distinct mechanisms:
 
-- `wasi:http`
+**Built-in via `wasmtime-wasi`** (always available, no registration needed): all [WASI P2 interfaces](https://docs.wasmtime.dev/api/wasmtime_wasi/p2/index.html#wasip2-interfaces) including `wasi:filesystem`, `wasi:clocks`, `wasi:random`, `wasi:io`, `wasi:sockets`, and the `wasi:cli` suite.
+
+**HTTP handler** (`HttpServer`, registered via `with_http_handler()`): `wasi:http` — HTTP client and server. Uses the `HostHandler` trait, not `HostPlugin`.
+
+**Host plugins** (registered via `with_plugin()`, feature-flag controlled): two sets are included — in-memory implementations for development with `wash dev`, and NATS-backed implementations for production. Supported interfaces:
+
 - `wasi:keyvalue`
 - `wasi:blobstore`
 - `wasi:config`
 - `wasi:logging`
-- `wasi:filesystem`
 - `wasmcloud:messaging`
 
-Hosts can be extended with additional host plugins at build-time.
+Hosts can be extended with additional custom plugins at build-time.
 
 ## Usage
 
@@ -46,9 +50,8 @@ use std::collections::HashMap;
 
 use wash_runtime::{
     engine::Engine,
-    host::{HostBuilder, HostApi},
-    plugin::wasi_http::HttpServer,
-    plugin::wasi_config::RuntimeConfig,
+    host::{HostBuilder, HostApi, http::{HttpServer, DevRouter}},
+    plugin::wasi_config::DynamicConfig,
     types::{WorkloadStartRequest, Workload},
 };
 
@@ -57,14 +60,14 @@ async fn main() -> anyhow::Result<()> {
     // Create a Wasmtime engine
     let engine = Engine::builder().build()?;
 
-    // Configure plugins
-    let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
-    let config_plugin = RuntimeConfig::default();
+    // Configure HTTP handler and plugins
+    let http_handler = HttpServer::new(DevRouter::default(), "127.0.0.1:8080".parse()?).await?;
+    let config_plugin = DynamicConfig::new(false);
 
     // Build and start the host
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_plugin(Arc::new(http_plugin))?
+        .with_http_handler(Arc::new(http_handler))
         .with_plugin(Arc::new(config_plugin))?
         .build()?;
 
@@ -72,6 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Start a workload
     let req = WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
         workload: Workload {
             namespace: "test".to_string(),
             name: "test-workload".to_string(),
@@ -93,10 +97,12 @@ async fn main() -> anyhow::Result<()> {
 
 The crate supports the following `cargo` features:
 
-- `wasi-http` (default): HTTP client and server support via `wasmtime-wasi-http`
 - `wasi-config` (default): Runtime configuration interface
 - `wasi-logging` (default): Logging interface
-- `wasi-blobstore` (default): Blob storage interface
+- `wasi-blobstore` (default): Blob/object storage interface
 - `wasi-keyvalue` (default): Key-value storage interface
+- `wasmcloud-postgres` (default): PostgreSQL-backed implementations for keyvalue and blobstore
+- `washlet` (default): Washlet support (depends on `oci`)
+- `wasi-webgpu`: WebGPU interface
 - `oci`: OCI registry integration for pulling components
 

--- a/versioned_docs/version-next/runtime/index.mdx
+++ b/versioned_docs/version-next/runtime/index.mdx
@@ -8,13 +8,11 @@ toc_max_heading_level: 2
 
 ### wasmCloud's runtime (`wash-runtime`) is a simple, flexible runtime environment for WebAssembly workloads.
 
-:::warning[Under construction]
-This section is under active development&mdash;please check back soon for a more complete reference.
-:::
+[`wash-runtime`](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime) is a Rust crate that includes Wasmtime as the underlying runtime engine, as well as the wasmCloud host, which serves as a runtime environment for WebAssembly components. A plugin system allows for extension of the host with new and custom capabilities.
 
-[`wash-runtime`](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime) is a Rust crate that includes Wasmtime as the underlying runtime engine, as well as the wasmCloud host, which serves as a runtime environment for WebAssembly components. A plugin system allows for extension of the host with new and custom capabilities. 
+The runtime provides easy-to-use abstractions over the low-level [Wasmtime API](https://wasmtime.dev/), as well as wasmCloud-specific APIs for managing workloads, handling NATS subscriptions, managing and utilizing host plugins, and more.
 
-The runtime provides easy-to-use abstractions over the low-level [Wasmtime API](https://wasmtime.dev/), as well as wasmCloud-specific APIs for managing workloads, handling NATS subscriptions, managing and utilizing host plugins, and more. 
+For a step-by-step guide to embedding the runtime, see [Building Custom Hosts](./building-custom-hosts.mdx). To extend a host with new capabilities, see [Creating Host Plugins](./creating-host-plugins.mdx).
 
 ## Architecture
 
@@ -28,7 +26,7 @@ The runtime provides three primary abstractions:
 
 ## WASI Interface Support
 
-The crate includes two sets of built-in plugins (toggleable at runtime via feature flags), one working in-memory for development with `wash dev`, and the other backed by NATS for production deployment. Both sets of plugins contain the following interfaces:
+The crate includes two sets of built-in plugins, one working in-memory for development with `wash dev`, and the other backed by NATS for production deployment. Some plugins can be enabled or disabled via Cargo feature flags. Both sets of plugins support the following interfaces:
 
 - `wasi:http`
 - `wasi:keyvalue`
@@ -48,13 +46,9 @@ use std::collections::HashMap;
 
 use wash_runtime::{
     engine::Engine,
-    host::{
-        HostBuilder, HostApi,
-        http::{HttpServer, DynamicRouter},
-    },
-    plugin::{
-        wasi_config::WasiConfig,
-    },
+    host::{HostBuilder, HostApi},
+    plugin::wasi_http::HttpServer,
+    plugin::wasi_config::RuntimeConfig,
     types::{WorkloadStartRequest, Workload},
 };
 
@@ -64,22 +58,20 @@ async fn main() -> anyhow::Result<()> {
     let engine = Engine::builder().build()?;
 
     // Configure plugins
-    let http_router = DynamicRouter::default();
-    let http_handler = HttpServer::new(http_router, "127.0.0.1:8080".parse()?);
-    let wasi_config_plugin = WasiConfig::default();
+    let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
+    let config_plugin = RuntimeConfig::default();
 
     // Build and start the host
     let host = HostBuilder::new()
         .with_engine(engine)
-        .with_http_handler(Arc::new(http_handler))
-        .with_plugin(Arc::new(wasi_config_plugin))?
+        .with_plugin(Arc::new(http_plugin))?
+        .with_plugin(Arc::new(config_plugin))?
         .build()?;
 
     let host = host.start().await?;
 
     // Start a workload
     let req = WorkloadStartRequest {
-        workload_id: uuid::Uuid::new_v4().to_string(), // or any id you like
         workload: Workload {
             namespace: "test".to_string(),
             name: "test-workload".to_string(),

--- a/versioned_docs/version-next/runtime/index.mdx
+++ b/versioned_docs/version-next/runtime/index.mdx
@@ -12,7 +12,7 @@ toc_max_heading_level: 2
 
 The runtime provides easy-to-use abstractions over the low-level [Wasmtime API](https://wasmtime.dev/), as well as wasmCloud-specific APIs for managing workloads, handling NATS subscriptions, managing and utilizing host plugins, and more.
 
-For a step-by-step guide to embedding the runtime, see [Building Custom Hosts](./building-custom-hosts.mdx). To extend a host with new capabilities, see [Creating Host Plugins](./creating-host-plugins.mdx).
+For a step-by-step guide to embedding the runtime, see [Building Custom Hosts](./building-custom-hosts.mdx). To run a cluster-connected host managed by the operator, see [Cluster Hosts (Washlet)](./washlet.mdx). To extend a host with new capabilities, see [Creating Host Plugins](./creating-host-plugins.mdx).
 
 ## Architecture
 

--- a/versioned_docs/version-next/runtime/washlet.mdx
+++ b/versioned_docs/version-next/runtime/washlet.mdx
@@ -1,0 +1,154 @@
+---
+title: "Cluster Hosts (Washlet)"
+sidebar_position: 4
+toc_max_heading_level: 2
+---
+
+### Run a wasmCloud host as a cluster node connected to the operator mesh.
+
+A **washlet** is a cluster-connected host: a `ClusterHost` from the `wash_runtime::washlet` module. Unlike a standalone `Host` (covered in [Building Custom Hosts](./building-custom-hosts.mdx)), a washlet connects to the wasmCloud operator mesh via NATS and receives workload commands from the scheduler. This is how the [Kubernetes Operator](../kubernetes-operator/index.mdx) deploys and manages workloads across a fleet of hosts.
+
+## Standalone host vs. cluster host
+
+| | Standalone `Host` | `ClusterHost` (washlet) |
+|---|---|---|
+| Managed by | Your application code | wasmCloud operator via NATS |
+| Workload commands | Programmatic API (`HostApi`) | NATS subjects |
+| Plugins | In-memory (dev) or custom | NATS-backed for production |
+| Entry point | `HostBuilder` | `ClusterHostBuilder` |
+| Use case | Embedding, custom integration | Operator-managed fleet |
+
+## Running with `wash host`
+
+The simplest way to run a washlet is the `wash host` CLI command. It connects to NATS and joins a host group, ready to receive workload commands from the operator.
+
+```shell
+wash host --host-group my-cluster --scheduler-nats-url nats://nats:4222
+```
+
+### `wash host` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host-group` | `default` | Host group label used for workload scheduling |
+| `--host-name` | (auto-generated) | Human-readable name for this host |
+| `--scheduler-nats-url` | `nats://localhost:4222` | NATS URL for the control plane (workload commands) |
+| `--data-nats-url` | `nats://localhost:4222` | NATS URL for the data plane (plugin backends) |
+| `--http-addr` | (disabled) | If set, enables the HTTP handler on this address |
+| `--postgres-url` | (disabled) | If set, enables PostgreSQL-backed keyvalue and blobstore |
+| `--wasi-webgpu` | false | Enable the WebGPU interface |
+| `--allow-insecure-registries` | false | Allow pulling from insecure OCI registries |
+| `--registry-pull-timeout` | `30s` | Timeout for OCI pulls |
+| `--scheduler-tls-ca` | — | TLS CA for scheduler NATS |
+| `--data-tls-ca` | — | TLS CA for data plane NATS |
+
+### Environment variables
+
+`WASH_POSTGRES_URL` can be used in place of `--postgres-url`.
+
+## Embedding programmatically
+
+Use `ClusterHostBuilder` to embed a washlet in your own application. The builder mirrors `HostBuilder` but adds NATS-specific configuration:
+
+```rust
+use std::sync::Arc;
+use wash_runtime::{
+    host::http::{HttpServer, DynamicRouter},
+    plugin::{
+        wasi_blobstore::NatsBlobstore,
+        wasi_config::DynamicConfig,
+        wasi_keyvalue::NatsKeyValue,
+        wasi_logging::TracingLogger,
+        wasmcloud_messaging::NatsMessaging,
+    },
+    washlet::{ClusterHostBuilder, run_cluster_host},
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    // Connect to NATS (scheduler and data plane can be separate connections)
+    let scheduler_nats = async_nats::connect("nats://localhost:4222").await?;
+    let data_nats = async_nats::connect("nats://localhost:4222").await?;
+
+    // Build the cluster host with NATS-backed plugins
+    let mut builder = ClusterHostBuilder::default()
+        .with_host_group("my-cluster")
+        .with_nats_client(Arc::new(scheduler_nats))
+        .with_plugin(Arc::new(DynamicConfig::new(true)))?   // true = NATS-backed
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(NatsBlobstore::new(&data_nats)))?
+        .with_plugin(Arc::new(NatsMessaging::new(data_nats.clone())))?
+        .with_plugin(Arc::new(NatsKeyValue::new(&data_nats)))?;
+
+    // Optionally enable HTTP
+    let http_router = DynamicRouter::default();
+    let http_server = HttpServer::new(http_router, "0.0.0.0:8080".parse()?).await?;
+    builder = builder.with_http_handler(Arc::new(http_server));
+
+    let cluster_host = builder.build()?;
+
+    // Start the host and run until shutdown
+    let shutdown = run_cluster_host(cluster_host).await?;
+
+    println!("Cluster host running. Press Ctrl+C to stop.");
+    tokio::signal::ctrl_c().await?;
+
+    // Graceful shutdown
+    shutdown.await?;
+    println!("Host stopped.");
+    Ok(())
+}
+```
+
+### `ClusterHostBuilder` methods
+
+| Method | Description |
+|--------|-------------|
+| `with_host_group(str)` | Host group label for workload scheduling |
+| `with_host_name(str)` | Human-readable name (auto-generated if not set) |
+| `with_nats_client(Arc<Client>)` | NATS client for the control plane |
+| `with_plugin(Arc<dyn HostPlugin>)` | Register a plugin (IDs must be unique) |
+| `with_http_handler(Arc<dyn HostHandler>)` | Register the HTTP handler |
+| `with_host_builder(HostBuilder)` | Provide a pre-configured `HostBuilder` for advanced use |
+| `with_artifact_cleaner(frequency, max_age)` | Clean up stale cached artifacts on a schedule |
+| `build()` | Construct the `ClusterHost` |
+
+### NATS-backed plugins
+
+In cluster mode, use NATS-backed plugin implementations so that workloads can access shared state across hosts:
+
+| Plugin | Type | Description |
+|--------|------|-------------|
+| Config | `DynamicConfig::new(true)` | NATS-backed runtime config (pass `false` for dev/in-memory) |
+| Logging | `TracingLogger::default()` | Structured logging via `tracing` |
+| Key-value | `NatsKeyValue::new(&nats_client)` | NATS-backed key-value store |
+| Blobstore | `NatsBlobstore::new(&nats_client)` | NATS-backed blob storage |
+| Messaging | `NatsMessaging::new(nats_client)` | NATS pub/sub messaging |
+
+## How the operator communicates with washlets
+
+The operator sends commands to washlets by publishing to NATS subjects:
+
+```
+runtime.host.<host_id>.workload.start
+runtime.host.<host_id>.workload.stop
+runtime.host.<host_id>.workload.status
+runtime.host.<host_id>.heartbeat
+```
+
+Washlets publish heartbeats to:
+
+```
+runtime.operator.heartbeat.<host_id>
+```
+
+Messages are JSON-encoded. You typically don't interact with these subjects directly—the operator handles scheduling and the washlet handles command processing.
+
+## Keep reading
+
+- [Building Custom Hosts](./building-custom-hosts.mdx) - Embed a standalone host without NATS
+- [Creating Host Plugins](./creating-host-plugins.mdx) - Build custom plugins for your host
+- [Kubernetes Operator](../kubernetes-operator/index.mdx) - Deploy washlets managed by the operator
+- [wash-runtime source code](https://github.com/wasmCloud/wash/tree/main/crates/wash-runtime/src/washlet) - `ClusterHost` implementation

--- a/versioned_docs/version-next/wash/commands.mdx
+++ b/versioned_docs/version-next/wash/commands.mdx
@@ -193,7 +193,7 @@ Check the health of your wash installation and environment.
 
 ## `wash host`
 
-Act as a wasmCloud host.
+Run a cluster-connected wasmCloud host ([washlet](../runtime/washlet.mdx)) that joins the operator mesh via NATS.
 
 **Usage:** `wash host [OPTIONS]`
 


### PR DESCRIPTION
Adds two pages, "Building Custom Hosts" and "Creating Host Plugins." Revisions and expansions throughout the Overview section.