### PR TITLE
docs: fix path_and_query to path() in persistent storage example

### DIFF
--- a/docs/quickstart/develop-a-webassembly-component.mdx
+++ b/docs/quickstart/develop-a-webassembly-component.mdx
@@ -236,7 +236,7 @@ use wasi::keyvalue::{atomics, store}; // [!code ++]
 
 #[wstd::http_server]
 async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
-    match req.uri().path_and_query().unwrap().as_str() {
+    match req.uri().path() {
         "/" => home(req).await,
         _ => not_found(req).await,
     }


### PR DESCRIPTION
Issue is same as that of #1121 
curl 'localhost:8000?name=Bob' threw a " not found Error" 
However changing it to just path() resolved it. 