### PR TITLE
update kind config path

### DIFF
--- a/versioned_docs/version-next/installation.mdx
+++ b/versioned_docs/version-next/installation.mdx
@@ -104,7 +104,7 @@ You'll also need a Kubernetes environment. We recommend [`kind`](https://kind.si
 You can use the one-liner below to start a `kind` cluster with a configuration from the [`wasmCloud/wasmCloud`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/kind-config.yaml) repository. 
 
 ```shell
-curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/kind-config.yaml && kind create cluster --config=kind-config.yaml && rm kind-config.yaml
+curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/deploy/kind/kind-config.yaml && kind create cluster --config=kind-config.yaml && rm kind-config.yaml
 ```
 
 ### Install the wasmCloud operator


### PR DESCRIPTION
Kind config was moved to `/deploy/kind`. This updates the documentation to reflect the new path.

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
