### PR TITLE
feat(docs): add Language Support section

### DIFF
--- a/versioned_docs/version-next/installation.mdx
+++ b/versioned_docs/version-next/installation.mdx
@@ -117,6 +117,14 @@ Use Helm to install the wasmCloud operator from an OCI chart image, using the [v
 helm install wasmcloud --version v2-canary oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
+Verify the deployment:
+
+```shell
+kubectl get pods -l app.kubernetes.io/instance=wasmcloud -n default
+```
+
+Once all pods are running, you're ready to deploy a Wasm workload.
+
 ### Deploy a Wasm workload
 
 You can deploy a "Hello world" Wasm workload from a [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) with this `kubectl` command:
@@ -135,3 +143,29 @@ Hello from wasmCloud!
 ```
 
 For more information on each of these steps, see [Kubernetes Operator](./kubernetes-operator/index.mdx).
+
+## Clean up
+
+Delete the workload deployment:
+
+```shell
+kubectl delete workloaddeployment hello-world
+```
+
+Uninstall wasmCloud:
+
+```shell
+helm uninstall wasmcloud
+```
+
+Delete the local Kubernetes environment:
+
+```shell
+kind delete cluster
+```
+
+## Next steps
+
+* Read the [Overview](./overview/index.mdx) for an explanation of core concepts in wasmCloud.
+* Explore the [`wash/examples` directory](https://github.com/wasmCloud/wash/tree/main/examples) for more advanced Wasm component examples.
+* Check out the [Developer Guide](./wash/developer-guide/index.mdx) for information on building Wasm components.

--- a/versioned_docs/version-next/kubernetes-operator/index.mdx
+++ b/versioned_docs/version-next/kubernetes-operator/index.mdx
@@ -79,6 +79,14 @@ You can build your own hosts that provide extended capabilities via [host plugin
 You can find the full set of configurable values for the chart in [`wasmcloud/wash/charts/runtime-operator`](https://github.com/wasmCloud/wash/blob/main/charts/runtime-operator/values.yaml).
 :::
 
+Verify the deployment:
+
+```shell
+kubectl get pods -l app.kubernetes.io/instance=wasmcloud -n default
+```
+
+Once all pods are running, you're ready to deploy a Wasm workload.
+
 ### Deploy a Wasm component
 
 Use a [`WorkloadDeployment`](./crds.mdx#workloaddeployment) manifest to deploy a Wasm component workload to your cluster:
@@ -108,7 +116,7 @@ spec:
 
 This manifest deploys a simple "Hello world!" component that uses the `wasi:http` interface to the `default` hostgroup, making it available to call via HTTP from outside the cluster. 
 
-You can deploy from the wasmCloud-hosted manifest with this `kubectl` command:
+You can deploy from the [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) with this `kubectl` command:
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml

--- a/versioned_docs/version-next/wash/commands.mdx
+++ b/versioned_docs/version-next/wash/commands.mdx
@@ -11,7 +11,6 @@ sidebar_position: 1
 * [`wash completion`↴](#wash-completion) - Generate shell completions
 * [`wash config`↴](#wash-config) - View configuration for `wash`
 * [`wash dev`↴](#wash-dev) - Start a development server for a Wasm component
-* [`wash doctor`↴](#wash-doctor) - Check the health of your `wash` installation and environment
 * [`wash host`↴](#wash-host) - Act as a wasmCloud host
 * [`wash inspect`↴](#wash-inspect) - Inspect a Wasm component's embedded WIT
 * [`wash new`↴](#wash-new) - Create a new project from a Git repository
@@ -171,22 +170,6 @@ Start a development server for a Wasm component.
 * `-l`, `--log-level <LOG_LEVEL>` — Set the log level (trace, debug, info, warn, error) [default: `info`]
 * `--non-interactive` - Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
 * `-o`, `--output <OUTPUT_FORMAT>` — Specify output format (text or json) [default: `text`]
-* `--user-config <USER_CONFIG>` - Path to user configuration file.
-* `--verbose` - Enable verbose output
-* `-h`, `--help` - Print help
-
-## `wash doctor`
-
-Check the health of your wash installation and environment.
-
-**Usage:** `wash doctor [OPTIONS] <PROJECT_PATH>`
-* `<PROJECT_PATH>` - The path to the project directory [default: `.`]
-
-###### **Options:**
-
-* `-l`, `--log-level <LOG_LEVEL>` — Set the log level (`trace`, `debug`, `info`, `warn`, `error`) [default: `info`]
-* `--non-interactive` - Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
-* `-o`, `--output <OUTPUT_FORMAT>` — Specify output format (`text` or `json`) [default: `text`]
 * `--user-config <USER_CONFIG>` - Path to user configuration file.
 * `--verbose` - Enable verbose output
 * `-h`, `--help` - Print help

--- a/versioned_docs/version-next/wash/developer-guide/build-and-publish.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/build-and-publish.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Building and publishing components'
+title: 'Building and Publishing Components'
 date: 2025-09-15T11:00:00+00:00
 sidebar_position: 1
 draft: false

--- a/versioned_docs/version-next/wash/developer-guide/debugging-components.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/debugging-components.mdx
@@ -1,0 +1,301 @@
+---
+title: "Debugging Components"
+sidebar_position: 4
+---
+
+Debugging WebAssembly components is different from debugging native applications. You can't attach a traditional debugger to a Wasm component, and error messages from the build toolchain can be cryptic if you're not familiar with the Component Model. This page covers the diagnostic tools available to you, common errors you'll encounter, and how to resolve them.
+
+:::info[AI-assisted debugging]
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) users can install skills that give Claude specialized information on WebAssembly component debugging. See the [Useful WebAssembly Tools](./useful-webassembly-tools.mdx#claude-code-skills-for-webassembly-development) page for installation instructions for the `webassembly-component-development` and `wash` skills.
+
+:::
+
+## Diagnostic tools
+
+### `wash inspect`
+
+Use `wash inspect` to view a compiled component's WIT world — its imports and exports:
+
+```shell
+wash inspect my_component.wasm
+```
+
+This shows you exactly which interfaces the component declares. If a component isn't behaving as expected at runtime, you can use `wash inspect` to confirm whether the component was built with the right interfaces.
+
+You can also use `wasm-tools component wit` for the same purpose:
+
+```shell
+wasm-tools component wit ./build/output.wasm
+```
+
+### `wasm-tools validate`
+
+Validate that a `.wasm` binary is a well-formed component:
+
+```shell
+wasm-tools validate ./build/output.wasm
+```
+
+If this fails, the binary isn't a valid Component Model component. This can happen when your build produces a core Wasm module instead of a component (for example, using a wrong compiler target).
+
+### Verbose build output
+
+When `wash build` or `wash dev` fails with an unclear error, add `--verbose` or `--log-level debug` for detailed output:
+
+```shell
+wash build --verbose
+wash build --log-level debug
+```
+
+The verbose output shows each step of the build pipeline — WIT dependency fetching, binding generation, compilation, and component encoding — so you can identify where the failure occurs.
+
+## Common build errors
+
+### WIT dependency errors
+
+**Symptom:**
+
+```
+error: failed to read path for WIT [./wit]
+Caused by:
+    No such file or directory (os error 2)
+```
+
+**Cause:** Your WIT files aren't at the expected path.
+
+**Fix:** Ensure your `wit/` directory exists and contains a `world.wit` file. If you're starting a new project, run `wkg wit fetch` (or `wash wit fetch`) to populate `wit/deps/` with your interface dependencies.
+
+### Version mismatches
+
+**Symptom (Rust):**
+
+```
+failed to find export of interface `wasi:http/incoming-handler@0.2.2` function `handle`
+```
+
+**Symptom (TinyGo / TypeScript):** Build errors mentioning a WASI interface version that doesn't match your WIT world.
+
+**Cause:** The `wasi:http/incoming-handler` version in your `wit/world.wit` doesn't match the version your toolchain provides.
+
+**Fix:** Check the version alignment for your language:
+
+- **Rust:** Run `cargo tree -p wasip2` and match the WASI HTTP version in your WIT world. See the [Rust Language Guide: Version alignment](./language-support/rust/index.mdx#version-alignment) for the version table.
+- **TinyGo:** Ensure the `wasi:http` version in your WIT world matches what `wit-bindgen-go` and TinyGo expect. See the [Go Language Guide](./language-support/go/index.mdx).
+- **TypeScript:** Match the version to your `jco` / `componentize-js` version. See the [TypeScript Language Guide](./language-support/typescript/index.mdx).
+
+After updating your WIT world, re-fetch dependencies:
+
+```shell
+rm -rf wit/deps wkg.lock && wkg wit fetch
+```
+
+### Missing function exports
+
+**Symptom:**
+
+```
+error: failed to encode a component from module
+Caused by:
+    0: failed to decode world from module
+    1: module was not valid
+    2: failed to find export of interface `wasmcloud:wash/plugin@0.0.1` function `info`
+```
+
+**Cause:** Your code doesn't export all functions required by your WIT world.
+
+**Fix:** Check your WIT world definition and ensure your code implements every exported interface. For example, if your world exports `wasi:http/incoming-handler`, your code must provide a handler function for incoming HTTP requests.
+
+### Missing import resolution
+
+**Symptom:**
+
+```
+error: failed to encode a component from module
+Caused by:
+    0: failed to decode world from module
+    1: module was not valid
+    2: failed to resolve import `wasi:http/outgoing-handler@0.2.0::handle`
+    3: module requires an import interface named `wasi:http/outgoing-handler@0.2.0`
+```
+
+**Cause:** Your code uses an import that isn't declared in your WIT world, or bindings weren't generated correctly.
+
+**Fix:**
+1. Add the import to your `wit/world.wit`.
+2. Re-fetch dependencies: `wkg wit fetch`
+3. Regenerate bindings (for Go: `go generate ./...`; for TypeScript: `jco types wit/ -o generated/types`)
+4. Rebuild.
+
+### Target and toolchain errors
+
+**Symptom (Rust):**
+
+```
+error[E0463]: can't find crate for `std`
+```
+
+**Cause:** Building without the Wasm target.
+
+**Fix:** Install and specify the target:
+
+```shell
+rustup target add wasm32-wasip2
+cargo build --target wasm32-wasip2
+```
+
+**Symptom (TinyGo):** Build errors referencing WIT world or package names.
+
+**Cause:** The `-wit-package` or `-wit-world` flags in your Makefile don't match your `wit/world.wit`.
+
+**Fix:** Ensure the `-wit-world` flag in your Makefile matches the world name in `wit/world.wit`, and `-wit-package` points to the correct WIT directory. See the [Go Language Guide](./language-support/go/index.mdx) for the recommended Makefile setup.
+
+## Runtime errors
+
+### "Unknown import" errors
+
+**Symptom:**
+
+```
+component imports instance `wasi:http/types@0.2.0`, but a matching implementation was not found in the linker
+```
+
+**Cause:** The runtime doesn't implement an interface your component imports. This happens when you use an import that the host runtime hasn't wired up.
+
+**Fix:**
+- Check that the runtime you're using supports the interface. For `wash dev`, supported interfaces include `wasi:http`, `wasi:cli`, `wasi:io`, `wasi:clocks`, `wasi:random`, and others.
+- If you're using a draft or experimental interface (like `wasi:keyvalue` or `wasi:config`), ensure your runtime is configured to provide it.
+- Use `wash inspect` to verify which interfaces your component imports, then check your runtime's documentation for supported interfaces.
+
+### Threading errors
+
+**Symptom:**
+
+```
+operation not supported on this platform
+```
+
+Or panics related to `std::thread`, `std::sync::Mutex`, or similar concurrency primitives.
+
+**Cause:** WASI 0.2 does not support threads. Standard library threading APIs (`std::thread` in Rust, goroutines with shared state in Go) may compile but fail at runtime.
+
+**Fix:**
+- **Rust:** Use `wstd`'s async runtime instead of `std::thread`. Mainstream async runtimes (`tokio`, `async-std`) don't support WASI 0.2 yet.
+- **Go:** TinyGo supports goroutines via the `asyncify` scheduler, but some synchronization patterns may not work. Test concurrent code in the Wasm target specifically.
+- **TypeScript:** JavaScript is single-threaded by nature, so this is less likely to be an issue.
+
+### Unexpected behavior from stdlib modules
+
+Some standard library modules compile to the `wasip2` target but don't behave as expected:
+
+- **`net/http` in Go** — does not work directly. Use `wasihttp.HandleFunc` and `wasihttp.Transport` from `go.wasmcloud.dev/component`.
+- **`os` in Go** — limited; filesystem and process operations require WASI filesystem configuration.
+- **`std::net` and `std::fs` in Rust** — require OS-level syscalls not available in the Wasm sandbox. Use `wstd::net` and WASI filesystem interfaces.
+- **Node.js APIs in TypeScript** — `fs`, `path`, `os`, `child_process`, `Buffer`, `process.env`, `require()` are not available. Use Web Standards APIs and WASI interfaces instead.
+
+For a complete list of what works and what doesn't, see the compatibility sections of each language guide:
+- [Rust: Crate compatibility](./language-support/rust/index.mdx#crate-compatibility)
+- [Go: Standard library compatibility](./language-support/go/index.mdx#standard-library-compatibility)
+- [TypeScript: Library compatibility](./language-support/typescript/index.mdx#library-compatibility)
+
+## Language-specific debugging
+
+### Rust
+
+**Check compilation before building:**
+
+```shell
+cargo check --target wasm32-wasip2
+```
+
+This is faster than a full build and catches most type errors and missing imports.
+
+**Type conflicts with `wit-bindgen`:**
+
+If you use both `wstd` and `wit-bindgen` for custom WASI interfaces, you may get type conflicts when an interface shares types with `wasi:io` or other standard interfaces. Use `wit-bindgen`'s `with` option to point to `wasip2`'s types:
+
+```rust
+wit_bindgen::generate!({
+    world: "my-world",
+    path: "wit",
+    with: {
+        "wasi:io/streams@0.2.9": wasip2::wasi::io::streams,
+        "wasi:io/poll@0.2.9": wasip2::wasi::io::poll,
+    },
+    generate_all,
+});
+```
+
+See the [Rust Language Guide: Handling type conflicts](./language-support/rust/index.mdx#handling-type-conflicts) for details.
+
+### Go (TinyGo)
+
+**World not found — defaults to CLI.** If TinyGo can't find the specified world, it silently targets `wasi:cli/run` instead of your intended world. Use `wash inspect` to check:
+
+```shell
+wash inspect ./build/output.wasm
+```
+
+If you see `wasi:cli` imports and `export wasi:cli/run@0.2.0` instead of your expected world, verify:
+1. The `-wit-world` flag in your Makefile matches the world name in `wit/world.wit`.
+2. The `-wit-package` flag points to the correct WIT directory (typically `./wit`).
+3. Your WIT files are at the expected path.
+
+**Common TinyGo build errors** are cataloged in the [FAQ: Common issues with TinyGo builds](../faq.mdx#common-issues-with-tinygo-builds).
+
+### TypeScript
+
+**`@ts-expect-error` for WASI imports.** When importing WASI interfaces directly (rather than using the fetch event pattern), TypeScript may not resolve the import specifiers. Use `@ts-expect-error` or configure `paths` in your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "wasi:http/types@0.2.3": ["./generated/types/interfaces/wasi-http-types.d.ts"]
+    }
+  }
+}
+```
+
+**`bigint` pitfalls.** WASI interfaces use 64-bit integers, which map to JavaScript's `bigint` type. Watch for implicit `number`-to-`bigint` conversion issues and use `BigInt()` explicitly when needed.
+
+**StarlingMonkey limitations.** TypeScript components run inside the [StarlingMonkey](https://github.com/bytecodealliance/StarlingMonkey) engine (SpiderMonkey compiled to Wasm). Not all JavaScript APIs are available — notably, WebSocket support is missing, `require()` doesn't work (ESM only), and `Buffer` should be replaced with `Uint8Array`. See the [TypeScript Language Guide: Library compatibility](./language-support/typescript/index.mdx#library-compatibility) for details.
+
+## Logging
+
+Adding log output to your component is one of the most effective debugging techniques.
+
+### Rust
+
+Use the [`wasi:logging`](https://github.com/WebAssembly/wasi-logging) interface. The `wstd` crate doesn't include logging directly, but you can add it via `wit-bindgen`. For simple debugging, `eprintln!` writes to stderr and is visible in `wash dev` output.
+
+### Go (TinyGo)
+
+Use the `wasilog` package from the wasmCloud Go component library:
+
+```go
+import "go.wasmcloud.dev/component/log/wasilog"
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    logger := wasilog.ContextLogger("handler")
+    logger.Info("request received", "path", r.URL.Path)
+}
+```
+
+### TypeScript
+
+Use `console.log` and `console.error` — StarlingMonkey routes these to WASI stderr:
+
+```typescript
+console.log('Request received:', req.url);
+console.error('Something went wrong:', error);
+```
+
+## Further reading
+
+- [FAQ](../faq.mdx) — common errors and troubleshooting, including a detailed [TinyGo error catalog](../faq.mdx#common-issues-with-tinygo-builds)
+- [Rust Language Guide](./language-support/rust/index.mdx) — crate compatibility, version alignment, type conflict resolution
+- [Go (TinyGo) Language Guide](./language-support/go/index.mdx) — stdlib compatibility, `wasm-tools` pinning, project configuration
+- [TypeScript Language Guide](./language-support/typescript/index.mdx) — library compatibility, StarlingMonkey APIs, build pipeline
+- [Useful WebAssembly Tools](./useful-webassembly-tools.mdx) — `wasm-tools`, Wasmtime, WASI Virt, and other ecosystem tools
+- [Command Reference](../commands.mdx) — full `wash` CLI reference including `--verbose` and `--log-level` flags

--- a/versioned_docs/version-next/wash/developer-guide/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/index.mdx
@@ -25,7 +25,6 @@ This guide requires Wasm Shell (`wash`) and the language toolchain for your lang
 To get started:
 
 * [Install Wasm Shell (`wash`)](../index.mdx).
-* Run `wash doctor` to check your system for development dependencies.
 
 ## Create a new component project
 
@@ -65,19 +64,19 @@ This command...
 </TabItem>
 
 <TabItem value="typescript" label="TypeScript">
-Let's create a component that accepts an HTTP request and responds with "Hello from TypeScript!"  
+Let's create a component that accepts an HTTP request and responds with "Hello from TypeScript!"
 
-Use `wash new` to create a new component project from a template: 
+Use `wash new` to create a new component project from a template:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name hello --subfolder examples/components/http-hello-world
+wash new https://github.com/wasmCloud/typescript.git --name hello --subfolder templates/http-hello-world-hono --git-ref v2
 ```
 
 This command...
 
 * Creates a new project named `hello`...
 * Based on a template found in the `wasmCloud/typescript` Git repository...
-* In the subfolder `examples/components/http-hello-world`
+* In the subfolder `templates/http-hello-world-hono` on the `v2` branch
 </TabItem>
 
 <TabItem value="other" label="Other">
@@ -250,100 +249,75 @@ func main() {}
 * **In the `handleRequest` function**, we respond to an HTTP request by printing `Hello from Go!`
 * **The main function is empty**, since the component doesn't run like a CLI, but instead runs the `handleRequest` function when triggered by an HTTP request.
 
-## Add a configuration file
+## Add a configuration file and Makefile
 
-To start a developer loop or build a component binary from a Go project, `wash` requires the project's WIT world to be specified in a [configuration file](../config.mdx) called `config.json` at `/.wash`. (When you try to build without a config file, `wash` will prompt you, but we'll go ahead and get it out of the way.)
+Go projects use a `Makefile` to wrap the build steps and a [configuration file](../config.mdx) at `.wash/config.yaml` to tell `wash` how to invoke the build.
 
 Create the config file:
 
 ```shell
-mkdir .wash && touch ./.wash/config.json
+mkdir .wash && touch ./.wash/config.yaml
 ```
 
-Add the contents below to `config.json`, specifying your WIT world as `hello`:
+Add the contents below to `config.yaml`:
 
-```json
-{
-  "build": {
-    "tinygo": {
-      "target": "wasip2",
-      "build_flags": [],
-      "disable_go_generate": false,
-      "scheduler": "asyncify",
-      "gc": "conservative",
-      "opt": "z",
-      "panic": "print",
-      "tags": [],
-      "no_debug": true,
-      "wit_world": "hello"
-    },
-    "component_path": "build/output.wasm"
-  },
-  "wit": {
-    "registries": [],
-    "skip_fetch": true,
-    "wit_dir": null,
-    "sources": {}
-  }
-}
+```yaml
+dev:
+  command: make build
+
+build:
+  command: make bindgen build
 ```
+
+Create a `Makefile` at the project root:
+
+```makefile
+all: build
+
+.PHONY: build
+build:
+	tinygo build -target wasip2 -wit-package ./wit -wit-world hello -o hello.wasm ./
+
+.PHONY: bindgen
+bindgen:
+	go generate ./...
+```
+
+For more on the Makefile-based build workflow, see the [Go Language Guide](./language-support/go/index.mdx).
 
 </TabItem>
 
 <TabItem value="typescript" label="TypeScript">
-The file `http-hello-world.ts` will include imports and a `handle` function exported under `incomingHandler`. Let's walk through these pieces in depth.
+The file `src/component.ts` uses [Hono](https://hono.dev/), a lightweight web framework built on Web Standards. Let's walk through the pieces in depth.
 
 ```typescript
-import {
-  IncomingRequest,
-  ResponseOutparam,
-  OutgoingBody,
-  OutgoingResponse,
-  Fields,
-} from 'wasi:http/types@0.2.0';
+import { Hono } from 'hono';
+import { fire } from '@bytecodealliance/jco-std/wasi/0.2.6/http/adapters/hono/server';
 ```
 
-The import section of this file imports our generated types (from `jco`) for the WASI HTTP interface.
+The import section brings in the Hono framework and `fire` from [`@bytecodealliance/jco-std`](https://www.npmjs.com/package/@bytecodealliance/jco-std), a Bytecode Alliance library that adapts Hono to the WASI HTTP incoming handler interface.
 
 ```typescript
-// Implementation of wasi-http incoming-handler
-//
-// NOTE: To understand the types involved, take a look at wit/deps/http/types.wit
-function handle(req: IncomingRequest, resp: ResponseOutparam) {
-  // Start building an outgoing response
-  const outgoingResponse = new OutgoingResponse(new Fields());
+const app = new Hono();
 
-  // Access the outgoing response body
-  let outgoingBody = outgoingResponse.body();
-  {
-    // Create a stream for the response body
-    let outputStream = outgoingBody.write();
-    // Write hello world to the response stream
-    outputStream.blockingWriteAndFlush(
-      new Uint8Array(new TextEncoder().encode('Hello from Typescript!\n')),
-    );
-    // @ts-ignore: This is required in order to dispose the stream before we return
-    outputStream[Symbol.dispose]();
-  }
+app.get('/', (c) => {
+  return c.text('Hello from TypeScript!\n');
+});
 
-  // Set the status code for the response
-  outgoingResponse.setStatusCode(200);
-  // Finish the response body
-  OutgoingBody.finish(outgoingBody, undefined);
-  // Set the created response
-  ResponseOutparam.set(resp, { tag: 'ok', val: outgoingResponse });
-}
+app.notFound((c) => {
+  return c.text('Not found\n', 404);
+});
+
+fire(app);
 ```
 
-The core logic is contained within the `handle` function, where the component receives the HTTP request, creates an `OutgoingResponse` and writes that response back out to the requesting HTTP client (such as a `curl` command or a web browser).
+We create a Hono app with a route for `/` and a fallback for unmatched routes. The `fire()` function wires the Hono app to the Service Worker `fetch` event listener, which StarlingMonkey (the embedded JavaScript engine) maps to `wasi:http/incoming-handler`. When a request arrives, Hono routes it and returns the appropriate response.
 
 ```typescript
-export const incomingHandler = {
-  handle,
-};
+export { incomingHandler } from '@bytecodealliance/jco-std/wasi/0.2.6/http/adapters/hono/server';
 ```
 
-Lastly, this export statement includes the `handle` function under the `incomingHandler` interface, which matches the `wasi:http/incoming-handler` interface declared in the application's [WIT file](https://github.com/wasmCloud/typescript/blob/main/examples/components/http-hello-world/wit/world.wit).
+This re-export provides the `incomingHandler` that the Wasm component must export to satisfy the `wasi:http/incoming-handler` interface declared in the WIT world. The `jco-std` adapter handles all the conversion between WASI HTTP types and the Web Standard `Request`/`Response` objects that Hono uses.
 
 </TabItem>
 
@@ -369,15 +343,6 @@ We're looking to add more examples in languages that support Wasm components. If
 </TabItem>
 </Tabs>
 
-:::info[Something's missing]
-Note what's _not_ included in this code: 
-
-* The code is _not_ tightly coupled to any particular HTTP server. It returns an abstraction of an HTTP response. 
-* You don't see the port number or server configuration options anywhere in the code. 
-
-This style of **interface driven development** enables you to write application logic in the language of your choice without having to worry about the non-functional requirements of your application. 
-:::
-
 ## Start a development loop
 
 Now we'll start a development loop that runs the component, watches for modifications to the code, and refreshes when we make changes. 
@@ -396,11 +361,28 @@ Now we can send a request to `localhost:8000` with `curl` (in a new tab), or by 
 curl localhost:8000
 ```
 
+<Tabs groupId="lang" queryString>
+  <TabItem value="rust" label="Rust" default>
+
 You should see:
 
 ```text
-Hello from <your language>
+Hello from wasmCloud!
 ```
+
+  </TabItem>
+  <TabItem value="tinygo" label="TinyGo">
+```text
+Hello from Go!
+```
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+```text
+Hello from TypeScript!
+```
+  </TabItem>
+</Tabs>
+
 
 You can stop the development loop with CTRL+C.
 

--- a/versioned_docs/version-next/wash/developer-guide/language-support/go/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/go/index.mdx
@@ -1,0 +1,430 @@
+---
+title: "Go (TinyGo) Language Guide"
+sidebar_position: 2
+---
+
+wasmCloud uses [TinyGo](https://tinygo.org/) to build WebAssembly components from Go source code. TinyGo compiles a large subset of Go to the `wasip2` target, producing Wasm components that work with the Component Model and WASI 0.2.
+
+This guide covers the toolchain, the wasmCloud Go component library, bindings generation, and practical guidance for building Go components on wasmCloud.
+
+If you're looking for a quick walkthrough of creating, building, and running a Go component, see the [Developer Guide](../../index.mdx?lang=tinygo).
+
+## Why TinyGo?
+
+The standard Go compiler does not yet support the WebAssembly Component Model or WASI P2. TinyGo targets `wasip2` directly using LLVM, producing much smaller Wasm binaries. TinyGo supports a large subset of Go — including goroutines, interfaces, closures, and most of the standard library — making it the current path for Go developers building Wasm components.
+
+Since the TinyGo project moves quickly, we recommend using the latest version.
+
+## Toolchain overview
+
+### Build pipeline
+
+![Go build pipeline](../../../images/build-pipeline-go.svg)
+
+Building a Go component has two steps: generating Go bindings from WIT interfaces, then compiling to a Wasm component with TinyGo. We recommend using a `Makefile` to wrap these steps. When you run `wash build`, it executes the build command from your `.wash/config.yaml`, which calls the Makefile targets.
+
+### TinyGo
+
+[TinyGo](https://tinygo.org/) is a Go compiler for microcontrollers, WebAssembly, and other constrained environments. For wasmCloud, the key feature is native Component Model support via the `-target wasip2` flag.
+
+Install TinyGo following the [official installation guide](https://tinygo.org/getting-started/install/).
+
+Key compiler flags for Wasm components:
+
+| Flag | Value | Description |
+|---|---|---|
+| `-target` | `wasip2` | Compile to a WASI P2 component |
+| `-wit-package` | `./wit` | Path to the WIT package directory |
+| `-wit-world` | `<world>` | Name of the WIT world to target |
+| `-o` | `<name>.wasm` | Output file path |
+
+Optional optimization flags:
+
+| Flag | Value | Description |
+|---|---|---|
+| `-scheduler` | `asyncify` | Enable goroutine support via Binaryen's Asyncify |
+| `-gc` | `conservative` | Mark/sweep garbage collector suitable for Wasm |
+| `-opt` | `z` | Aggressive code size optimization |
+| `-no-debug` | | Remove debug info (reduces binary size significantly) |
+
+### `wit-bindgen-go`
+
+[`wit-bindgen-go`](https://github.com/bytecodealliance/go-modules) generates Go code from WIT interface definitions. It produces typed Go packages that map to your component's imports and exports.
+
+`wit-bindgen-go` is invoked via a `//go:generate` directive at the top of your `main.go`:
+
+```go
+//go:generate go tool wit-bindgen-go generate --world wasmcloud:hello/hello --out gen ./wit
+```
+
+This reads the WIT files in `./wit`, generates Go packages for the `hello` world in the `wasmcloud:hello` package, and writes them to the `gen/` directory. The `--world` flag uses the fully-qualified world name in the format `<package>/<world>`. The generated packages depend on the [`cm`](https://pkg.go.dev/go.bytecodealliance.org/cm) package for Component Model types like `option`, `result`, `list`, and `resource`.
+
+Declare `wit-bindgen-go` as a tool dependency in your `go.mod` using the Go 1.24+ `tool` directive:
+
+```go title="go.mod"
+tool go.bytecodealliance.org/cmd/wit-bindgen-go
+```
+
+Then run `go mod tidy` to resolve the dependency.
+
+## Handling HTTP requests
+
+The [`go.wasmcloud.dev/component`](https://github.com/wasmCloud/go) package provides idiomatic Go adapters for WASI interfaces. The `wasihttp` package bridges Go's standard `net/http` library with WASI HTTP, so you can write familiar Go HTTP handlers.
+
+### Basic HTTP server
+
+```go
+//go:generate go tool wit-bindgen-go generate --world wasmcloud:hello/hello --out gen ./wit
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"go.wasmcloud.dev/component/net/wasihttp"
+)
+
+func init() {
+	wasihttp.HandleFunc(handleRequest)
+}
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello from Go!\n")
+}
+
+func main() {}
+```
+
+Key points:
+
+- **`wasihttp.HandleFunc`** accepts a standard `http.HandlerFunc` and registers it as the WASI HTTP incoming handler. All conversion between WASI HTTP types and Go's `net/http` types happens behind the scenes.
+- **Handlers are registered in `init()`**, not `main()`. The component doesn't run like a CLI — it responds to incoming HTTP requests.
+- **`main()` is empty.** This is required but does nothing for component-based programs.
+- You can use Go's standard `http.ResponseWriter` and `*http.Request` types exactly as you would in a normal Go HTTP server.
+
+### Routing
+
+`wasihttp.Handle` accepts any `http.Handler`, so Go's standard `http.ServeMux`, third-party routers, and middleware chains all work.
+
+With Go's standard library:
+
+```go
+func init() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleHome)
+	mux.HandleFunc("/api/data", handleData)
+	wasihttp.Handle(mux)
+}
+```
+
+With [`httprouter`](https://github.com/julienschmidt/httprouter) (used in the [wasmCloud Go example](https://github.com/wasmCloud/wash/tree/main/examples/go-hello-world)):
+
+```go
+import "github.com/julienschmidt/httprouter"
+
+func init() {
+	router := httprouter.New()
+	router.HandlerFunc(http.MethodGet, "/", indexHandler)
+	router.HandlerFunc(http.MethodGet, "/headers", headersHandler)
+	router.HandlerFunc(http.MethodPost, "/post", postHandler)
+	wasihttp.Handle(router)
+}
+```
+
+### Outgoing HTTP requests
+
+The `wasihttp` package provides a `Transport` that implements `http.RoundTripper`, enabling outgoing HTTP requests via WASI:
+
+```go
+import (
+	"io"
+	"net/http"
+
+	"go.wasmcloud.dev/component/net/wasihttp"
+)
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	client := http.Client{Transport: &wasihttp.Transport{}}
+	resp, err := client.Get("https://api.example.com/data")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+	io.Copy(w, resp.Body)
+}
+```
+
+To make outgoing requests, your WIT world must import `wasi:http/outgoing-handler`.
+
+### Logging
+
+The `wasilog` package provides structured logging backed by WASI interfaces:
+
+```go
+import "go.wasmcloud.dev/component/log/wasilog"
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	logger := wasilog.ContextLogger("handler")
+	logger.Info("request received", "path", r.URL.Path, "method", r.Method)
+	fmt.Fprintf(w, "Hello from Go!\n")
+}
+```
+
+## Adding custom WASI interfaces
+
+The `wasmcloud:component-go/imports` include pulls in standard imports for the wasmCloud Go component library (logging, config, etc.). For additional interfaces like `wasi:keyvalue`, `wasi:config`, or custom interfaces, add them to your WIT world and regenerate bindings.
+
+### Example: Adding `wasi:keyvalue`
+
+**1. Declare the imports in your WIT world:**
+
+```wit title="wit/world.wit"
+package wasmcloud:hello;
+
+world hello {
+    include wasmcloud:component-go/imports@0.1.0;
+    import wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/atomics@0.2.0-draft;
+    export wasi:http/incoming-handler@0.2.0;
+}
+```
+
+**2. Fetch dependencies and regenerate bindings:**
+
+```shell
+wkg wit fetch
+go generate ./...
+```
+
+This downloads the WIT definitions for `wasi:keyvalue` into `wit/deps/` and generates Go packages in `gen/`.
+
+**3. Use the generated bindings:**
+
+```go
+import (
+	"fmt"
+	"net/http"
+
+	"go.wasmcloud.dev/component/net/wasihttp"
+	"<your-module>/gen/wasi/keyvalue/store"
+	"<your-module>/gen/wasi/keyvalue/atomics"
+)
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	bucket := store.Open("")
+	count := atomics.Increment(bucket, "visitor-count", 1)
+	fmt.Fprintf(w, "Visit count: %d\n", count)
+}
+```
+
+Generated bindings follow Go naming conventions — WIT function names are converted to PascalCase. The generated packages are in `gen/` under the WIT namespace path (e.g., `gen/wasi/keyvalue/store`).
+
+Replace `<your-module>` with your Go module path from `go.mod`.
+
+### WIT dependency management with `wkg`
+
+[`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools) is the WebAssembly package manager. It reads your WIT world and fetches the interface definitions your component needs:
+
+```shell
+wkg wit fetch
+```
+
+This populates `wit/deps/` with downloaded interface definitions and creates a `wkg.lock` file. You should:
+
+- Add `wit/deps/` to `.gitignore` — these are fetched dependencies
+- Commit `wkg.lock` — this ensures reproducible builds
+
+When you run `wash build`, it calls `wkg wit fetch` automatically, so you typically don't need to run it manually.
+
+For a detailed explanation of `wkg` and auto-resolved namespaces, see the [Rust Language Guide's WIT dependency management section](../rust/index.mdx#wit-dependency-management-with-wkg).
+
+## Project structure
+
+A typical Go component project:
+
+```
+my-component/
+├── main.go              # Application code
+├── Makefile             # Build recipes (bindgen, build)
+├── go.mod               # Go module definition
+├── go.sum               # Go dependency checksums
+├── gen/                 # Generated bindings (gitignored)
+├── wit/
+│   ├── world.wit        # WIT world definition
+│   └── deps/            # Fetched WIT dependencies (gitignored)
+├── wkg.lock             # WIT dependency lock file
+└── .wash/
+    └── config.yaml      # wash project configuration
+```
+
+### `Makefile`
+
+A `Makefile` wraps the two-step build process (bindings generation + TinyGo compilation) so that `wash build` and `wash dev` can invoke them with simple commands:
+
+```makefile title="Makefile"
+all: build
+
+.PHONY: build
+build:
+	tinygo build -target wasip2 -wit-package ./wit -wit-world hello -o my-component.wasm ./
+
+.PHONY: bindgen
+bindgen:
+	go generate ./...
+```
+
+The `build` target invokes TinyGo with:
+- `-target wasip2` — compile to a WASI P2 component
+- `-wit-package ./wit` — path to the WIT package directory
+- `-wit-world hello` — name of the WIT world to target
+- `-o my-component.wasm` — output file path
+
+The `bindgen` target runs `go generate`, which invokes `wit-bindgen-go` via the directive in `main.go`.
+
+### `go.mod`
+
+```go title="go.mod"
+module github.com/myorg/my-component
+
+go 1.24
+
+require (
+	go.bytecodealliance.org/cm v0.3.0
+	go.wasmcloud.dev/component v0.0.10
+)
+
+tool go.bytecodealliance.org/cmd/wit-bindgen-go
+```
+
+The `tool` directive (Go 1.24+) declares `wit-bindgen-go` as a build tool dependency. This replaces the older `tools.go` file pattern.
+
+You should add both `gen/` and `wit/deps/` to your `.gitignore` — these are generated or fetched during the build and should not be committed.
+
+### WIT world
+
+```wit title="wit/world.wit"
+package wasmcloud:hello;
+
+world hello {
+    include wasmcloud:component-go/imports@0.1.0;
+    export wasi:http/incoming-handler@0.2.0;
+}
+```
+
+The `include wasmcloud:component-go/imports` line pulls in standard imports used by the wasmCloud Go component library (logging, config, etc.). You can also declare imports individually if you prefer.
+
+:::info[WASI HTTP version]
+The `wasi:http/incoming-handler` version in your WIT world (here `@0.2.0`) must match the version supported by your TinyGo and `wit-bindgen-go` toolchain. The version shown here matches the wasmCloud Go project template. If you see build errors about missing exports, check that the version in your `world.wit` aligns with your installed toolchain versions.
+:::
+
+### `.wash/config.yaml`
+
+The [project configuration file](../../../config.mdx) at `.wash/config.yaml` tells `wash` how to build the component:
+
+```yaml title=".wash/config.yaml"
+build:
+  command: make bindgen build
+```
+
+The `build.command` is a shell command that `wash build` executes. Here it runs the Makefile's `bindgen` and `build` targets in sequence — first generating Go bindings from WIT, then compiling with TinyGo.
+
+You can also specify a separate command for `wash dev` that skips binding generation for faster iteration:
+
+```yaml title=".wash/config.yaml"
+dev:
+  command: make build
+
+build:
+  command: make bindgen build
+```
+
+With this configuration, `wash dev` runs only `make build` (recompiling Go code), while `wash build` runs `make bindgen build` (regenerating bindings and recompiling). This speeds up the development loop when you're only changing Go code, not WIT interfaces.
+
+For a full reference of configuration options, see the [Configuration](../../../config.mdx) page.
+
+## Standard library compatibility
+
+TinyGo supports most of the Go standard library, but some packages have limitations in the `wasip2` target.
+
+### What works
+
+- **`fmt`** — formatted I/O (adds ~100 KB to binary size)
+- **`io`** — I/O primitives
+- **`strings`**, **`bytes`** — string and byte manipulation
+- **`strconv`** — string conversions
+- **`encoding/json`** — JSON encoding/decoding (may have edge-case panics — test thoroughly)
+- **`encoding/base64`** — base64 encoding
+- **`math`** — mathematical functions
+- **`sort`** — sorting
+- **`sync`** — synchronization primitives
+- **`time`** — time operations
+- **`net/http`** — via `wasihttp` adapter (not directly — see below)
+
+### What does not work
+
+- **`net/http` directly** — Go's standard HTTP server/client does not work in `wasip2`. Use `wasihttp.HandleFunc` for incoming requests and `wasihttp.Transport` for outgoing requests.
+- **`os`** — limited; filesystem and process operations are not available unless WASI filesystem is configured
+- **`net`** — raw networking is not available; use WASI HTTP interfaces
+- **Packages requiring cgo** — TinyGo does not support cgo in the `wasip2` target
+- **`plugin`**, **`net/smtp`**, **`debug/buildinfo`** — cannot be imported
+
+### Practical guidance
+
+- Use the `wasihttp` package instead of `net/http` directly — it provides `http.Handler` and `http.RoundTripper` implementations backed by WASI
+- Prefer pure Go libraries; anything requiring cgo will not compile
+- Test your dependencies against the `wasip2` target early — some packages compile but have runtime issues
+- Be mindful of binary size: packages like `fmt` add meaningful overhead to Wasm components
+
+## Building and running
+
+### Create a new project
+
+Use `wash new` to scaffold a Go component project:
+
+```shell
+wash new https://github.com/wasmCloud/wash.git --name hello --subfolder examples/go-hello-world
+```
+
+### Development loop
+
+Start a development loop that builds, runs, and watches for changes:
+
+```shell
+wash dev
+```
+
+Send a request to test:
+
+```shell
+curl localhost:8000
+```
+
+### Build a component
+
+Compile your project to a `.wasm` binary:
+
+```shell
+wash build
+```
+
+`wash build` executes the `build.command` from your `.wash/config.yaml`. With the recommended Makefile setup, this runs `make bindgen build` — generating bindings from WIT, then compiling with TinyGo. The compiled component is output to the path specified by `-o` in your Makefile (e.g., `my-component.wasm`).
+
+You can also run the Makefile targets directly:
+
+```shell
+make bindgen  # Regenerate Go bindings from WIT
+make build    # Compile to .wasm with TinyGo
+```
+
+## Further reading
+
+- [Developer Guide](../../index.mdx?lang=tinygo) — quickstart tutorial for creating, building, and running a Go component
+- [wasmCloud Go examples](https://github.com/wasmCloud/wash/tree/main/examples/go-hello-world) — reference example project in the `wash` repository
+- [wasmCloud Go component library](https://github.com/wasmCloud/go) — `wasihttp`, `wasilog`, and other Go adapters for WASI interfaces
+- [TinyGo documentation](https://tinygo.org/docs/) — compiler reference and standard library support
+- [TinyGo package support](https://tinygo.org/docs/reference/lang-support/stdlib/) — standard library compatibility matrix
+- [`wit-bindgen-go`](https://github.com/bytecodealliance/go-modules) — Bytecode Alliance Go modules for WIT bindings
+- [Component Model: Go](https://component-model.bytecodealliance.org/language-support/go.html) — Component Model documentation for Go
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/versioned_docs/version-next/wash/developer-guide/language-support/go/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/go/index.mdx
@@ -225,10 +225,10 @@ Replace `<your-module>` with your Go module path from `go.mod`.
 
 ### WIT dependency management with `wkg`
 
-[`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools) is the WebAssembly package manager. It reads your WIT world and fetches the interface definitions your component needs:
+`wash` bundles the [`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools) WebAssembly package manager, so you can fetch WIT dependencies directly:
 
 ```shell
-wkg wit fetch
+wash wit fetch
 ```
 
 This populates `wit/deps/` with downloaded interface definitions and creates a `wkg.lock` file. You should:
@@ -236,7 +236,7 @@ This populates `wit/deps/` with downloaded interface definitions and creates a `
 - Add `wit/deps/` to `.gitignore` — these are fetched dependencies
 - Commit `wkg.lock` — this ensures reproducible builds
 
-When you run `wash build`, it calls `wkg wit fetch` automatically, so you typically don't need to run it manually.
+When you run `wash build`, it calls `wash wit fetch` automatically, so you typically don't need to run it manually.
 
 For a detailed explanation of `wkg` and auto-resolved namespaces, see the [Rust Language Guide's WIT dependency management section](../rust/index.mdx#wit-dependency-management-with-wkg).
 

--- a/versioned_docs/version-next/wash/developer-guide/language-support/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/index.mdx
@@ -18,7 +18,8 @@ This chart summarizes the current state of language support for WebAssembly comp
 | **TypeScript / JavaScript** | `jco` + `componentize-js` | Stable | P2 |
 | **C# / .NET** | `componentize-dotnet` | Stable | P2 |
 | **Python** | `componentize-py` | Stable | P2 |
-| **C / C++** | `wasi-sdk` | In progress | P1 (P2 in progress) |
+| **C** | `wasi-sdk` + `wit-bindgen-c` | Stable | P2 |
+| **C++** | `wit-bindgen-cpp` | Experimental | P2 |
 | **Ruby** | `ruby.wasm` | In progress | P2 (partial) |
 | **Kotlin** | Kotlin/Wasm (native) | Planned | &mdash; |
 | **Swift** | SwiftWasm | Roadmap accepted | &mdash; |
@@ -85,7 +86,8 @@ These toolchains are actively working toward Component Model support. Components
 
 | Language | Toolchain | Status | More information |
 |---|---|---|---|
-| **C / C++** | [`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk) | WASI P1 stable; P2 + Component Model support in progress | [wasi-sdk releases](https://github.com/WebAssembly/wasi-sdk/releases) |
+| **C** | [`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk) + [`wit-bindgen-c`](https://github.com/bytecodealliance/wit-bindgen) | WASI P2 + Component Model support complete | [wasi-sdk releases](https://github.com/WebAssembly/wasi-sdk/releases) |
+| **C++** | [`wit-bindgen-cpp`](https://github.com/aspect-build/wit-bindgen-cpp) | Experimental | [wit-bindgen-cpp repository](https://github.com/aspect-build/wit-bindgen-cpp) |
 | **Ruby** | [`ruby.wasm`](https://github.com/ruby/ruby.wasm) | Component Model support in progress | [ruby.wasm repository](https://github.com/ruby/ruby.wasm) |
 | **Kotlin** | Kotlin/Wasm | Native Wasm Component Model support planned by JetBrains | [JetBrains tracking issue](https://youtrack.jetbrains.com/issue/KT-56492) |
 | **Swift** | SwiftWasm | Component Model roadmap accepted | [WebAssembly vision](https://github.com/swiftlang/swift-evolution/blob/main/visions/webassembly.md) |

--- a/versioned_docs/version-next/wash/developer-guide/language-support/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/index.mdx
@@ -1,0 +1,112 @@
+---
+title: "Language Support"
+sidebar_position: 3
+---
+
+wasmCloud runs standard [WebAssembly components](https://component-model.bytecodealliance.org/) targeting [WASI P2](https://wasi.dev/). Any language toolchain that can produce a Wasm component with WASI P2 support can build components that run on wasmCloud.
+
+This page provides a reference for various languages' support for compiling WebAssembly components, as well as wasmCloud ecosystem support for building and running components developed in a given language.
+
+## Component Support
+
+This chart summarizes the current state of language support for WebAssembly components, from languages with built-in WASI P2 targets to toolchains that are still in progress.
+
+| Language | Toolchain | Status | WASI version |
+|---|---|---|---|
+| **Rust** | `cargo` + `wasm32-wasip2` target | Stable | P2 |
+| **Go** | TinyGo | Stable | P2 |
+| **TypeScript / JavaScript** | `jco` + `componentize-js` | Stable | P2 |
+| **C# / .NET** | `componentize-dotnet` | Stable | P2 |
+| **Python** | `componentize-py` | Stable | P2 |
+| **C / C++** | `wasi-sdk` | In progress | P1 (P2 in progress) |
+| **Ruby** | `ruby.wasm` | In progress | P2 (partial) |
+| **Kotlin** | Kotlin/Wasm (native) | Planned | &mdash; |
+| **Swift** | SwiftWasm | Roadmap accepted | &mdash; |
+| **Java** | GraalWasm | Planned | &mdash; |
+
+## Tier 1: Well-supported toolchains
+
+These languages are supported by wasmCloud component project templates, `wash dev` integration, and documentation in the [Developer Guide](../index.mdx).
+
+### Rust
+
+Rust has first-class WebAssembly support via the `wasm32-wasip2` compiler target, which ships with the standard Rust toolchain.
+
+- **Toolchain:** `cargo` with target `wasm32-wasip2` (install via `rustup target add wasm32-wasip2`)
+- **Bindings:** The [`wstd`](https://crates.io/crates/wstd) crate provides an async Rust standard library for Wasm components and WASI 0.2, hosted by the [Bytecode Alliance](https://github.com/bytecodealliance/wstd). You can also use [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) directly for lower-level control.
+- **Get started:** [Developer Guide](../index.mdx?lang=rust) | [Rust Language Guide](./rust/index.mdx)
+
+### JavaScript (TypeScript)
+
+TypeScript components are built using the [`jco`](https://github.com/bytecodealliance/jco) toolchain (part of the Bytecode Alliance), which compiles JS/TS to Wasm components via [`componentize-js`](https://github.com/bytecodealliance/ComponentizeJS).
+
+- **Toolchain:** `jco` + `componentize-js`
+- **Bindings:** `jco` generates TypeScript types from WIT files automatically
+- **Get started:** [Developer Guide](../index.mdx?lang=typescript) | [TypeScript Language Guide](./typescript/index.mdx)
+
+### Go (TinyGo)
+
+wasmCloud uses [TinyGo](https://tinygo.org/) (not the standard Go compiler) for WebAssembly component support. TinyGo compiles a large subset of Go to WebAssembly with a much smaller binary footprint.
+
+- **Toolchain:** TinyGo with `-target wasip2`
+- **Bindings:** [`wit-bindgen-go`](https://github.com/bytecodealliance/go-modules) generates Go bindings from WIT files. The [`go.wasmcloud.dev/component`](https://github.com/wasmCloud/go/tree/main/component) package provides idiomatic Go helpers (e.g. `wasihttp.HandleFunc` for `net/http`-style request handling).
+- **`wash` support:** `wash new`, `wash dev`, `wash build` &mdash; requires a [`.wash/config.yaml` configuration file](../../config.mdx) and a `Makefile`
+- **Get started:** [Developer Guide](../index.mdx?lang=tinygo) | [Go Language Guide](./go/index.mdx)
+
+:::note[Why TinyGo?]
+The standard Go compiler does not yet support the Wasm Component Model. TinyGo targets `wasip2` directly and produces much smaller binaries, making it the current path for Go developers building Wasm components.
+:::
+
+## Tier 2: Stable toolchains
+
+These languages have stable Component Model toolchains that can produce components compatible with wasmCloud. You can build components manually and run them with `wash`, but there are no `wash` project templates or `wash dev` integrations yet.
+
+### C# / .NET
+
+[`componentize-dotnet`](https://github.com/bytecodealliance/componentize-dotnet) is a Bytecode Alliance project that compiles .NET applications to Wasm components using NativeAOT.
+
+- **Toolchain:** `componentize-dotnet` NuGet package
+- **Status:** Stable; actively maintained by the Bytecode Alliance
+- **Build:** Components are built with `dotnet build` and the `componentize-dotnet` MSBuild integration
+- **Repository:** [bytecodealliance/componentize-dotnet](https://github.com/bytecodealliance/componentize-dotnet)
+
+### Python
+
+[`componentize-py`](https://github.com/bytecodealliance/componentize-py) is a Bytecode Alliance project that compiles Python applications to Wasm components.
+
+- **Toolchain:** `componentize-py` CLI
+- **Status:** Stable; actively maintained by the Bytecode Alliance
+- **Build:** `componentize-py componentize --wit-path wit --world <world-name> -o output.wasm app.py`
+- **Repository:** [bytecodealliance/componentize-py](https://github.com/bytecodealliance/componentize-py)
+
+## Tier 3: In progress or planned
+
+These toolchains are actively working toward Component Model support. Components built with these tools may not yet be fully compatible with wasmCloud.
+
+| Language | Toolchain | Status | More information |
+|---|---|---|---|
+| **C / C++** | [`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk) | WASI P1 stable; P2 + Component Model support in progress | [wasi-sdk releases](https://github.com/WebAssembly/wasi-sdk/releases) |
+| **Ruby** | [`ruby.wasm`](https://github.com/ruby/ruby.wasm) | Component Model support in progress | [ruby.wasm repository](https://github.com/ruby/ruby.wasm) |
+| **Kotlin** | Kotlin/Wasm | Native Wasm Component Model support planned by JetBrains | [JetBrains tracking issue](https://youtrack.jetbrains.com/issue/KT-56492) |
+| **Swift** | SwiftWasm | Component Model roadmap accepted | [WebAssembly vision](https://github.com/swiftlang/swift-evolution/blob/main/visions/webassembly.md) |
+| **Java** | [GraalWasm](https://www.graalvm.org/latest/reference-manual/wasm/) | WASI support planned | [GraalVM documentation](https://www.graalvm.org/latest/reference-manual/wasm/) |
+
+## Binding generators
+
+Most languages use [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) (or a language-specific tool built on the same foundation) to generate typed bindings from WIT interface definitions. `wit-bindgen` currently supports:
+
+- **Rust** (`wit-bindgen-rust`)
+- **Go** (`wit-bindgen-go`)
+- **C** (`wit-bindgen-c`)
+- **C#** (via `componentize-dotnet`)
+- **Java** (`wit-bindgen-java`, early stage)
+
+For TypeScript/JavaScript, [`jco`](https://github.com/bytecodealliance/jco) handles binding generation as part of its build pipeline.
+
+## Further reading
+
+- [WebAssembly Component Model specification](https://github.com/WebAssembly/component-model) &mdash; Official Component Model repository and specification
+- [Component Model documentation](https://component-model.bytecodealliance.org/) &mdash; Specification and guides for the Wasm Component Model
+- [WASI.dev](https://wasi.dev/) &mdash; WebAssembly System Interface specifications
+- [Developer Guide](../index.mdx) &mdash; `wash` tutorial for creating, building, and publishing components
+- [Useful WebAssembly Tools](../useful-webassembly-tools.mdx) &mdash; Additional tooling for Wasm development

--- a/versioned_docs/version-next/wash/developer-guide/language-support/rust/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/rust/index.mdx
@@ -1,0 +1,429 @@
+---
+title: "Rust Language Guide"
+sidebar_position: 0
+---
+
+Rust has first-class support for building WebAssembly components. The `wasm32-wasip2` compiler target ships with the standard Rust toolchain, and the [`wstd`](https://crates.io/crates/wstd) crate provides an async standard library purpose-built for WASI 0.2 components.
+
+This guide covers the toolchain, the `wstd` library, adding custom WASI interfaces, and practical guidance for building Rust components on wasmCloud.
+
+If you're looking for a quick walkthrough of creating, building, and running a Rust component, see the [Developer Guide](../../index.mdx?lang=rust).
+
+## Toolchain overview
+
+### Build pipeline
+
+![Rust build pipeline](../../../images/build-pipeline-rust.svg)
+
+Unlike TypeScript or Go, Rust compiles directly to a Wasm component in a single step. No post-processing, bundling, or external tools are required.
+
+### `wasm32-wasip2` target
+
+The `wasm32-wasip2` target has been a [Tier 2 target](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip2.html) since Rust 1.82. It compiles Rust code to a WebAssembly component targeting WASI 0.2 (Preview 2), which includes the Component Model.
+
+Install the target:
+
+```shell
+rustup target add wasm32-wasip2
+```
+
+Build a component:
+
+```shell
+cargo build --target wasm32-wasip2 --release
+```
+
+The compiled component is written to `target/wasm32-wasip2/release/<crate_name>.wasm`.
+
+### `wstd`
+
+[`wstd`](https://github.com/bytecodealliance/wstd) is a minimal async Rust standard library for Wasm components, maintained by the Bytecode Alliance. It provides high-level APIs for HTTP, networking, I/O, timers, and randomness — all backed by WASI 0.2 interfaces.
+
+`wstd` handles WASI bindings internally through its dependency on the [`wasip2`](https://crates.io/crates/wasip2) crate. For standard HTTP components, `wstd` is the only dependency you need.
+
+:::note[`wstd` is a transitional library]
+`wstd` exists because mainstream async runtimes like `tokio` and `async-std` do not yet support WASI 0.2. Once they do, the `wstd` project recommends migrating to those runtimes. The API is designed to make that migration straightforward.
+:::
+
+Available modules:
+
+| Module | Description |
+|---|---|
+| `wstd::http` | HTTP request/response types, `#[http_server]` macro |
+| `wstd::io` | Async I/O abstractions |
+| `wstd::net` | Async networking (`TcpListener`, `TcpStream`) |
+| `wstd::time` | Async timers and durations |
+| `wstd::rand` | Random number generation (backed by `wasi:random`) |
+| `wstd::task` | Async task types |
+| `wstd::runtime` | Async event loop (`block_on()` executor) |
+
+### `wit-bindgen`
+
+[`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) is a lower-level tool that generates Rust code from WIT interface definitions. You don't need `wit-bindgen` for standard HTTP components — `wstd` handles those bindings internally. However, `wit-bindgen` is essential when you need to use WASI interfaces that aren't included in `wstd`, such as `wasi:keyvalue` or `wasi:config`.
+
+See [Adding custom WASI interfaces](#adding-custom-wasi-interfaces) for details on using `wstd` and `wit-bindgen` together.
+
+## Handling HTTP requests
+
+The `#[wstd::http_server]` macro is the standard way to build an HTTP component in Rust. It wires an async function to the `wasi:http/incoming-handler` export:
+
+```rust
+use wstd::http::{Body, Request, Response, StatusCode};
+
+#[wstd::http_server]
+async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    match req.uri().path() {
+        "/" => home().await,
+        _ => not_found().await,
+    }
+}
+
+async fn home() -> Result<Response<Body>, wstd::http::Error> {
+    Ok(Response::new(Body::from("Hello from wasmCloud!\n")))
+}
+
+async fn not_found() -> Result<Response<Body>, wstd::http::Error> {
+    Ok(Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::from("Not found\n"))?)
+}
+```
+
+Key points:
+
+- The function must be `async` and accept a `Request<Body>`, returning `Result<Response<Body>, wstd::http::Error>`.
+- Route matching is manual (pattern match on `req.uri().path()`). For complex routing, you can use helper functions or a lightweight router crate.
+- `Response::new()` creates a 200 OK response. Use `Response::builder()` for custom status codes or headers.
+- Handler functions can be `async`, enabling outgoing HTTP calls, key-value operations, or other async work within a request.
+
+### Outgoing HTTP requests
+
+Components can make outgoing HTTP requests using `wstd::http::Client`:
+
+```rust
+use wstd::http::{Body, Client, Request, Response};
+
+#[wstd::http_server]
+async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    let client = Client::new();
+    let upstream_resp = client.send(
+        Request::get("https://api.example.com/data").body(Body::empty())?
+    ).await?;
+
+    Ok(Response::new(upstream_resp.into_body()))
+}
+```
+
+To make outgoing HTTP requests, your WIT world must import `wasi:http/outgoing-handler`:
+
+```wit
+world hello {
+    import wasi:http/outgoing-handler@0.2.2;
+    export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+## Adding custom WASI interfaces
+
+`wstd` (through its `wasip2` dependency) provides bindings for standard WASI interfaces: `wasi:http`, `wasi:io`, `wasi:clocks`, `wasi:random`, and others. For draft or experimental interfaces like `wasi:keyvalue`, `wasi:config`, or custom interfaces, you need `wit-bindgen` to generate bindings for the additional interfaces.
+
+### How `wstd` and `wit-bindgen` coexist
+
+- **`wstd`** handles the HTTP export via the `#[wstd::http_server]` macro
+- **`wasip2`** (bundled with `wstd`) provides bindings for standard WASI imports
+- **`wit-bindgen`** generates bindings for your custom imports only
+
+Many draft interfaces like `wasi:keyvalue` are self-contained — they don't share types with `wasi:io` or other standard interfaces. This means there are no type conflicts between what `wasip2` provides and what `wit-bindgen` generates.
+
+### Example: Adding `wasi:keyvalue`
+
+**1. Add `wit-bindgen` to `Cargo.toml`:**
+
+```toml title="Cargo.toml"
+[package]
+name = "my-component"
+edition = "2024"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wstd = "0.6"
+wit-bindgen = "0.41"
+```
+
+**2. Declare the imports in your WIT world:**
+
+```wit title="wit/world.wit"
+package myorg:mycomponent;
+
+world my-world {
+    import wasi:keyvalue/store@0.2.0-draft;
+    import wasi:keyvalue/atomics@0.2.0-draft;
+    export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+**3. Fetch the WIT dependencies:**
+
+```shell
+wkg wit fetch
+```
+
+This populates `wit/deps/` with the interface definitions for `wasi:keyvalue`, `wasi:http`, and their transitive dependencies.
+
+**4. Generate bindings and use the interface:**
+
+```rust title="src/lib.rs"
+use wstd::http::{Body, Request, Response};
+
+// Generate bindings for all interfaces in the WIT world.
+// wstd handles the HTTP export; wit-bindgen generates the keyvalue imports.
+wit_bindgen::generate!({
+    world: "my-world",
+    path: "wit",
+    generate_all,
+});
+
+use wasi::keyvalue::{atomics, store};
+
+#[wstd::http_server]
+async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    let bucket = store::open("")
+        .map_err(|e| wstd::http::Error::msg(format!("keyvalue error: {:?}", e)))?;
+
+    let count = atomics::increment(&bucket, "visitor-count", 1)
+        .map_err(|e| wstd::http::Error::msg(format!("increment error: {:?}", e)))?;
+
+    Ok(Response::new(Body::from(format!("Visit count: {count}\n"))))
+}
+```
+
+The `generate_all` option tells `wit-bindgen` to generate bindings for all imports in the world. Since `wasi:keyvalue` isn't in `wasip2`, `wit-bindgen` generates it. The HTTP export is still handled by `wstd`, not `wit-bindgen`.
+
+Generated bindings are available under `wasi::keyvalue::*`, matching the WIT package namespace.
+
+### Version alignment
+
+The `wasi:http/incoming-handler` version in your WIT world **must match** the version provided by your `wasip2` dependency. Check your resolved version with:
+
+```shell
+cargo tree -p wasip2
+```
+
+| `wasip2` version | WASI HTTP version |
+|---|---|
+| 1.0.0, 1.0.1 | 0.2.4 |
+| 1.0.2+ | 0.2.9 |
+
+If versions mismatch, you'll get a linker error: `failed to find export of interface wasi:http/incoming-handler@... function handle`.
+
+To fix this, update the version in `wit/world.wit` and re-fetch dependencies:
+
+```shell
+rm -rf wit/deps wkg.lock && wkg wit fetch
+```
+
+### Handling type conflicts
+
+If a custom interface imports types from `wasi:io` or other standard interfaces (creating overlap with `wasip2`), use `wit-bindgen`'s `with` option to point to `wasip2`'s types:
+
+```rust
+wit_bindgen::generate!({
+    world: "my-world",
+    path: "wit",
+    with: {
+        "wasi:io/streams@0.2.9": wasip2::wasi::io::streams,
+        "wasi:io/poll@0.2.9": wasip2::wasi::io::poll,
+    },
+    generate_all,
+});
+```
+
+Self-contained interfaces like `wasi:keyvalue@0.2.0-draft` don't share types with standard interfaces, so this isn't needed in most cases.
+
+## Project structure
+
+A typical Rust component project:
+
+```
+my-component/
+├── .wash/
+│   └── config.yaml      # wash project configuration
+├── src/
+│   └── lib.rs           # Application code
+├── wit/
+│   ├── world.wit        # WIT world definition
+│   └── deps/            # Fetched WIT dependencies (gitignored)
+├── Cargo.toml
+├── Cargo.lock
+└── wkg.lock             # WIT dependency lock file
+```
+
+### `Cargo.toml`
+
+```toml title="Cargo.toml"
+[package]
+name = "my-component"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wstd = "0.6"
+```
+
+- **`crate-type = ["cdylib"]`** is required — it tells Cargo to produce a C-compatible dynamic library, which is the format used by the `wasm32-wasip2` target to emit a `.wasm` component.
+- For a standard HTTP component, `wstd` is the only dependency needed.
+
+### WIT world
+
+```wit title="wit/world.wit"
+package wasmcloud:hello;
+
+world hello {
+    export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+The WIT world declares your component's imports and exports. A component exporting `wasi:http/incoming-handler` can handle incoming HTTP requests. Adding imports (like `wasi:http/outgoing-handler` or `wasi:keyvalue/store`) declares the capabilities your component requires from the runtime.
+
+:::info[WASI HTTP version]
+The `wasi:http/incoming-handler` version in your WIT world must match the version provided by your `wasip2` dependency. The version shown here (`@0.2.2`) matches the wasmCloud project template. See [Version alignment](#version-alignment) for details on matching versions.
+:::
+
+### WIT dependency management with `wkg`
+
+[`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools) is the WebAssembly package manager. It reads your WIT world and fetches the interface definitions your component needs.
+
+```shell
+wkg wit fetch
+```
+
+This populates `wit/deps/` with downloaded interface definitions and creates a `wkg.lock` file. You should:
+
+- Add `wit/deps/` to `.gitignore` — these are fetched dependencies
+- Commit `wkg.lock` — this ensures reproducible builds
+
+When you run `wash build`, it calls `wkg wit fetch` automatically, so you typically don't need to run it manually. The following namespaces are resolved automatically without configuration:
+
+- `wasi` — standard [WASI](https://wasi.dev/) interfaces
+- `wasmcloud` — wasmCloud project interfaces
+- `wrpc` — [wRPC](https://github.com/wrpc) interfaces
+- `ba` — [Bytecode Alliance](https://bytecodealliance.org/) interfaces
+
+### `.wash/config.yaml`
+
+Rust projects use a [project configuration file](../../../config.mdx) at `.wash/config.yaml` that tells `wash` how to build the component:
+
+```yaml title=".wash/config.yaml"
+build:
+  command: cargo build --target wasm32-wasip2 --release
+  component_path: target/wasm32-wasip2/release/hello_world.wasm
+```
+
+The `command` field specifies the build command and `component_path` points to the compiled `.wasm` binary. For a full reference of configuration options, see the [Configuration](../../../config.mdx) page.
+
+### Optimizing binary size
+
+Wasm component binaries can be reduced with standard Cargo release profile settings:
+
+```toml title="Cargo.toml"
+[profile.release]
+opt-level = "z"       # Optimize for size
+lto = true            # Link-time optimization
+codegen-units = 1     # Better optimization (slower compile)
+strip = true          # Remove debug symbols
+```
+
+## Crate compatibility
+
+### What works
+
+Any Rust crate that compiles to `wasm32-wasip2` works inside a Wasm component. This includes:
+
+- **Pure computation** — `serde`, `serde_json`, `regex`, `uuid`, `base64`, `chrono` (without `std` time), etc.
+- **Error handling** — `anyhow`, `thiserror`
+- **Async** — `wstd`'s own async runtime (not `tokio` or `async-std` — see below)
+- **HTTP types** — `wstd::http` provides `Request`, `Response`, `Body`, `StatusCode`, etc.
+
+### What does not work
+
+- **`tokio`, `async-std`, `smol`** — mainstream async runtimes do not yet support WASI 0.2. `wstd` exists specifically to fill this gap. When these runtimes add WASI 0.2 support, migration from `wstd` is expected to be straightforward.
+- **Crates that use `std::net` or `std::fs` directly** — these require OS-level syscalls not available in the Wasm sandbox. Use `wstd::net` and WASI filesystem interfaces instead.
+- **Crates with native C dependencies** — anything that links to a C library via `build.rs` (e.g., `openssl-sys`, `libsqlite3-sys`) will not compile for `wasm32-wasip2`.
+- **Crates using threads** — `std::thread` is not available in WASI 0.2. Async concurrency through `wstd` is the alternative.
+
+### Practical guidance
+
+- Check a crate's compatibility by attempting `cargo check --target wasm32-wasip2` before committing to it
+- Prefer crates with `no_std` support or explicit Wasm compatibility
+- For JSON handling, `wstd` has optional `serde` and `serde_json` feature flags: `wstd = { version = "0.6", features = ["serde", "serde_json"] }`
+
+## Building and running
+
+### Create a new project
+
+Use `wash new` to scaffold a Rust component project:
+
+```shell
+wash new https://github.com/wasmCloud/wash.git --name hello --subfolder examples/http-hello-world
+```
+
+### Development loop
+
+Start a development loop that builds, runs, and watches for changes:
+
+```shell
+wash dev
+```
+
+Send a request to test:
+
+```shell
+curl localhost:8000
+```
+
+### Build a component
+
+Compile your project to a `.wasm` binary using standard Cargo:
+
+```shell
+cargo build --target wasm32-wasip2 --release
+```
+
+The compiled component is written to `target/wasm32-wasip2/release/<crate_name>.wasm`.
+
+If your WIT world references external interfaces (e.g. `wasi:keyvalue`), fetch the definitions first:
+
+```shell
+wkg wit fetch
+```
+
+:::tip[`wash build` as an alternative]
+`wash build` wraps both steps — it runs `wkg wit fetch` and then `cargo build` using the command from your `.wash/config.yaml`. Either approach produces the same output. This guide shows `cargo` directly because it's the standard Rust build command and works without any wasmCloud-specific configuration.
+:::
+
+### Inspect a component
+
+Verify your component's imports and exports with `wasm-tools`:
+
+```shell
+wasm-tools component wit target/wasm32-wasip2/release/my_component.wasm
+```
+
+This prints the resolved WIT world, showing exactly which interfaces the component imports and exports.
+
+## Further reading
+
+- [Developer Guide](../../index.mdx?lang=rust) — quickstart tutorial for creating, building, and running a Rust component
+- [wasmCloud Rust examples](https://github.com/wasmCloud/wash/tree/main/examples) — example projects in the `wash` repository
+- [`wstd` documentation](https://docs.rs/wstd) — API reference for the async Wasm standard library
+- [`wstd` repository](https://github.com/bytecodealliance/wstd) — source code and examples
+- [`wit-bindgen` documentation](https://docs.rs/wit-bindgen) — API reference for the WIT bindings generator
+- [`wasm32-wasip2` platform support](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip2.html) — Rust target documentation
+- [Component Model: Rust](https://component-model.bytecodealliance.org/language-support/rust.html) — Component Model documentation for Rust
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/versioned_docs/version-next/wash/developer-guide/language-support/rust/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/rust/index.mdx
@@ -297,18 +297,20 @@ The `wasi:http/incoming-handler` version in your WIT world must match the versio
 
 ### WIT dependency management with `wkg`
 
-[`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools) is the WebAssembly package manager. It reads your WIT world and fetches the interface definitions your component needs.
+`wash` bundles the [`wkg`](https://github.com/bytecodealliance/wasm-pkg-tools) WebAssembly package manager, so you don't need to install a separate tool. You can fetch WIT dependencies directly with `wash`:
 
 ```shell
-wkg wit fetch
+wash wit fetch
 ```
 
-This populates `wit/deps/` with downloaded interface definitions and creates a `wkg.lock` file. You should:
+This reads your WIT world, populates `wit/deps/` with downloaded interface definitions, and creates a `wkg.lock` file. You should:
 
 - Add `wit/deps/` to `.gitignore` — these are fetched dependencies
 - Commit `wkg.lock` — this ensures reproducible builds
 
-When you run `wash build`, it calls `wkg wit fetch` automatically, so you typically don't need to run it manually. The following namespaces are resolved automatically without configuration:
+When you run `wash build`, it calls `wash wit fetch` automatically, so you typically don't need to run it manually. If you have `wkg` installed separately, it works the same way — `wash` and `wkg` share the same underlying crate and produce the same `wkg.lock` file.
+
+The following namespaces are resolved automatically without configuration:
 
 - `wasi` — standard [WASI](https://wasi.dev/) interfaces
 - `wasmcloud` — wasmCloud project interfaces

--- a/versioned_docs/version-next/wash/developer-guide/language-support/typescript/blob-storage.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/typescript/blob-storage.mdx
@@ -1,0 +1,432 @@
+---
+title: "Blob Storage"
+sidebar_position: 1
+---
+
+You can add blob storage capabilities to a component with the [`wasi:blobstore`](https://github.com/WebAssembly/wasi-blobstore/) interface.
+
+This guide walks through replacing the in-memory mock data store in the wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template with the `wasi:blobstore` interface. You can use this guide as a model for implementing `wasi:blobstore` in your own components or adding any new WIT interface to an existing component.
+
+## Overview
+
+The wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:blobstore`, which gives the component persistent object storage backed by a real blob store. 
+
+:::info[]
+By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Blobstore NATS plugin](https://github.com/wasmCloud/wash/blob/main/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:blobstore` with a different storage solution.
+:::
+
+`wasi:blobstore` models storage as **containers** (analogous to S3 buckets) that hold named **objects** (blobs of bytes). Unlike a simple key-value store, blobstore uses a streaming I/O model with `OutgoingValue`/`IncomingValue` resources, designed to handle potentially large objects.
+
+Our changes will focus on two files:
+
+* `wit/world.wit` - Declare the new WIT imports
+* `src/routes/items.ts` - Use the imported interfaces in application code
+
+No changes are needed to `rolldown.config.mjs`, `tsconfig.json`, `package.json`, or any other file.
+
+:::tip[Complete example]
+A full working example is available as a template:
+```bash
+wash new https://github.com/wasmCloud/typescript.git \
+  --name http-blobstore-service-hono \
+  --subfolder templates/http-blobstore-service-hono \
+  --git-ref v2
+```
+:::
+
+## Step 1: Declare the WIT imports in `wit/world.wit`
+
+Every capability your component uses must be declared in its WIT world. Open `wit/world.wit` and add an `import` line for the blobstore interface.
+
+```wit {4}
+package wasmcloud:templates@0.1.0;
+
+world typescript-http-blobstore-service-hono {
+  import wasi:blobstore/blobstore@0.2.0-draft;
+
+  export wasi:http/incoming-handler@0.2.6;
+}
+```
+
+### What these interfaces provide
+
+- **`wasi:blobstore/blobstore`** -- Top-level container management: `createContainer`, `getContainer`, `containerExists`, `deleteContainer`.
+- **`wasi:blobstore/container`** -- Object operations within a container: `getData`, `writeData`, `listObjects`, `deleteObject`, `hasObject`, `objectInfo`. Pulled in transitively by `blobstore`.
+- **`wasi:blobstore/types`** -- Streaming resource types: `OutgoingValue` (for writes), `IncomingValue` (for reads), and `ObjectMetadata`. Pulled in transitively by `blobstore`.
+
+Unlike interfaces with multiple sub-imports (e.g. `wasi:keyvalue/store` and `wasi:keyvalue/atomics`), blobstore only needs the single `wasi:blobstore/blobstore` import — `container` and `types` are available automatically.
+
+### How dependency resolution works
+
+When you run `npm run build`, the build pipeline calls `wkg wit fetch` as a setup step. This resolves the WIT package references (like `wasi:blobstore`) and downloads their definitions into the `wit/deps/` directory automatically. You don't need to manually download any WIT files.
+
+The bundler (`rolldown`) is already configured with `external: /wasi:.*/` in `rolldown.config.mjs`, which tells it to leave all `wasi:*` imports as external -- they'll be resolved at component instantiation time, not at bundle time. This covers any new `wasi:` interface you add.
+
+## Step 2: Import and use the interface in TypeScript
+
+With the WIT world updated, you can now import functions from the new interfaces in your TypeScript code. The import paths match the WIT interface names exactly.
+
+### Importing WIT interfaces
+
+Add these imports at the top of `src/routes/items.ts`:
+
+```typescript
+// @ts-expect-error - JCO doesn't generate types for wasi:blobstore yet
+import { getContainer, createContainer, containerExists } from 'wasi:blobstore/blobstore@0.2.0-draft';
+// @ts-expect-error - JCO doesn't generate types for wasi:blobstore yet
+import { OutgoingValue, IncomingValue } from 'wasi:blobstore/types@0.2.0-draft';
+```
+
+**Why `@ts-expect-error`?** The `jco types` command generates `.d.ts` files for your WIT interfaces into `generated/types/`, but TypeScript can't resolve bare `wasi:` specifier imports against those files. The `@ts-expect-error` directive suppresses the resulting type error. The imports work correctly at runtime because `rolldown` marks them as external and `jco componentize` wires them up during Wasm component creation.
+
+### Key pattern: import path = WIT interface name
+
+The import path always matches the fully-qualified WIT interface name:
+
+```
+wasi:blobstore/blobstore@0.2.0-draft  -->  import { getContainer, ... } from 'wasi:blobstore/blobstore@0.2.0-draft'
+wasi:blobstore/types@0.2.0-draft      -->  import { OutgoingValue, ... } from 'wasi:blobstore/types@0.2.0-draft'
+```
+
+To discover which functions are available on an interface, look at the generated type file (e.g. `generated/types/interfaces/wasi-blobstore-blobstore.d.ts`) after running `npm run build` once, or read the WIT definition in `wit/deps/`.
+
+### Serialization: values are `Uint8Array`
+
+Blobstore reads and writes blobs as bytes. To store structured data, you need to serialize and deserialize:
+
+```typescript
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function serializeItem(item: Item): Uint8Array {
+  return encoder.encode(JSON.stringify(item));
+}
+
+function deserializeItem(bytes: Uint8Array): Item {
+  return JSON.parse(decoder.decode(bytes));
+}
+```
+
+### Ensuring a container exists
+
+All blobstore operations happen on a **container**. Unlike a simple key-value bucket, you must ensure the container exists before using it:
+
+```typescript
+const CONTAINER_NAME = 'default';
+
+function ensureContainer() {
+  if (!containerExists(CONTAINER_NAME)) {
+    createContainer(CONTAINER_NAME);
+  }
+  return getContainer(CONTAINER_NAME);
+}
+```
+
+Call `ensureContainer()` inside each route handler rather than at module scope -- the container handle should be obtained per-request.
+
+### Key namespacing
+
+Use a prefix to separate different kinds of data in the same container:
+
+```typescript
+const ITEM_PREFIX = 'item:';
+// Item keys: "item:<uuid>", "item:<uuid>", ...
+```
+
+This prevents collisions if you store other kinds of objects in the same container.
+
+### Writing blobs
+
+Writing to blobstore uses a streaming pattern with `OutgoingValue`. This is more involved than a simple `set(key, bytes)` call:
+
+```typescript
+function writeBlob(container: any, name: string, bytes: Uint8Array): void {
+  const ov = OutgoingValue.newOutgoingValue();
+  const stream = ov.outgoingValueWriteBody();
+  stream.blockingWriteAndFlush(bytes);
+  container.writeData(name, ov);
+  OutgoingValue.finish(ov);
+}
+```
+
+:::warning[Operation ordering]
+You must write bytes to the stream **before** calling `writeData`. Calling `writeData` first commits an empty value — subsequent writes to the stream won't be associated with the object. This produces no error; the object simply has no data.
+
+You must also call `OutgoingValue.finish(ov)` **after** `writeData`. Dropping an `OutgoingValue` without finishing it signals corruption to the runtime.
+:::
+
+### Reading blobs
+
+Reading uses `IncomingValue` with inclusive byte offsets:
+
+```typescript
+function readBlob(container: any, name: string): Uint8Array {
+  const metadata = container.objectInfo(name);
+  const iv = container.getData(name, 0n, metadata.size - 1n);
+  return IncomingValue.incomingValueConsumeSync(iv);
+}
+```
+
+:::warning[Inclusive offsets]
+`getData` uses **inclusive** start and end offsets as **`bigint`** values. For a 100-byte object, the valid range is `(0n, 99n)`, which is `(0n, metadata.size - 1n)`. Using `metadata.size` as the end offset reads one byte past the object.
+:::
+
+### Listing objects
+
+Listing returns a paginated stream that you read in batches:
+
+```typescript
+function listObjectNames(container: any): string[] {
+  const stream = container.listObjects();
+  const names: string[] = [];
+  while (true) {
+    const [batch, done] = stream.readStreamObjectNames(100n);
+    names.push(...batch);
+    if (done) break;
+  }
+  return names;
+}
+```
+
+:::warning[`bigint` and tuple return type]
+`readStreamObjectNames` takes a **`bigint`**, not a `number`. Passing `100` instead of `100n` causes a runtime type error.
+
+The method returns `[string[], boolean]` — a tuple of names and a done flag. Always destructure it: `const [batch, done] = ...`. If you assign the return value to a single variable, `batch.length` will always be `2` (the tuple length).
+:::
+
+### ID generation
+
+Blobstore has no atomic increment operation. Use `crypto.randomUUID()` to generate unique IDs:
+
+```typescript
+const id = crypto.randomUUID();
+```
+
+This means IDs are UUIDs rather than sequential integers.
+
+### Synchronous API
+
+All blobstore operations (`getData`, `writeData`, `deleteObject`, `hasObject`, `listObjects`) are **synchronous** in the JCO bindings. The WebAssembly component model uses blocking calls, so these don't return Promises. Your existing synchronous Hono route handlers work without modification.
+
+## Step 3: Route-by-route changes
+
+Here is exactly what changed in each CRUD route handler, showing the before (in-memory `Map`) and after (`wasi:blobstore` container).
+
+### Removed code
+
+The entire mock data store and its initialization were removed:
+
+```typescript
+// REMOVED: Simulated database
+const items = new Map<string, Item>();
+let nextId = 1;
+
+// REMOVED: Sample data initialization
+items.set('1', {
+  id: '1',
+  name: 'Sample Item',
+  description: 'This is a sample item',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+nextId = 2;
+```
+
+With persistent storage, the store starts empty and users create items via the API. Data survives component restarts.
+
+### GET `/` -- List all items
+
+**Before:**
+```typescript
+itemsRouter.get('/', (c) => {
+  const itemList = Array.from(items.values());
+  // ... filtering and pagination ...
+});
+```
+
+**After:**
+```typescript
+itemsRouter.get('/', (c) => {
+  const container = ensureContainer();
+  const allNames = listObjectNames(container);
+  const itemNames = allNames.filter((n: string) => n.startsWith(ITEM_PREFIX));
+
+  const itemList: Item[] = [];
+  for (const name of itemNames) {
+    const bytes = readBlob(container, name);
+    itemList.push(deserializeItem(bytes));
+  }
+  // ... filtering and pagination unchanged ...
+});
+```
+
+`listObjectNames` reads the paginated stream and returns all object names. We filter for the `item:` prefix, then fetch and deserialize each item.
+
+### GET `/:id` -- Get single item
+
+**Before:**
+```typescript
+const item = items.get(id);
+if (!item) { /* 404 */ }
+return c.json(item);
+```
+
+**After:**
+```typescript
+const container = ensureContainer();
+if (!container.hasObject(`${ITEM_PREFIX}${id}`)) { /* 404 */ }
+const bytes = readBlob(container, `${ITEM_PREFIX}${id}`);
+return c.json(deserializeItem(bytes));
+```
+
+`container.hasObject()` returns a boolean. `readBlob` handles the streaming read and inclusive offset calculation.
+
+### POST `/` -- Create new item
+
+**Before:**
+```typescript
+const id = String(nextId++);
+// ... build newItem ...
+items.set(id, newItem);
+```
+
+**After:**
+```typescript
+const container = ensureContainer();
+const id = crypto.randomUUID();
+// ... build newItem ...
+writeBlob(container, `${ITEM_PREFIX}${id}`, serializeItem(newItem));
+```
+
+`crypto.randomUUID()` generates a unique ID. `writeBlob` handles the `OutgoingValue` lifecycle (create, write to stream, commit, finish).
+
+### PUT `/:id` -- Update item
+
+**Before:**
+```typescript
+const existing = items.get(id);
+if (!existing) { /* 404 */ }
+// ... build updated ...
+items.set(id, updated);
+```
+
+**After:**
+```typescript
+const container = ensureContainer();
+if (!container.hasObject(`${ITEM_PREFIX}${id}`)) { /* 404 */ }
+const bytes = readBlob(container, `${ITEM_PREFIX}${id}`);
+const existing = deserializeItem(bytes);
+// ... build updated ...
+writeBlob(container, `${ITEM_PREFIX}${id}`, serializeItem(updated));
+```
+
+### DELETE `/:id` -- Delete item
+
+**Before:**
+```typescript
+if (!items.has(id)) { /* 404 */ }
+items.delete(id);
+```
+
+**After:**
+```typescript
+const container = ensureContainer();
+if (!container.hasObject(`${ITEM_PREFIX}${id}`)) { /* 404 */ }
+container.deleteObject(`${ITEM_PREFIX}${id}`);
+```
+
+## Build and verify
+
+### Build
+
+```bash
+npm run build
+```
+
+This runs the full pipeline:
+1. `wash wit fetch` -- downloads `wasi:blobstore` WIT definitions into `wit/deps/`
+2. `jco types` -- generates TypeScript type definitions in `generated/types/`
+3. `rolldown` -- bundles TypeScript into `dist/component.js` (leaving `wasi:` imports external)
+4. `jco componentize` -- compiles `dist/component.js` into a `.wasm` component
+
+### Configure `wash dev`
+
+To get persistent blob storage during development, add `wasi_blobstore_path` to your `.wash/config.yaml`:
+
+```yaml
+dev:
+  wasi_blobstore_path: tmp/blobstore
+```
+
+- **Without `wasi_blobstore_path`**: `wash dev` uses an in-memory provider. State is lost when the dev session ends.
+- **With `wasi_blobstore_path`**: `wash dev` uses a filesystem provider. Blobs persist as files in the specified directory across restarts. Container names map to subdirectories, and object names map to files within them.
+
+### Run
+
+```bash
+npm run dev
+```
+
+This starts `wash dev`, which automatically provisions a blobstore provider to satisfy the `wasi:blobstore` imports.
+
+### Test
+
+```bash
+# Create an item
+curl -X POST http://localhost:8000/api/items \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Item","description":"Testing blobstore"}'
+
+# List items
+curl http://localhost:8000/api/items
+
+# Get by ID (replace <uuid> with a real ID from the create response)
+curl http://localhost:8000/api/items/<uuid>
+
+# Update
+curl -X PUT http://localhost:8000/api/items/<uuid> \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Updated Item"}'
+
+# Delete
+curl -X DELETE http://localhost:8000/api/items/<uuid>
+```
+
+To verify persistence, restart the component and confirm previously created items are still returned by `GET /api/items`.
+
+## Summary: checklist for adding any WIT interface
+
+1. **Add `import` lines to `wit/world.wit`** for the interfaces you need.
+2. **Run `npm run build` once** so `wash wit fetch` downloads the WIT definitions and `jco types` generates TypeScript types you can reference.
+3. **Import functions in TypeScript** using the exact WIT interface name as the import path, with `@ts-expect-error` to suppress the type error.
+4. **Use the imported functions** in your route handlers. Remember that Wasm component model calls are synchronous.
+5. **Handle serialization** -- most WIT interfaces use `Uint8Array` for binary data; use `TextEncoder`/`TextDecoder` and `JSON.stringify`/`JSON.parse` for structured data.
+6. **No bundler changes needed** -- `rolldown.config.mjs` already externalizes all `wasi:*` imports.
+7. **No new npm dependencies needed** -- WIT interfaces are provided by the runtime, not by npm packages.
+
+---
+
+## API reference: `wasi:blobstore` operations used
+
+| Operation | Signature | Description |
+|-----------|-----------|-------------|
+| `createContainer(name)` | `(string) => Container` | Create a named container |
+| `getContainer(name)` | `(string) => Container` | Get an existing container by name |
+| `containerExists(name)` | `(string) => boolean` | Check if a container exists |
+| `container.writeData(name, ov)` | `(string, OutgoingValue) => void` | Write an object to the container |
+| `container.getData(name, start, end)` | `(string, bigint, bigint) => IncomingValue` | Read an object (inclusive offsets) |
+| `container.deleteObject(name)` | `(string) => void` | Delete an object |
+| `container.hasObject(name)` | `(string) => boolean` | Check if an object exists |
+| `container.objectInfo(name)` | `(string) => ObjectMetadata` | Get object metadata (name, size, timestamps) |
+| `container.listObjects()` | `() => StreamObjectNames` | Get a paginated stream of object names |
+| `stream.readStreamObjectNames(len)` | `(bigint) => [string[], boolean]` | Read a batch of names; returns `[names, done]` |
+| `OutgoingValue.newOutgoingValue()` | `() => OutgoingValue` | Create a new outgoing value for writing |
+| `ov.outgoingValueWriteBody()` | `() => OutputStream` | Get the write stream for an outgoing value |
+| `OutgoingValue.finish(ov)` | `(OutgoingValue) => void` | Finalize the outgoing value (required after write) |
+| `IncomingValue.incomingValueConsumeSync(iv)` | `(IncomingValue) => Uint8Array` | Read all bytes from an incoming value |
+
+## Further reading
+
+- [TypeScript Language Guide](../index.mdx) — toolchain overview, HTTP patterns, framework integration, and library compatibility
+- [Key-Value Storage](./key-value-storage.mdx) — simpler key-value storage for small values and counters
+- [Language Support overview](../../index.mdx) — summary of all supported languages and toolchains

--- a/versioned_docs/version-next/wash/developer-guide/language-support/typescript/index.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/typescript/index.mdx
@@ -1,0 +1,402 @@
+---
+title: "TypeScript Language Guide"
+sidebar_position: 1
+---
+
+TypeScript and JavaScript are first-class languages for building WebAssembly components on wasmCloud. This guide covers the toolchain, patterns for handling HTTP requests, framework integration with Hono, and practical guidance for library compatibility.
+
+If you're looking for a quick walkthrough of creating, building, and running a TypeScript component, see the [Developer Guide](../../index.mdx?lang=typescript).
+
+## Toolchain overview
+
+Building a TypeScript Wasm component involves a pipeline of tools that compile your code from TypeScript source to a `.wasm` binary. Understanding what each tool does will help you debug build issues and make informed decisions about your project setup.
+
+### Build pipeline
+
+![TypeScript build pipeline](../../../images/build-pipeline-typescript.svg)
+
+### jco
+
+[`jco`](https://github.com/bytecodealliance/jco) is the JavaScript component toolchain maintained by the Bytecode Alliance. It is the primary CLI tool for building and working with JavaScript Wasm components.
+
+Key commands:
+
+| Command | Description |
+|---|---|
+| `jco componentize` | Compile a JavaScript file into a Wasm component |
+| `jco types` | Generate TypeScript type definitions from WIT interface files |
+| `jco transpile` | Convert a Wasm component (from any language) into ES modules for Node.js or browsers |
+| `jco serve` | Transpile and run a component as an HTTP server |
+
+When you run `wash build` on a TypeScript project, `wash` executes the build script defined in your `package.json`, which typically calls `jco types`, `tsc`, and `jco componentize` in sequence.
+
+### ComponentizeJS
+
+[ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS) is the library behind `jco componentize`. It takes a JavaScript source file and a WIT world definition as input and produces a Wasm component binary.
+
+Because JavaScript cannot be compiled ahead-of-time to raw WebAssembly instructions, ComponentizeJS embeds a JavaScript engine inside each component. It uses [Wizer](https://github.com/bytecodealliance/wizer) to pre-initialize the engine, parse your source code, and snapshot the result. At runtime, only the pre-compiled bytecode executes — there is no parsing or compilation overhead at startup.
+
+### StarlingMonkey
+
+[StarlingMonkey](https://github.com/bytecodealliance/StarlingMonkey) is the JavaScript engine embedded by ComponentizeJS. It is Mozilla's SpiderMonkey engine (the same engine used by Firefox) compiled to WebAssembly and targeting WASI 0.2.
+
+StarlingMonkey provides a subset of standard Web APIs inside the Wasm sandbox:
+
+- **`fetch()`** — outgoing HTTP requests (backed by `wasi:http`)
+- **`Request` / `Response` / `Headers`** — standard Web request and response objects
+- **`URL` / `URLSearchParams`** — URL parsing
+- **`TextEncoder` / `TextDecoder`** — text encoding
+- **`ReadableStream` / `WritableStream` / `TransformStream`** — WHATWG Streams
+- **`addEventListener('fetch', ...)`** — incoming HTTP request handling (Service Worker pattern)
+- **`setTimeout` / `setInterval`** — timers
+- **`console.log` / `console.error`** — logging (routed to WASI stderr)
+- **`crypto.getRandomValues()`** — cryptographic randomness (backed by `wasi:random`)
+
+These Web APIs are what make framework compatibility possible — libraries written against Web Standards (rather than Node.js APIs) can run inside a Wasm component without modification.
+
+:::note[Binary size]
+Each JavaScript Wasm component includes the StarlingMonkey runtime, which adds approximately 8 MB to the component binary. This is a fixed cost — it does not grow with the size of your application code.
+:::
+
+## Handling HTTP requests
+
+There are two patterns for handling incoming HTTP requests in a TypeScript component. They are **mutually exclusive** — you must choose one or the other for a given component.
+
+### Direct `incomingHandler` export
+
+The direct approach works with the raw WASI HTTP types. You export an `incomingHandler` object with a `handle` method that receives an `IncomingRequest` and a `ResponseOutparam`:
+
+```typescript
+import {
+  IncomingRequest,
+  ResponseOutparam,
+  OutgoingBody,
+  OutgoingResponse,
+  Fields,
+} from 'wasi:http/types@0.2.3';
+
+function handle(req: IncomingRequest, resp: ResponseOutparam) {
+  const outgoingResponse = new OutgoingResponse(new Fields());
+  let outgoingBody = outgoingResponse.body();
+  {
+    let outputStream = outgoingBody.write();
+    outputStream.blockingWriteAndFlush(
+      new Uint8Array(new TextEncoder().encode('Hello from TypeScript!\n')),
+    );
+    // @ts-ignore: dispose the stream before returning
+    outputStream[Symbol.dispose]();
+  }
+  outgoingResponse.setStatusCode(200);
+  OutgoingBody.finish(outgoingBody, undefined);
+  ResponseOutparam.set(resp, { tag: 'ok', val: outgoingResponse });
+}
+
+export const incomingHandler = {
+  handle,
+};
+```
+
+This pattern gives you full control over the WASI HTTP types but requires more boilerplate.
+
+### Service Worker fetch pattern
+
+The fetch pattern uses `addEventListener('fetch', ...)` — the same API used by browser Service Workers and platforms like Cloudflare Workers. StarlingMonkey automatically maps this event listener to the `wasi:http/incoming-handler` export:
+
+```typescript
+addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  if (url.pathname === '/hello') {
+    event.respondWith(new Response('Hello from TypeScript!\n'));
+  } else {
+    event.respondWith(new Response('Not found\n', { status: 404 }));
+  }
+});
+```
+
+The fetch pattern lets you work with standard Web `Request` and `Response` objects instead of low-level WASI types. This is the pattern that makes web frameworks like Hono work — they expect `Request` in and `Response` out.
+
+### When to use which
+
+| | Direct `incomingHandler` | Service Worker fetch |
+|---|---|---|
+| **Best for** | Simple handlers, learning WASI HTTP types | Framework integration, complex routing |
+| **API surface** | WASI HTTP types (`IncomingRequest`, `ResponseOutparam`, etc.) | Web Standards (`Request`, `Response`, `Headers`) |
+| **Framework compatible** | No | Yes (Hono, itty-router, etc.) |
+| **Boilerplate** | More | Less |
+
+### Outgoing HTTP requests
+
+Components can make outgoing HTTP requests using the standard `fetch()` API, which is provided by [StarlingMonkey](#starlingmonkey) and backed by `wasi:http/outgoing-handler`:
+
+```typescript
+addEventListener('fetch', async (event) => {
+  const upstream = await fetch('https://api.example.com/data');
+  const data = await upstream.json();
+
+  event.respondWith(
+    new Response(JSON.stringify(data), {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+});
+```
+
+To make outgoing requests, your WIT world must import `wasi:http/outgoing-handler`:
+
+```wit
+world hello {
+    import wasi:http/outgoing-handler@0.2.3;
+    export wasi:http/incoming-handler@0.2.3;
+}
+```
+
+## Using Hono
+
+[Hono](https://hono.dev/) is a lightweight web framework built on Web Standards. Because it uses standard `Request`/`Response` objects rather than Node.js APIs, it works naturally inside Wasm components.
+
+### With `jco-std` (recommended)
+
+[`@bytecodealliance/jco-std`](https://www.npmjs.com/package/@bytecodealliance/jco-std) is a Bytecode Alliance library that provides standard adapters for building Wasm components in JavaScript, including a Hono adapter. This is the simplest way to use Hono with wasmCloud.
+
+```typescript title="src/index.ts"
+import { Hono } from 'hono';
+import { fire } from '@bytecodealliance/jco-std/wasi/0.2.6/http/adapters/hono/server';
+
+const app = new Hono();
+
+app.get('/', (c) => c.text('Hello from wasmCloud!'));
+app.get('/api/data', (c) => c.json({ message: 'This is some JSON data.' }));
+app.notFound((c) => c.json({ error: 'Not found' }, 404));
+
+fire(app);
+
+export { incomingHandler } from '@bytecodealliance/jco-std/wasi/0.2.6/http/adapters/hono/server';
+```
+
+The `fire()` function wires your Hono app to the Service Worker fetch event listener under the hood. The re-exported `incomingHandler` provides the Wasm component export that `jco componentize` expects.
+
+Install the dependencies:
+
+```shell
+npm install hono
+npm install -D @bytecodealliance/jco @bytecodealliance/componentize-js @bytecodealliance/jco-std
+```
+
+Because `jco-std` and Hono are npm packages with multiple modules, you need a bundler to produce a single JavaScript file for componentization. [Rolldown](https://rolldown.rs/), [Rollup](https://rollupjs.org/), [esbuild](https://esbuild.github.io/), and [Rsbuild](https://rsbuild.dev/) all work.
+
+### With the Service Worker pattern directly
+
+You can also wire Hono to the fetch event listener yourself, without `jco-std`:
+
+```typescript title="src/index.ts"
+/// <reference lib="WebWorker" />
+declare const self: ServiceWorkerGlobalScope;
+
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/', (c) => c.text('Hello from wasmCloud!'));
+app.get('/api/data', (c) => c.json({ message: 'This is some JSON data.' }));
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(app.fetch(event.request));
+});
+```
+
+This approach gives you more control — for example, you can inject WASI configuration values into the Hono context or add custom middleware.
+
+The wasmCloud TypeScript examples repository includes a [full http-service example built with Hono](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono).
+
+## Project structure
+
+A typical TypeScript component project looks like this:
+
+```
+my-component/
+├── .wash/
+│   └── config.yaml      # wash project configuration
+├── generated/
+│   └── types/           # Generated by `jco types` — TypeScript definitions from WIT
+├── src/
+│   └── index.ts         # Your application code
+├── wit/
+│   └── world.wit        # WIT world definition
+├── dist/                # Build output (JS and .wasm)
+├── package.json
+└── tsconfig.json
+```
+
+### WIT world
+
+The `wit/world.wit` file declares the interfaces your component exports and imports:
+
+```wit title="wit/world.wit"
+package wasmcloud:hello;
+
+world hello {
+  export wasi:http/incoming-handler@0.2.3;
+}
+```
+
+A component that exports `wasi:http/incoming-handler` is declaring that it can handle incoming HTTP requests. When you add imports (like `wasi:http/outgoing-handler` for outgoing `fetch()` calls, or `wasi:config/runtime` for configuration), `wash` automatically resolves the dependencies.
+
+:::info[WASI HTTP version]
+The `wasi:http/incoming-handler` version in your WIT world (here `@0.2.3`) must match the version supported by your `jco`/`componentize-js` toolchain. The version shown here matches the wasmCloud TypeScript project template. If you see build errors about missing exports, check that the version in your `world.wit` aligns with your installed `jco` version.
+:::
+
+### `.wash/config.yaml`
+
+TypeScript projects use a [project configuration file](../../../config.mdx) at `.wash/config.yaml` that tells `wash` how to build the component:
+
+```yaml title=".wash/config.yaml"
+build:
+  command: npm run install-and-build
+  component_path: dist/http-hello-world.wasm
+```
+
+The `command` field specifies the build command (which runs the scripts in your `package.json`) and `component_path` points to the compiled `.wasm` binary. For a full reference of configuration options, see the [Configuration](../../../config.mdx) page.
+
+### `package.json` build scripts
+
+A standard build pipeline has three steps:
+
+```json title="package.json"
+{
+  "scripts": {
+    "generate:types": "jco types wit/ -o generated/types",
+    "build:ts": "tsc",
+    "build:js": "jco componentize -w wit -o dist/my-component.wasm dist/my-component.js",
+    "build": "npm run generate:types && npm run build:ts && npm run build:js",
+    "install-and-build": "npm install && npm run build"
+  },
+  "devDependencies": {
+    "@bytecodealliance/jco": "^1.16.0",
+    "typescript": "^5.9.0"
+  }
+}
+```
+
+1. **`generate:types`** — `jco types` reads your WIT files and generates TypeScript type definitions into `generated/types/`. This gives you IDE autocompletion and type checking for WASI interfaces.
+2. **`build:ts`** — `tsc` compiles TypeScript to JavaScript.
+3. **`build:js`** — `jco componentize` takes the compiled JavaScript, embeds it with StarlingMonkey, and produces a `.wasm` component binary.
+
+If you use a bundler (for framework projects with npm dependencies), add a bundling step between `build:ts` and `build:js`.
+
+### `tsconfig.json`
+
+The key configuration is the `paths` mapping, which tells TypeScript how to resolve WASI import specifiers:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "paths": {
+      "wasi:http/types@0.2.3": ["./generated/types/interfaces/wasi-http-types.d.ts"]
+    },
+    "outDir": "./dist/",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+The `paths` entry maps `wasi:http/types@0.2.3` (the import specifier you use in your TypeScript code) to the generated type definition file. Without this, TypeScript cannot resolve the WASI imports at compile time.
+
+## Library compatibility
+
+### What works
+
+Libraries that target **Web Standards** — meaning they use `fetch()`, `Request`/`Response`, `URL`, `Headers`, `TextEncoder`, Streams, and similar APIs — generally work inside a Wasm component.
+
+Known compatible libraries include:
+
+- **[Hono](https://hono.dev/)** — web framework (officially supports WASI)
+- **[itty-router](https://github.com/kwhitley/itty-router)** — lightweight router
+- **[Axios](https://axios-http.com/)** — HTTP client (uses `fetch()` when available)
+- Pure computation libraries (parsers, validators, formatters) that don't depend on platform APIs
+
+### What does not work
+
+Currently, **Node.js APIs are not available** inside a Wasm component. Libraries that depend on Node.js built-in modules will not work:
+
+- `fs`, `path`, `os`, `child_process` — no Node.js built-ins
+- `require()` — no CommonJS (ESM only)
+- `Buffer` — use `Uint8Array` and `TextEncoder` instead
+- `process.env` — use `wasi:config/runtime` instead
+- `net`, `http`, `https` — use `fetch()` instead
+
+This rules out frameworks like Express.js (which depends on the Node.js `http` module), most database drivers, and anything that uses native addons.
+
+### Practical guidance
+
+- Prefer libraries designed for edge or serverless environments — they tend to use Web Standards rather than Node.js APIs
+- Use a bundler to combine your dependencies into a single JavaScript file before componentization
+- All imports must be statically resolvable — dynamic `import()` is not supported
+- WebSocket support is not yet available in StarlingMonkey
+
+## Building and running
+
+### Create a new project
+
+Use `wash new` to scaffold a TypeScript component project:
+
+```shell
+wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-hello-world-fetch --git-ref v2
+```
+
+For an HTTP service project with Hono:
+
+```shell
+wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-service-hono --git-ref v2
+```
+
+TypeScript templates for wasmCloud v2.x use standard `npm` commands for development loops and builds.
+
+### Development loop
+
+Start a development loop that watches for source changes, rebuilds, and re-runs the component:
+
+```shell
+npm run dev
+```
+
+TypeScript templates designed for wasmCloud v2 use [`nodemon`](https://nodemon.io/) to watch your `src/` directory and automatically re-run the build pipeline when files change. Under the hood, `npm run dev` runs `nodemon` which triggers `npm run build` on each change and serves the resulting component with `wash dev`.
+
+Send a request to test:
+
+```shell
+curl localhost:8000
+```
+
+### Build a component
+
+Compile your project to a `.wasm` binary:
+
+```shell
+npm run build
+```
+
+The compiled component is generated in the `dist/` directory by default. The output path is configured in your `package.json` build scripts.
+
+## Working with WASI interfaces
+
+These guides walk through adding WASI interfaces to a TypeScript component, using the [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template as a starting point:
+
+- [Key-Value Storage](./key-value-storage.mdx) — replace an in-memory data store with persistent key-value storage
+- [Blob Storage](./blob-storage.mdx) — use streaming blob storage for larger objects
+
+The patterns in these guides (declaring WIT imports, importing interfaces with `@ts-expect-error`, handling serialization) apply to any WASI interface you add to a TypeScript component.
+
+## Further reading
+
+- [Developer Guide](../../index.mdx?lang=typescript) — quickstart tutorial for creating, building, and running a TypeScript component
+- [wasmCloud TypeScript templates](https://github.com/wasmCloud/typescript/tree/main/templates) — project templates including http-client, http-service-hono, and more
+- [jco documentation](https://github.com/bytecodealliance/jco) — full reference for the JavaScript Component toolchain
+- [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS) — details on how JavaScript is compiled to Wasm components
+- [StarlingMonkey](https://github.com/bytecodealliance/StarlingMonkey) — the embedded JavaScript engine and its supported Web APIs
+- [Hono WASI guide](https://hono.dev/docs/getting-started/webassembly-wasi) — Hono's official documentation for WebAssembly/WASI
+- [Component Model: JavaScript](https://component-model.bytecodealliance.org/language-support/javascript.html) — Component Model documentation for JavaScript
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/versioned_docs/version-next/wash/developer-guide/language-support/typescript/key-value-storage.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/language-support/typescript/key-value-storage.mdx
@@ -1,0 +1,343 @@
+---
+title: "Key-Value Storage"
+sidebar_position: 0
+---
+
+You can add key-value capabilities to a component with the [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue/) interface.
+
+This guide walks through replacing the in-memory mock data store in the wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template with the `wasi:keyvalue` interface. You can use this guide as a model for implementing `wasi:keyvalue` in your own components or adding any new WIT interface to an existing component.
+
+## Overview
+
+The wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:keyvalue`, which gives the component persistent storage backed by a real key-value store. 
+
+:::info[]
+By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Key-Value NATS plugin](https://github.com/wasmCloud/wash/blob/main/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:keyvalue` with a different storage solution.
+:::
+
+Our changes will focus on two files:
+
+* `wit/world.wit` - Declare the new WIT imports 
+* `src/routes/items.ts` - Use the imported interfaces in application code
+
+No changes are needed to `rolldown.config.mjs`, `tsconfig.json`, `package.json`, or any other file.
+
+:::tip[Complete example]
+A full working example is available as a template:
+```bash
+wash new https://github.com/wasmCloud/typescript.git \
+  --name http-kv-service-hono \
+  --subfolder templates/http-kv-service-hono \
+  --git-ref v2
+```
+:::
+
+## Step 1: Declare the WIT imports in `wit/world.wit`
+
+Every capability your component uses must be declared in its WIT world. Open `wit/world.wit` and add `import` lines for the interfaces you need.
+
+```wit {4-5}
+package wasmcloud:templates@0.1.0;
+
+world typescript-http-service-hono {
+  import wasi:keyvalue/store@0.2.0-draft;
+  import wasi:keyvalue/atomics@0.2.0-draft;
+
+  export wasi:http/incoming-handler@0.2.6;
+}
+```
+
+### What these interfaces provide
+
+- **`wasi:keyvalue/store`** -- Bucket-based key-value storage with `open`, `get`, `set`, `delete`, `exists`, and `list-keys` operations.
+- **`wasi:keyvalue/atomics`** -- Atomic operations like `increment` on numeric values in a bucket.
+
+### How dependency resolution works
+
+When you run `npm run build`, the build pipeline calls `wkg wit fetch` as a setup step. This resolves the WIT package references (like `wasi:keyvalue`) and downloads their definitions into the `wit/deps/` directory automatically. You don't need to manually download any WIT files.
+
+The bundler (`rolldown`) is already configured with `external: /wasi:.*/` in `rolldown.config.mjs`, which tells it to leave all `wasi:*` imports as external -- they'll be resolved at component instantiation time, not at bundle time. This covers any new `wasi:` interface you add.
+
+## Step 2: Import and use the interface in TypeScript
+
+With the WIT world updated, you can now import functions from the new interfaces in your TypeScript code. The import paths match the WIT interface names exactly.
+
+### Importing WIT interfaces
+
+Add these imports at the top of `src/routes/items.ts`:
+
+```typescript
+// @ts-expect-error - JCO doesn't generate types for wasi:keyvalue yet
+import { open } from 'wasi:keyvalue/store@0.2.0-draft';
+// @ts-expect-error - JCO doesn't generate types for wasi:keyvalue yet
+import { increment } from 'wasi:keyvalue/atomics@0.2.0-draft';
+```
+
+**Why `@ts-expect-error`?** The `jco types` command generates `.d.ts` files for your WIT interfaces into `generated/types/`, but TypeScript can't resolve bare `wasi:` specifier imports against those files. The `@ts-expect-error` directive suppresses the resulting type error. The imports work correctly at runtime because `rolldown` marks them as external and `jco componentize` wires them up during Wasm component creation.
+
+### Key pattern: import path = WIT interface name
+
+The import path always matches the fully-qualified WIT interface name:
+
+```
+wasi:keyvalue/store@0.2.0-draft    -->  import { open } from 'wasi:keyvalue/store@0.2.0-draft'
+wasi:keyvalue/atomics@0.2.0-draft  -->  import { increment } from 'wasi:keyvalue/atomics@0.2.0-draft'
+```
+
+To discover which functions are available on an interface, look at the generated type file (e.g. `generated/types/interfaces/wasi-keyvalue-store.d.ts`) after running `npm run build` once, or read the WIT definition in `wit/deps/`.
+
+### Serialization: values are `Uint8Array`
+
+The `wasi:keyvalue/store` interface uses `list<u8>` (mapped to `Uint8Array` in JS) for values. To store structured data, you need to serialize and deserialize:
+
+```typescript
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function serializeItem(item: Item): Uint8Array {
+  return encoder.encode(JSON.stringify(item));
+}
+
+function deserializeItem(bytes: Uint8Array): Item {
+  return JSON.parse(decoder.decode(bytes));
+}
+```
+
+### Opening a bucket
+
+All key-value operations happen on a **bucket**. Open one with:
+
+```typescript
+function getBucket() {
+  return open('default');
+}
+```
+
+The `'default'` bucket is automatically provisioned by the wasmCloud runtime. Call `getBucket()` inside each route handler rather than at module scope -- the bucket handle should be obtained per-request.
+
+### Key namespacing
+
+Use a prefix to separate different kinds of data in the same bucket:
+
+```typescript
+const ITEM_PREFIX = 'item:';
+// Item keys: "item:1", "item:2", ...
+// Metadata keys: "next_id"
+```
+
+This prevents collisions between item data and metadata (like the ID counter).
+
+### Synchronous API
+
+All bucket operations (`get`, `set`, `delete`, `exists`, `listKeys`) and `increment` are **synchronous** in the JCO bindings. The WebAssembly component model uses blocking calls, so these don't return Promises. Your existing synchronous Hono route handlers work without modification.
+
+---
+
+## Step 3: Route-by-route changes
+
+Here is exactly what changed in each CRUD route handler, showing the before (in-memory `Map`) and after (`wasi:keyvalue` bucket).
+
+### Removed code
+
+The entire mock data store and its initialization were removed:
+
+```typescript
+// REMOVED: Simulated database
+const items = new Map<string, Item>();
+let nextId = 1;
+
+// REMOVED: Sample data initialization
+items.set('1', {
+  id: '1',
+  name: 'Sample Item',
+  description: 'This is a sample item',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+nextId = 2;
+```
+
+With persistent storage, the store starts empty and users create items via the API. Data survives component restarts.
+
+### GET `/` -- List all items
+
+**Before:**
+```typescript
+itemsRouter.get('/', (c) => {
+  const itemList = Array.from(items.values());
+  // ... filtering and pagination ...
+});
+```
+
+**After:**
+```typescript
+itemsRouter.get('/', (c) => {
+  const bucket = getBucket();
+  const keys = bucket.listKeys(undefined) as { keys: string[] };
+  const itemKeys = keys.keys.filter((k: string) => k.startsWith(ITEM_PREFIX));
+
+  const itemList: Item[] = [];
+  for (const key of itemKeys) {
+    const bytes = bucket.get(key);
+    if (bytes) {
+      itemList.push(deserializeItem(bytes));
+    }
+  }
+  // ... filtering and pagination unchanged ...
+});
+```
+
+`listKeys(undefined)` returns all keys in the bucket. We filter for the `item:` prefix, then fetch and deserialize each item.
+
+### GET `/:id` -- Get single item
+
+**Before:**
+```typescript
+const item = items.get(id);
+if (!item) { /* 404 */ }
+return c.json(item);
+```
+
+**After:**
+```typescript
+const bucket = getBucket();
+const bytes = bucket.get(`${ITEM_PREFIX}${id}`);
+if (!bytes) { /* 404 */ }
+return c.json(deserializeItem(bytes));
+```
+
+`bucket.get()` returns `Uint8Array | undefined`. If the key doesn't exist, it returns `undefined`.
+
+### POST `/` -- Create new item
+
+**Before:**
+```typescript
+const id = String(nextId++);
+// ... build newItem ...
+items.set(id, newItem);
+```
+
+**After:**
+```typescript
+const bucket = getBucket();
+const id = String(increment(bucket, 'next_id', 1n));
+// ... build newItem ...
+bucket.set(`${ITEM_PREFIX}${id}`, serializeItem(newItem));
+```
+
+`increment(bucket, 'next_id', 1n)` atomically increments the `next_id` key by 1 and returns the new value (as a `bigint`). On first call the key is created starting at 0, so the first returned ID is `1`. This is persistent and atomic -- safe even if multiple instances of the component are running.
+
+### PUT `/:id` -- Update item
+
+**Before:**
+```typescript
+const existing = items.get(id);
+if (!existing) { /* 404 */ }
+// ... build updated ...
+items.set(id, updated);
+```
+
+**After:**
+```typescript
+const bucket = getBucket();
+const bytes = bucket.get(`${ITEM_PREFIX}${id}`);
+if (!bytes) { /* 404 */ }
+const existing = deserializeItem(bytes);
+// ... build updated ...
+bucket.set(`${ITEM_PREFIX}${id}`, serializeItem(updated));
+```
+
+### DELETE `/:id` -- Delete item
+
+**Before:**
+```typescript
+if (!items.has(id)) { /* 404 */ }
+items.delete(id);
+```
+
+**After:**
+```typescript
+const bucket = getBucket();
+if (!bucket.exists(`${ITEM_PREFIX}${id}`)) { /* 404 */ }
+bucket.delete(`${ITEM_PREFIX}${id}`);
+```
+
+`bucket.exists()` returns a boolean. `bucket.delete()` removes the key.
+
+## Build and verify
+
+### Build
+
+```bash
+npm run build
+```
+
+This runs the full pipeline:
+1. `wash wit fetch` -- downloads `wasi:keyvalue` WIT definitions into `wit/deps/`
+2. `jco types` -- generates TypeScript type definitions in `generated/types/`
+3. `rolldown` -- bundles TypeScript into `dist/component.js` (leaving `wasi:` imports external)
+4. `jco componentize` -- compiles `dist/component.js` into `dist/http_service_hono.wasm`
+
+### Run
+
+```bash
+npm run dev
+```
+
+This starts `wash dev`, which automatically provisions a NATS-KV keyvalue provider to satisfy the `wasi:keyvalue` imports.
+
+### Test
+
+```bash
+# Create an item
+curl -X POST http://localhost:8000/api/items \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test Item","description":"Testing keyvalue"}'
+
+# List items
+curl http://localhost:8000/api/items
+
+# Get by ID
+curl http://localhost:8000/api/items/1
+
+# Update
+curl -X PUT http://localhost:8000/api/items/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Updated Item"}'
+
+# Delete
+curl -X DELETE http://localhost:8000/api/items/1
+```
+
+To verify persistence, restart the component and confirm previously created items are still returned by `GET /api/items`.
+
+## Summary: checklist for adding any WIT interface
+
+1. **Add `import` lines to `wit/world.wit`** for the interfaces you need.
+2. **Run `npm run build` once** so `wash wit fetch` downloads the WIT definitions and `jco types` generates TypeScript types you can reference.
+3. **Import functions in TypeScript** using the exact WIT interface name as the import path, with `@ts-expect-error` to suppress the type error.
+4. **Use the imported functions** in your route handlers. Remember that WASM component model calls are synchronous.
+5. **Handle serialization** -- most WIT interfaces use `Uint8Array` for binary data; use `TextEncoder`/`TextDecoder` and `JSON.stringify`/`JSON.parse` for structured data.
+6. **No bundler changes needed** -- `rolldown.config.mjs` already externalizes all `wasi:*` imports.
+7. **No new npm dependencies needed** -- WIT interfaces are provided by the runtime, not by npm packages.
+8. **Update documentation** to reflect the new capability.
+
+---
+
+## API reference: `wasi:keyvalue` operations used
+
+| Operation | Signature | Description |
+|-----------|-----------|-------------|
+| `open(name)` | `(string) => Bucket` | Open a named bucket |
+| `bucket.get(key)` | `(string) => Uint8Array \| undefined` | Get a value by key |
+| `bucket.set(key, value)` | `(string, Uint8Array) => void` | Set a key to a value |
+| `bucket.delete(key)` | `(string) => void` | Delete a key |
+| `bucket.exists(key)` | `(string) => boolean` | Check if a key exists |
+| `bucket.listKeys(cursor)` | `(bigint \| undefined) => { keys: string[] }` | List all keys in the bucket |
+| `increment(bucket, key, delta)` | `(Bucket, string, bigint) => bigint` | Atomically increment a numeric key |
+
+## Further reading
+
+- [TypeScript Language Guide](../index.mdx) — toolchain overview, HTTP patterns, framework integration, and library compatibility
+- [Blob Storage](./blob-storage.mdx) — Add streaming blob storage for larger objects
+- [Language Support overview](../../index.mdx) — summary of all supported languages and toolchains

--- a/versioned_docs/version-next/wash/developer-guide/useful-webassembly-tools.mdx
+++ b/versioned_docs/version-next/wash/developer-guide/useful-webassembly-tools.mdx
@@ -81,3 +81,27 @@ WAC requires [Cargo](https://doc.rust-lang.org/cargo/getting-started/installatio
 ```shell
 cargo install wac-cli
 ```
+
+## Claude Code skills for WebAssembly development
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) users can install skills that give Claude specialized knowledge about WebAssembly component development and the `wash` CLI. Skills are reusable expertise files that Claude loads on demand.
+
+### WebAssembly Component Development
+
+The [`webassembly-component-development`](https://github.com/cosmonic-labs/skills/tree/main/webassembly-component-development) skill provides guidance on WASI fundamentals, component composition patterns, language interoperability, runtime compatibility, and troubleshooting.
+
+Install it with:
+
+```shell
+claude skill install cosmonic-labs/skills/webassembly-component-development
+```
+
+### wash CLI
+
+The [`wash`](https://github.com/cosmonic-labs/skills/tree/main/wash) skill provides expertise on the wasmCloud Shell CLI — building, running, and managing WebAssembly components and wasmCloud applications.
+
+Install it with:
+
+```shell
+claude skill install cosmonic-labs/skills/wash
+```

--- a/versioned_docs/version-next/wash/faq.mdx
+++ b/versioned_docs/version-next/wash/faq.mdx
@@ -31,7 +31,6 @@ The table below outlines major differences in versions:
 | Pull a component OCI artifact from a registry    | Yes, with `wash oci pull`          | Yes, with `wash pull`              | Wasm Shell uses the `oras` library&mdash;learn more in the Registries docs        |
 | Extend `wash` via component plugin               | Yes, with `wash plugin`            | Limited experimental support       |                                                                                   |
 | Self-update `wash`                               | Yes, with `wash update`            | No                                 |                                                                                   |
-| Check for component development dependencies     | Yes, with `wash doctor`            | No                                 |                                                                                   |
 | Inspect a component's WIT                        | Yes, with `wash inspect`           | Yes, with `wash inspect`           |                                                                                   |
 | Create a wasmCloud capability provider           | No                                 | Yes, with `wash new provider`      | The capability provider model is being overhauled&mdash;learn more in the Roadmap |
 | Run a wasmCloud host                             | Yes, with `wash host`              | Yes, with `wash up`                |                                                                                   |
@@ -46,17 +45,33 @@ If you've updated `wash`, changes to WIT may be acting as a breaking change. To 
 
 ### Building with TinyGo
 
-**Do I need to use a configuration file for TinyGo builds?**
+**How do I set up a TinyGo project for `wash build`?**
 
-Yes. TinyGo builds require a configuration file that is stored in a `.wash` subfolder of your project directory. This file is required in order to specify the WIT world used by the component.
+TinyGo projects use a `Makefile` to wrap the build steps and a `.wash/config.yaml` file to tell `wash` which commands to run.
 
-If you attempt to build without a configuration file, `wash` will create a `config.yaml` file at `./.wash/config.yaml` and return this message:
+Your `.wash/config.yaml` should specify the build command:
 
-```text
-TinyGo builds require wit_world to be specified in the configuration. A config file has been created at ./.wash/config.yaml with a placeholder. Please update the wit_world field to match your WIT world name.
+```yaml
+dev:
+  command: make build
+
+build:
+  command: make bindgen build
 ```
 
-For instructions on configuring a TinyGo build, see [Configuration](./config.mdx).
+Your `Makefile` invokes TinyGo directly with the `-wit-package` and `-wit-world` flags:
+
+```makefile
+.PHONY: build
+build:
+	tinygo build -target wasip2 -wit-package ./wit -wit-world hello -o my-component.wasm ./
+
+.PHONY: bindgen
+bindgen:
+	go generate ./...
+```
+
+For full instructions, see the [Go (TinyGo) Language Guide](./developer-guide/language-support/go/index.mdx).
 
 #### Common issues with TinyGo builds
 

--- a/versioned_docs/version-next/wash/images/build-pipeline-go.svg
+++ b/versioned_docs/version-next/wash/images/build-pipeline-go.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 310" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, sans-serif; }
+    .box { rx: 8; ry: 8; }
+    .label { font-size: 14px; fill: #1a1a2e; font-weight: 600; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .arrow { stroke: #9ca3af; stroke-width: 2; marker-end: url(#arrowhead); }
+    .cmd { font-size: 11px; fill: #7c3aed; font-family: ui-monospace, monospace; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#9ca3af"/>
+    </marker>
+  </defs>
+
+  <!-- Go source box -->
+  <rect class="box" x="140" y="20" width="200" height="44" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text class="label" x="240" y="40" text-anchor="middle">Go source</text>
+  <text class="sublabel" x="240" y="54" text-anchor="middle">.go</text>
+
+  <!-- Arrow 1 -->
+  <line class="arrow" x1="240" y1="64" x2="240" y2="126"/>
+  <text class="cmd" x="252" y="92">make bindgen</text>
+  <text class="sublabel" x="252" y="106">(go generate → wit-bindgen-go)</text>
+
+  <!-- Generated bindings box -->
+  <rect class="box" x="140" y="130" width="200" height="44" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text class="label" x="240" y="150" text-anchor="middle">Generated bindings</text>
+  <text class="sublabel" x="240" y="164" text-anchor="middle">gen/</text>
+
+  <!-- Arrow 2 -->
+  <line class="arrow" x1="240" y1="174" x2="240" y2="236"/>
+  <text class="cmd" x="252" y="202">make build</text>
+  <text class="sublabel" x="252" y="216">(tinygo build -target wasip2)</text>
+
+  <!-- Wasm component box -->
+  <rect class="box" x="140" y="240" width="200" height="44" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text class="label" x="240" y="260" text-anchor="middle">WebAssembly Component</text>
+  <text class="sublabel" x="240" y="274" text-anchor="middle">.wasm</text>
+</svg>

--- a/versioned_docs/version-next/wash/images/build-pipeline-rust.svg
+++ b/versioned_docs/version-next/wash/images/build-pipeline-rust.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 200" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, sans-serif; }
+    .box { rx: 8; ry: 8; }
+    .label { font-size: 14px; fill: #1a1a2e; font-weight: 600; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .arrow { stroke: #9ca3af; stroke-width: 2; marker-end: url(#arrowhead); }
+    .cmd { font-size: 11px; fill: #7c3aed; font-family: ui-monospace, monospace; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#9ca3af"/>
+    </marker>
+  </defs>
+
+  <!-- Rust source box -->
+  <rect class="box" x="140" y="20" width="200" height="44" fill="#fff7ed" stroke="#f97316" stroke-width="1.5"/>
+  <text class="label" x="240" y="40" text-anchor="middle">Rust source</text>
+  <text class="sublabel" x="240" y="54" text-anchor="middle">.rs</text>
+
+  <!-- Arrow -->
+  <line class="arrow" x1="240" y1="64" x2="240" y2="126"/>
+  <text class="cmd" x="252" y="100">cargo build --target wasm32-wasip2</text>
+
+  <!-- Wasm component box -->
+  <rect class="box" x="140" y="130" width="200" height="44" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text class="label" x="240" y="150" text-anchor="middle">WebAssembly Component</text>
+  <text class="sublabel" x="240" y="164" text-anchor="middle">.wasm</text>
+</svg>

--- a/versioned_docs/version-next/wash/images/build-pipeline-typescript.svg
+++ b/versioned_docs/version-next/wash/images/build-pipeline-typescript.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 420" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, sans-serif; }
+    .box { rx: 8; ry: 8; }
+    .label { font-size: 14px; fill: #1a1a2e; font-weight: 600; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .arrow { stroke: #9ca3af; stroke-width: 2; marker-end: url(#arrowhead); }
+    .cmd { font-size: 11px; fill: #7c3aed; font-family: ui-monospace, monospace; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#9ca3af"/>
+    </marker>
+  </defs>
+
+  <!-- TypeScript source box -->
+  <rect class="box" x="150" y="20" width="220" height="44" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text class="label" x="260" y="40" text-anchor="middle">TypeScript source</text>
+  <text class="sublabel" x="260" y="54" text-anchor="middle">.ts</text>
+
+  <!-- Arrow 1 -->
+  <line class="arrow" x1="260" y1="64" x2="260" y2="126"/>
+  <text class="cmd" x="272" y="100">tsc</text>
+
+  <!-- JavaScript box -->
+  <rect class="box" x="150" y="130" width="220" height="44" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text class="label" x="260" y="150" text-anchor="middle">JavaScript</text>
+  <text class="sublabel" x="260" y="164" text-anchor="middle">.js</text>
+
+  <!-- Arrow 2 -->
+  <line class="arrow" x1="260" y1="174" x2="260" y2="236"/>
+  <text class="cmd" x="272" y="200">bundler</text>
+  <text class="sublabel" x="272" y="214">(optional — rollup, rolldown, esbuild)</text>
+
+  <!-- Bundled JS box -->
+  <rect class="box" x="150" y="240" width="220" height="44" fill="#fefce8" stroke="#eab308" stroke-width="1.5"/>
+  <text class="label" x="260" y="260" text-anchor="middle">Bundled JavaScript</text>
+  <text class="sublabel" x="260" y="274" text-anchor="middle">.js</text>
+
+  <!-- Arrow 3 -->
+  <line class="arrow" x1="260" y1="284" x2="260" y2="346"/>
+  <text class="cmd" x="272" y="310">jco componentize</text>
+  <text class="sublabel" x="272" y="324">(ComponentizeJS + StarlingMonkey)</text>
+
+  <!-- Wasm component box -->
+  <rect class="box" x="150" y="350" width="220" height="44" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5"/>
+  <text class="label" x="260" y="370" text-anchor="middle">WebAssembly Component</text>
+  <text class="sublabel" x="260" y="384" text-anchor="middle">.wasm</text>
+</svg>

--- a/versioned_docs/version-next/wash/index.mdx
+++ b/versioned_docs/version-next/wash/index.mdx
@@ -30,8 +30,7 @@ On a successful installation, the script will return:
 [INFO] Next steps:
   1. Add /path/to to your PATH if not already included
   2. Run 'wash --help' to see available commands
-  3. Run 'wash doctor' to verify your environment
-  4. Run 'wash new' to create your first WebAssembly component
+  3. Run 'wash new' to create your first WebAssembly component
 ```
 
 Add `wash` to your PATH with the filepath listed in Step 1, replacing `/path/to` with your local filepath:
@@ -52,8 +51,7 @@ iwr -useb https://raw.githubusercontent.com/wasmcloud/wash/refs/heads/main/insta
 Next steps:
   1. Add /path/to to your PATH if not already included
   2. Run 'wash --help' to see available commands
-  3. Run 'wash doctor' to verify your environment
-  4. Run 'wash new' to create your first WebAssembly component
+  3. Run 'wash new' to create your first WebAssembly component
 ```
 
 To add `wash` to your PATH by updating your PowerShell profile, add the filepath for `wash` returned above to your profile, replacing `/path/to` with your local filepath:
@@ -87,12 +85,6 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
 :::note[]
 This quick command tour requires the [Rust toolchain](https://www.rust-lang.org/tools/install) and the `wasm32-wasip2` target for Rust: `rustup target add wasm32-wasip2`
 :::
-
-Check your environment for component development dependencies:
-
-   ```shell
-   wash doctor
-   ```
 
 Create a new component and navigate to the project directory:
 


### PR DESCRIPTION
This PR adds: 

* Language Support section, under which are organized: 
  - Language Guides for TypeScript, Rust, and Go
 * TypeScript subpages on working with WASI Key-Value and Blobstore interfaces
 * Debugging page.

In addition to the above new pages, there are a number of updates to existing pages that bring them in line with existing material.