### PR TITLE
updating docs v2.0.2

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,7 +22,7 @@ Install the parts of the [wasmCloud platform](./overview/index.mdx) that you nee
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.1`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -66,7 +66,7 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.1`**):
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -108,7 +108,7 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-Verify that `wash` is properly installed and check your version for **`2.0.1`** with:
+Verify that `wash` is properly installed and check your version for **`2.0.2`** with:
 
 ```bash
 wash -V
@@ -138,7 +138,7 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
 Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml):
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
 Verify the deployment:

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -100,7 +100,7 @@ Use Helm to install the wasmCloud operator from an OCI chart image:
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -111,7 +111,7 @@ helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the Runtime Gateway as a NodePort service on port 30950, which the kind cluster config maps to host port 80:
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -121,7 +121,7 @@ helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3d supports `LoadBalancer` services natively, so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -132,7 +132,7 @@ helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3s includes a built-in load balancer (Klipper), so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```

--- a/docs/kubernetes-operator/operator-manual/cicd.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd.mdx
@@ -29,7 +29,7 @@ The [`setup-wash-action`](https://github.com/wasmCloud/setup-wash-action) instal
 ```yaml
 - uses: wasmCloud/setup-wash-action@main
   with:
-    wash-version: "v2.0.1"    # version to install (default: v2.0.1)
+    wash-version: "v2.0.2"    # version to install (default: v2.0.2)
 ```
 
 ### setup-wash-cargo-auditable

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -29,9 +29,9 @@ The K3s setup (`deploy/k3s` in the `wasmCloud/wasmCloud` repository) runs five c
 |---------|-------|-------------|
 | `kubernetes` | `rancher/k3s` | K3s Kubernetes control plane |
 | `nats` | `nats:2-alpine` | NATS with JetStream (messaging backbone and object storage) |
-| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.1` | wasmCloud operator (watches CRDs, schedules workloads) |
-| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.1` | HTTP ingress — routes requests to workloads (port 80) |
-| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.1` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
+| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.2` | wasmCloud operator (watches CRDs, schedules workloads) |
+| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.2` | HTTP ingress — routes requests to workloads (port 80) |
+| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.2` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
 
 The `kubernetes` container automatically loads wasmCloud CRDs from the operator chart on first start, and writes a kubeconfig to `tmp/kubeconfig.yaml` for local use.
 
@@ -151,7 +151,7 @@ To scale out, add additional `wash-host` entries to `docker-compose.yml`:
 
 ```yaml
   wash-host-2:
-    image: ghcr.io/wasmcloud/wash:2.0.1
+    image: ghcr.io/wasmcloud/wash:2.0.2
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host-2
     depends_on:
       nats:

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -27,11 +27,11 @@ helm show values oci://ghcr.io/wasmcloud/charts/runtime-operator --version <vers
 ```
 :::
 
-For example, with version `2.0.1`, the images are:
+For example, with version `2.0.2`, the images are:
 
-- `ghcr.io/wasmcloud/runtime-operator:2.0.1`
-- `ghcr.io/wasmcloud/runtime-gateway:2.0.1`
-- `ghcr.io/wasmcloud/wash:2.0.1`
+- `ghcr.io/wasmcloud/runtime-operator:2.0.2`
+- `ghcr.io/wasmcloud/runtime-gateway:2.0.2`
+- `ghcr.io/wasmcloud/wash:2.0.2`
 - `docker.io/nats:2.11.3-alpine`
 
 If you disable the built-in NATS server (`--set nats.enabled=false`), you do not need to mirror the NATS image.
@@ -51,12 +51,12 @@ Create a `mirror.yaml` file listing the source and destination for each image. R
 ```yaml
 images:
   # wasmCloud runtime images
-  - source: ghcr.io/wasmcloud/runtime-operator:2.0.1
-    destination: myregistry/wasmcloud/runtime-operator:2.0.1
-  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.1
-    destination: myregistry/wasmcloud/runtime-gateway:2.0.1
-  - source: ghcr.io/wasmcloud/wash:2.0.1
-    destination: myregistry/wasmcloud/wash:2.0.1
+  - source: ghcr.io/wasmcloud/runtime-operator:2.0.2
+    destination: myregistry/wasmcloud/runtime-operator:2.0.2
+  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.2
+    destination: myregistry/wasmcloud/runtime-gateway:2.0.2
+  - source: ghcr.io/wasmcloud/wash:2.0.2
+    destination: myregistry/wasmcloud/wash:2.0.2
 
   # Third-party images
   - source: docker.io/nats:2.11.3-alpine
@@ -100,7 +100,7 @@ The Helm chart provides a `global.image.registry` value that overrides the regis
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   --create-namespace \
   --set global.image.registry="myregistry"
@@ -124,7 +124,7 @@ Then install with the pull secret:
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   --create-namespace \
   --set global.image.registry="myregistry" \
@@ -137,7 +137,7 @@ If you need to mirror images to different registry paths, you can override each 
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   --create-namespace \
   --set operator.image.registry="myregistry" \
@@ -154,7 +154,7 @@ If your organization uses a GitOps workflow or requires manifests to be reviewed
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
@@ -166,7 +166,7 @@ Write the rendered manifests to a directory for review or to check into version 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret" \
@@ -185,7 +185,7 @@ After rendering, you can verify that all image references point to your private 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   | grep "image:"
@@ -209,7 +209,7 @@ Then reference it with `-f`:
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.1 \
+  --version 2.0.2 \
   --namespace wasmcloud \
   -f my-values.yaml
 ```
@@ -258,7 +258,7 @@ These are the image-related values you can configure:
 | `gateway.image.repository` | `wasmcloud/runtime-gateway` | Gateway image repository |
 | `runtime.image.registry` | `ghcr.io` | Runtime host image registry |
 | `runtime.image.repository` | `wasmcloud/wash` | Runtime host image repository |
-| `runtime.image.tag` | `2.0.1` | Runtime host image tag |
+| `runtime.image.tag` | `2.0.2` | Runtime host image tag |
 | `nats.image.registry` | `docker.io` | NATS image registry |
 | `nats.image.repository` | `nats` | NATS image repository |
 | `nats.image.tag` | `2.11.3-alpine` | NATS image tag |

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -232,7 +232,7 @@ Use Helm to install the wasmCloud operator:
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -243,7 +243,7 @@ helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the Runtime Gateway as a NodePort service on port 30950, which the kind cluster config maps to host port 80:
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -253,7 +253,7 @@ helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3d supports `LoadBalancer` services natively, so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -264,7 +264,7 @@ helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3s includes a built-in load balancer (Klipper), so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.1 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -21,7 +21,7 @@ Components are compiled from your language of choice—Rust, TypeScript, Go, and
 
 ## Install `wash`
 
-First, we need to install the latest version of `wash` (**`2.0.1`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
+First, we need to install the latest version of `wash` (**`2.0.2`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
 
 <Tabs groupId="os" queryString>
   <TabItem value="macoslinux" label="macOS and Linux" default>
@@ -30,7 +30,7 @@ First, we need to install the latest version of `wash` (**`2.0.1`**). If you've 
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.1`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -74,7 +74,7 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.1`**):
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -116,13 +116,13 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.1`** with:
+In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.2`** with:
 
 ```bash
 wash -V
 ```
 
-If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.1`.
+If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.2`.
 Run `wash --help` to see all available commands and short descriptions for each.
 
 ## Choose your language


### PR DESCRIPTION
## Feature or Problem
The runtime operator and wash are now both at 2.0.2; updating the common set of docs to ensure people are on the correct version.

`wash --version
wash 2.0.2
`