### PR TITLE
fix(homepage): implement light mode theme support

### DIFF
--- a/src/pages/_components/section/styles.module.css
+++ b/src/pages/_components/section/styles.module.css
@@ -97,3 +97,59 @@
   --section-button-background: var(--wasmcloud-color-brand-green);
   --section-button-color: var(--wasmcloud-color-brand-space-blue);
 }
+
+/* light theme */
+
+:global(html[data-theme='light']) .section {
+  --section-color-foreground: var(--wasmcloud-color-brand-space-blue);
+  --section-color-background: #ffffff;
+  --section-color-highlight: var(--wasmcloud-color-brand-green);
+  --section-button-background: var(--wasmcloud-color-brand-green);
+  --section-button-color: var(--wasmcloud-color-brand-space-blue);
+}
+
+:global(html[data-theme='light']) .section:global(.section--light-gray) {
+  --section-color-foreground: var(--wasmcloud-color-brand-space-blue);
+  --section-color-background: #f4f7f8;
+  --section-color-highlight: var(--wasmcloud-color-brand-green);
+  --section-button-background: var(--wasmcloud-color-brand-green);
+  --section-button-color: var(--wasmcloud-color-brand-space-blue);
+  --section-color-link: color-mix(
+    in oklch increasing hue,
+    var(--section-color-highlight) 40%,
+    var(--section-color-foreground) 60%
+  );
+}
+
+:global(html[data-theme='light']) .section:global(.section--dark-gray) {
+  --section-color-foreground: var(--wasmcloud-color-brand-space-blue);
+  --section-color-background: #e8eef1;
+  --section-color-highlight: var(--wasmcloud-color-brand-green-dark);
+  --section-button-background: var(--wasmcloud-color-brand-green);
+  --section-button-color: var(--wasmcloud-color-brand-space-blue);
+}
+
+:global(html[data-theme='light']) .section:global(.section--green) {
+  --section-color-foreground: var(--wasmcloud-color-brand-space-blue);
+  --section-color-background: var(--wasmcloud-color-brand-green);
+  --section-color-highlight: var(--wasmcloud-color-brand-space-blue-light);
+  --section-button-background: var(--wasmcloud-color-brand-space-blue);
+  --section-button-color: var(--wasmcloud-color-brand-green);
+  --section-color-link: var(--section-color-foreground);
+}
+
+:global(html[data-theme='light']) .section:global(.section--space-blue) {
+  --section-color-foreground: var(--wasmcloud-color-brand-space-blue);
+  --section-color-background: #dfe8ef;
+  --section-color-highlight: var(--wasmcloud-color-brand-green-dark);
+  --section-button-background: var(--wasmcloud-color-brand-green);
+  --section-button-color: var(--wasmcloud-color-brand-space-blue);
+}
+
+:global(html[data-theme='light']) .section:global(.section--yellow) {
+  --section-color-foreground: var(--wasmcloud-color-brand-space-blue);
+  --section-color-background: var(--wasmcloud-color-brand-yellow);
+  --section-color-highlight: var(--wasmcloud-color-brand-green);
+  --section-button-background: var(--wasmcloud-color-brand-space-blue);
+  --section-button-color: var(--wasmcloud-color-brand-yellow);
+}

--- a/src/pages/_index/_components/cncf/cncf.module.css
+++ b/src/pages/_index/_components/cncf/cncf.module.css
@@ -5,3 +5,15 @@
 .cncf h3 {
     font-size: 1.5rem;
 }
+
+.cncf .logoLight {
+  display: none;
+}
+
+:global(html[data-theme='light']) .cncf .logoDark {
+  display: none;
+}
+
+:global(html[data-theme='light']) .cncf .logoLight {
+  display: block;
+}

--- a/src/pages/_index/_components/cncf/index.tsx
+++ b/src/pages/_index/_components/cncf/index.tsx
@@ -16,7 +16,16 @@ function Cncf({}: Props) {
             wasmCloud is a <Link href="https://www.cncf.io/">Cloud Native Computing Foundation</Link> Incubating project
           </p>
         </SectionHeading>
-        <img src="/pages/home/cncf/cncf-white.svg" alt="Cloud Native Computing Foundation" />
+        <img
+          src="/pages/home/cncf/cncf-white.svg"
+          alt="Cloud Native Computing Foundation"
+          className={styles.logoDark}
+        />
+        <img
+          src="/pages/home/cncf/cncf-color.svg"
+          alt="Cloud Native Computing Foundation"
+          className={styles.logoLight}
+        />
       </SectionContent>
     </Section>
   );

