### PR TITLE
chore(docs): remove v2 git-refs for TS examples

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -69,7 +69,7 @@ A minimal HTTP server component using the [Hono](https://hono.dev/) web framewor
 - **Interfaces**: Exports `wasi:http/incoming-handler@0.2.6`
 
 ```shell title="Create from template"
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-hello-world-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-hello-world-hono
 ```
 
 #### HTTP Hello World (Fetch API)
@@ -80,7 +80,7 @@ A minimal HTTP server component using the Service Worker [Fetch API](https://dev
 - **Interfaces**: Exports `wasi:http/incoming-handler@0.2.3`
 
 ```shell title="Create from template"
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-hello-world-fetch --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-hello-world-fetch
 ```
 
 #### HTTP Client
@@ -91,7 +91,7 @@ An HTTP proxy component that makes outgoing HTTP requests. Supports GET, POST, P
 - **Interfaces**: Imports `wasi:http/outgoing-handler@0.2.3`; exports `wasi:http/incoming-handler@0.2.3`
 
 ```shell title="Create from template"
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-client --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-client
 ```
 
 #### HTTP Service (Hono)
@@ -102,7 +102,7 @@ A full-featured HTTP service component using Hono, demonstrating middleware patt
 - **Interfaces**: Exports `wasi:http/incoming-handler@0.2.3`
 
 ```shell title="Create from template"
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-service-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-service-hono
 ```
 
 #### HTTP Service with Blob Storage (Hono)
@@ -113,7 +113,7 @@ An HTTP service component using Hono, backed by `wasi:blobstore` for persistent 
 - **Interfaces**: Imports `wasi:blobstore/blobstore@0.2.0-draft`; exports `wasi:http/incoming-handler@0.2.6`
 
 ```shell title="Create from template"
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-blobstore-service-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-blobstore-service-hono
 ```
 
 #### HTTP Service with Key-Value Storage (Hono)
@@ -124,7 +124,7 @@ An HTTP service component using Hono, backed by `wasi:keyvalue` for persistent k
 - **Interfaces**: Imports `wasi:keyvalue/store@0.2.0-draft`, `wasi:keyvalue/atomics@0.2.0-draft`; exports `wasi:http/incoming-handler@0.2.6`
 
 ```shell title="Create from template"
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-kv-service-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-kv-service-hono
 ```
 
 ## Examples

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -433,7 +433,7 @@ Hello from Rust!
 In your terminal, run:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name http-hello-world --subfolder templates/http-hello-world-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name http-hello-world --subfolder templates/http-hello-world-hono
 ```
 
 This command...

--- a/docs/wash/developer-guide/index.mdx
+++ b/docs/wash/developer-guide/index.mdx
@@ -69,7 +69,7 @@ Let's create a component that accepts an HTTP request and responds with "Hello f
 Use `wash new` to create a new component project from a template:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name hello --subfolder templates/http-hello-world-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --name hello --subfolder templates/http-hello-world-hono
 ```
 
 This command...

--- a/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
@@ -30,7 +30,7 @@ A full working example is available as a template:
 wash new https://github.com/wasmCloud/typescript.git \
   --name http-blobstore-service-hono \
   --subfolder templates/http-blobstore-service-hono \
-  --git-ref v2
+ 
 ```
 :::
 

--- a/docs/wash/developer-guide/language-support/typescript/index.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/index.mdx
@@ -344,13 +344,13 @@ This rules out frameworks like Express.js (which depends on the Node.js `http` m
 Use `wash new` to scaffold a TypeScript component project:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-hello-world-fetch --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-hello-world-fetch
 ```
 
 For an HTTP service project with Hono:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-service-hono --git-ref v2
+wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-service-hono
 ```
 
 TypeScript templates for wasmCloud v2.x use standard `npm` commands for development loops and builds.

--- a/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
@@ -28,7 +28,7 @@ A full working example is available as a template:
 wash new https://github.com/wasmCloud/typescript.git \
   --name http-kv-service-hono \
   --subfolder templates/http-kv-service-hono \
-  --git-ref v2
+ 
 ```
 :::
 


### PR DESCRIPTION
Remove v2 git-refs now that v2 has moved to main