### PR TITLE
fix:docs quickstart had code that didnt work as intended, path() shou…

### DIFF
--- a/docs/quickstart/develop-a-webassembly-component.mdx
+++ b/docs/quickstart/develop-a-webassembly-component.mdx
@@ -32,7 +32,7 @@ use wstd::http::{Body, Request, Response, StatusCode};
 
 #[wstd::http_server]
 async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
-    match req.uri().path_and_query().unwrap().as_str() {
+    match req.uri().path() {
         "/" => home(req).await,
         _ => not_found(req).await,
     }


### PR DESCRIPTION
The earlier code was buggy

Curl localhost:8000?name=bob always failed to resolve and threw a
"Not found Error"

However changing it to just .path() seemed to have resolved it & the route pattern matching didn't use the query anyways since we rely on the base "/" endpoint

Open to suggestions.