--- a/src/pages/_index/_components/hero/styles.module.css
+++ b/src/pages/_index/_components/hero/styles.module.css
@@ -118,3 +118,23 @@
     left: 5%;
   }
 }
+
+/* light theme */
+:global(html[data-theme='light']) .hero {
+  background-image: radial-gradient(
+      ellipse 50% 80% at 50% 0%,
+      rgba(var(--wasmcloud-color-base-brand-green) / 0.25) 0%,
+      rgba(var(--wasmcloud-color-base-brand-green) / 0.15) 33%,
+      rgba(var(--wasmcloud-color-base-brand-green) / 0.06) 66%,
+      rgba(var(--wasmcloud-color-base-brand-green) / 0) 100%
+    ),
+    linear-gradient(to bottom, #f0faf6, #ffffff);
+}
+
+:global(html[data-theme='light']) .content {
+  color: var(--wasmcloud-color-brand-space-blue);
+}
+
+:global(html[data-theme='light']) .content .callout {
+  color: var(--wasmcloud-color-brand-green-dark);
+}

--- a/src/styles/theme/_navbar.css
+++ b/src/styles/theme/_navbar.css
@@ -166,6 +166,31 @@ body:has(.navbar-glass) .navbar::before {
 }
 
 /* docs version picker */
+
+/* light theme: glass navbar text color */
+@supports (animation-timeline: view()) {
+  html[data-theme='light'] body:has(.navbar-glass) .navbar .navbar__inner .navbar__items button,
+  html[data-theme='light'] body:has(.navbar-glass) .navbar .navbar__inner .navbar__items a:not(.dropdown__link) {
+    color: var(--wasmcloud-color-brand-space-blue);
+    animation: navbar-text-light 1ms forwards;
+    animation-timeline: scroll();
+    animation-range-start: entry var(--ifm-navbar-height);
+    animation-range-end: exit calc(var(--ifm-navbar-height) * 4);
+    transition: none;
+  }
+
+  @keyframes navbar-text-light {
+    from {
+      --ifm-menu-color-background-hover: rgba(0 46 93 / 0.1);
+      color: var(--wasmcloud-color-brand-space-blue);
+    }
+    to {
+      --ifm-menu-color-background-hover: rgba(0 0 0 / 0.1);
+      color: var(--ifm-font-color-base);
+    }
+  }
+}
+
 .navbar__item:has(.navbar__link--version-dropdown) {
   border: 1px solid var(--wasmcloud-color-brand-green);
   font-size: 0.7em;


### PR DESCRIPTION
## Summary

Resolves #1112

The theme toggle on the homepage was functional but the homepage visuals were not responding to it. The hero, all content sections, and the navbar remained dark regardless of theme selection.

This PR wires up light mode styles across all affected homepage components.

## Changes

### `src/pages/_index/_components/hero/styles.module.css`
- Replaces the dark space-blue gradient with a soft mint-to-white gradient in light mode
- Sets content text color to `--wasmcloud-color-brand-space-blue` (dark navy) for readability
- Uses `--wasmcloud-color-brand-green-dark` for the handwritten callout annotation

### `src/pages/_components/section/styles.module.css`
- Adds `[data-theme=light]` overrides for all six section color variants: default, `light-gray`, `dark-gray`, `green`, `space-blue`, and `yellow`
- Light backgrounds use neutral whites and blue-grays; dark-on-light text ensures contrast

### `src/styles/theme/_navbar.css`
- Fixes the glass navbar text color on the homepage in light mode
- Dark mode navbar text starts white (correct); light mode now starts as `--wasmcloud-color-brand-space-blue` to stay readable against the light hero gradient

### `src/pages/_index/_components/cncf/index.tsx` and `cncf.module.css`
- Renders both `cncf-white.svg` (dark mode) and `cncf-color.svg` (light mode) logos
- CSS toggles visibility based on `[data-theme]` so the correct logo always shows

## Testing

- Toggle theme via the sun/moon icon in the top navbar on the homepage
- Verify the hero, all content sections, and the CNCF logo respond correctly in both modes
- Tested locally with `npm run start`