### PR TITLE
feat(docs): add recipes section

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,7 +22,7 @@ Install the parts of the [wasmCloud platform](./overview/index.mdx) that you nee
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -66,7 +66,7 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -108,7 +108,7 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-Verify that `wash` is properly installed and check your version for **`2.0.2`** with:
+Verify that `wash` is properly installed and check your version for **`2.0.3`** with:
 
 ```bash
 wash -V
@@ -138,7 +138,7 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
 Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml):
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
 Verify the deployment:

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -100,7 +100,7 @@ Use Helm to install the wasmCloud operator from an OCI chart image:
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -111,7 +111,7 @@ helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the Runtime Gateway as a NodePort service on port 30950, which the kind cluster config maps to host port 80:
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -121,7 +121,7 @@ helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3d supports `LoadBalancer` services natively, so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -132,7 +132,7 @@ helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3s includes a built-in load balancer (Klipper), so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```

--- a/docs/kubernetes-operator/operator-manual/cicd.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd.mdx
@@ -29,7 +29,7 @@ The [`setup-wash-action`](https://github.com/wasmCloud/setup-wash-action) instal
 ```yaml
 - uses: wasmCloud/setup-wash-action@main
   with:
-    wash-version: "v2.0.2"    # version to install (default: v2.0.2)
+    wash-version: "v2.0.3"    # version to install (default: v2.0.3)
 ```
 
 ### setup-wash-cargo-auditable

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -29,9 +29,9 @@ The K3s setup (`deploy/k3s` in the `wasmCloud/wasmCloud` repository) runs five c
 |---------|-------|-------------|
 | `kubernetes` | `rancher/k3s` | K3s Kubernetes control plane |
 | `nats` | `nats:2-alpine` | NATS with JetStream (messaging backbone and object storage) |
-| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.2` | wasmCloud operator (watches CRDs, schedules workloads) |
-| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.2` | HTTP ingress — routes requests to workloads (port 80) |
-| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.2` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
+| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.3` | wasmCloud operator (watches CRDs, schedules workloads) |
+| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.3` | HTTP ingress — routes requests to workloads (port 80) |
+| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.3` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
 
 The `kubernetes` container automatically loads wasmCloud CRDs from the operator chart on first start, and writes a kubeconfig to `tmp/kubeconfig.yaml` for local use.
 
@@ -151,7 +151,7 @@ To scale out, add additional `wash-host` entries to `docker-compose.yml`:
 
 ```yaml
   wash-host-2:
-    image: ghcr.io/wasmcloud/wash:2.0.2
+    image: ghcr.io/wasmcloud/wash:2.0.3
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host-2
     depends_on:
       nats:

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -27,11 +27,11 @@ helm show values oci://ghcr.io/wasmcloud/charts/runtime-operator --version <vers
 ```
 :::
 
-For example, with version `2.0.2`, the images are:
+For example, with version `2.0.3`, the images are:
 
-- `ghcr.io/wasmcloud/runtime-operator:2.0.2`
-- `ghcr.io/wasmcloud/runtime-gateway:2.0.2`
-- `ghcr.io/wasmcloud/wash:2.0.2`
+- `ghcr.io/wasmcloud/runtime-operator:2.0.3`
+- `ghcr.io/wasmcloud/runtime-gateway:2.0.3`
+- `ghcr.io/wasmcloud/wash:2.0.3`
 - `docker.io/nats:2.11.3-alpine`
 
 If you disable the built-in NATS server (`--set nats.enabled=false`), you do not need to mirror the NATS image.
@@ -51,12 +51,12 @@ Create a `mirror.yaml` file listing the source and destination for each image. R
 ```yaml
 images:
   # wasmCloud runtime images
-  - source: ghcr.io/wasmcloud/runtime-operator:2.0.2
-    destination: myregistry/wasmcloud/runtime-operator:2.0.2
-  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.2
-    destination: myregistry/wasmcloud/runtime-gateway:2.0.2
-  - source: ghcr.io/wasmcloud/wash:2.0.2
-    destination: myregistry/wasmcloud/wash:2.0.2
+  - source: ghcr.io/wasmcloud/runtime-operator:2.0.3
+    destination: myregistry/wasmcloud/runtime-operator:2.0.3
+  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.3
+    destination: myregistry/wasmcloud/runtime-gateway:2.0.3
+  - source: ghcr.io/wasmcloud/wash:2.0.3
+    destination: myregistry/wasmcloud/wash:2.0.3
 
   # Third-party images
   - source: docker.io/nats:2.11.3-alpine
@@ -100,7 +100,7 @@ The Helm chart provides a `global.image.registry` value that overrides the regis
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   --create-namespace \
   --set global.image.registry="myregistry"
@@ -124,7 +124,7 @@ Then install with the pull secret:
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   --create-namespace \
   --set global.image.registry="myregistry" \
@@ -137,7 +137,7 @@ If you need to mirror images to different registry paths, you can override each 
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   --create-namespace \
   --set operator.image.registry="myregistry" \
@@ -154,7 +154,7 @@ If your organization uses a GitOps workflow or requires manifests to be reviewed
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
@@ -166,7 +166,7 @@ Write the rendered manifests to a directory for review or to check into version 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret" \
@@ -185,7 +185,7 @@ After rendering, you can verify that all image references point to your private 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   | grep "image:"
@@ -209,7 +209,7 @@ Then reference it with `-f`:
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.2 \
+  --version 2.0.3 \
   --namespace wasmcloud \
   -f my-values.yaml
 ```
@@ -258,7 +258,7 @@ These are the image-related values you can configure:
 | `gateway.image.repository` | `wasmcloud/runtime-gateway` | Gateway image repository |
 | `runtime.image.registry` | `ghcr.io` | Runtime host image registry |
 | `runtime.image.repository` | `wasmcloud/wash` | Runtime host image repository |
-| `runtime.image.tag` | `2.0.2` | Runtime host image tag |
+| `runtime.image.tag` | `2.0.3` | Runtime host image tag |
 | `nats.image.registry` | `docker.io` | NATS image registry |
 | `nats.image.repository` | `nats` | NATS image repository |
 | `nats.image.tag` | `2.11.3-alpine` | NATS image tag |

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -232,7 +232,7 @@ Use Helm to install the wasmCloud operator:
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -243,7 +243,7 @@ helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the Runtime Gateway as a NodePort service on port 30950, which the kind cluster config maps to host port 80:
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -253,7 +253,7 @@ helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3d supports `LoadBalancer` services natively, so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```
@@ -264,7 +264,7 @@ helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3s includes a built-in load balancer (Klipper), so we override the gateway service type:
 
 ```shell
-helm install wasmcloud --version 2.0.2 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
   --set gateway.service.type=LoadBalancer
 ```

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -21,7 +21,7 @@ Components are compiled from your language of choice—Rust, TypeScript, Go, and
 
 ## Install `wash`
 
-First, we need to install the latest version of `wash` (**`2.0.2`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
+First, we need to install the latest version of `wash` (**`2.0.3`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
 
 <Tabs groupId="os" queryString>
   <TabItem value="macoslinux" label="macOS and Linux" default>
@@ -30,7 +30,7 @@ First, we need to install the latest version of `wash` (**`2.0.2`**). If you've 
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -74,7 +74,7 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.2`**):
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -116,13 +116,13 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.2`** with:
+In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.3`** with:
 
 ```bash
 wash -V
 ```
 
-If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.2`.
+If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.3`.
 Run `wash --help` to see all available commands and short descriptions for each.
 
 ## Choose your language

--- a/docs/recipes/expose-workload-via-kubernetes-service.mdx
+++ b/docs/recipes/expose-workload-via-kubernetes-service.mdx
@@ -1,0 +1,241 @@
+---
+title: 'Expose a Workload via Kubernetes Service'
+description: 'Route cluster traffic to a workload through a Kubernetes Service and EndpointSlice'
+---
+
+This recipe shows how to expose a wasmCloud workload to other services in your Kubernetes cluster using a standard Kubernetes Service. The operator manages an EndpointSlice that points to the host pods running the workload, so cluster-internal DNS (e.g. `my-service.default.svc.cluster.local`) resolves to the correct pods automatically.
+
+By the end, you will have a workload reachable by name from anywhere in the cluster.
+
+## Prerequisites
+
+- A Kubernetes cluster with wasmCloud installed via the [Helm chart](../kubernetes-operator/index.mdx) (runtime-operator **v2.0.3 or later** — the `kubernetes.service` field was added in 2.0.3)
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+## Overview
+
+When you set `spec.kubernetes.service.name` (or `spec.template.spec.kubernetes.service.name` on a `WorkloadDeployment`) to the name of an existing Kubernetes Service, the operator:
+
+1. Creates and maintains an EndpointSlice for that Service, pointing to the pod IPs of the hosts running the workload.
+2. Registers Service DNS aliases (`my-service`, `my-service.default`, `my-service.default.svc`) with the host, so the host's HTTP router accepts requests whose `Host` header matches any of these forms.
+
+This means you can call the workload from other pods by resolving its Service DNS name (short name or fully-qualified, in-cluster or cross-namespace), as long as the request's `Host` header is one of the registered aliases. Note that the fully-qualified `.cluster.local` form is **not** a registered alias — use it for DNS resolution only, and set the `Host` header to one of the shorter forms.
+
+## Step 1: Create the Kubernetes Service
+
+Create a Service before deploying the workload. The operator references this Service by name and manages its EndpointSlice.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-service
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+```
+
+Note that the Service does not include a `selector`. The operator manages the EndpointSlice directly, so no label matching is needed.
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-service
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+EOF
+```
+
+## Step 2: Deploy the workload with a Service reference
+
+Create a `WorkloadDeployment` that references the Service by name under `spec.template.spec.kubernetes.service`:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: hello-world
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      kubernetes:
+        service:
+          name: hello-service
+      components:
+        - name: hello-world
+          image: ghcr.io/wasmcloud/components/hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: hello-service
+```
+
+Key fields:
+
+- `kubernetes.service.name: hello-service` tells the operator to create an EndpointSlice for the `hello-service` Service. The EndpointSlice will contain the pod IPs of the host pods running this workload.
+- `hostInterfaces[].config.host: hello-service` registers the hostname with the wasmCloud host so it routes incoming HTTP requests on that hostname to this component.
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: hello-world
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      kubernetes:
+        service:
+          name: hello-service
+      components:
+        - name: hello-world
+          image: ghcr.io/wasmcloud/components/hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: hello-service
+EOF
+```
+
+## Step 3: Verify the EndpointSlice
+
+Once the workload is running, confirm that the operator has created an EndpointSlice:
+
+```shell
+kubectl get endpointslices -l kubernetes.io/service-name=hello-service
+```
+
+You should see an EndpointSlice with endpoints pointing to the host pod IPs:
+
+```text
+NAME                     ADDRESSTYPE   PORTS   ENDPOINTS     AGE
+hello-service-a46c2b39   IPv4          80      10.244.0.15   30s
+```
+
+The `PORTS` column shows `80` — the port the wasmCloud host listens on inside the pod. Kube-proxy forwards traffic from the Service's front-facing port (`8080` in this example) to port `80` on the host pod. You do not need to set `targetPort` on the Service; the operator manages the EndpointSlice directly.
+
+## Step 4: Call the workload from within the cluster
+
+From any pod in the cluster, the workload is now reachable via the Service DNS name. To test, run a one-off curl pod:
+
+```shell
+kubectl run curl-test --rm -it --restart=Never --image=curlimages/curl -- \
+  curl -s -H "Host: hello-service" http://hello-service:8080
+```
+
+You should see:
+
+```text
+Hello from wasmCloud!
+```
+
+The request reaches the workload through the standard Kubernetes Service DNS resolution and EndpointSlice routing.
+
+:::note[The `Host` header must match a registered alias]
+The host's HTTP router matches on the `Host` header, not the TCP destination. The operator registers three aliases for a Service named `my-svc` in namespace `default`:
+
+- `my-svc`
+- `my-svc.default`
+- `my-svc.default.svc`
+
+Any of these values in the `Host` header will match. The fully-qualified `my-svc.default.svc.cluster.local` form is **not** registered — use it for DNS resolution only and override the header.
+
+Also note: `curl http://my-svc:8080` (no explicit `-H`) sends `Host: my-svc:8080` (with port) and returns `400 Bad Request`. Strip the port by passing `-H "Host: my-svc"`.
+:::
+
+## Exposing the Service externally
+
+The Service created above is `ClusterIP` by default, meaning it is only reachable from within the cluster. To expose it externally, you can change the Service type or add an Ingress.
+
+### Using NodePort
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-service
+  namespace: default
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      nodePort: 30080
+```
+
+### Using LoadBalancer
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-service
+  namespace: default
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+```
+
+### Using an Ingress controller
+
+If your cluster has an Ingress controller (such as Nginx Ingress or Traefik), you can create an Ingress resource that routes to the Service:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-ingress
+  namespace: default
+spec:
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hello-service
+                port:
+                  number: 8080
+```
+
+## Clean up
+
+```shell
+kubectl delete workloaddeployment hello-world
+kubectl delete svc hello-service
+```
+
+## Related documentation
+
+- [Custom Resource Definitions](../kubernetes-operator/crds.mdx) for the full `KubernetesSpec` field reference
+- [API Reference](../kubernetes-operator/api-reference.md) for `KubernetesServiceRef` and `KubernetesSpec`
+- [Operator and Gateway Overview](../kubernetes-operator/operator-manual/overview.mdx) for the architecture of the operator and host groups

--- a/docs/recipes/expose-workload-via-kubernetes-service.mdx
+++ b/docs/recipes/expose-workload-via-kubernetes-service.mdx
@@ -23,7 +23,7 @@ This means you can call the workload from other pods by resolving its Service DN
 
 ## Step 1: Create the Kubernetes Service
 
-Create a Service before deploying the workload. The operator references this Service by name and manages its EndpointSlice.
+Create a Service before deploying the workload. The operator will reference this Service by name and manage its EndpointSlices.
 
 ```yaml
 apiVersion: v1

--- a/docs/recipes/expose-workload-via-kubernetes-service.mdx
+++ b/docs/recipes/expose-workload-via-kubernetes-service.mdx
@@ -3,7 +3,7 @@ title: 'Expose a Workload via Kubernetes Service'
 description: 'Route cluster traffic to a workload through a Kubernetes Service and EndpointSlice'
 ---
 
-This recipe shows how to expose a wasmCloud workload to other services in your Kubernetes cluster using a standard Kubernetes Service. The operator manages an EndpointSlice that points to the host pods running the workload, so cluster-internal DNS (e.g. `my-service.default.svc.cluster.local`) resolves to the correct pods automatically.
+This recipe shows how to expose a wasmCloud workload to other services in your Kubernetes cluster using a standard [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service). The operator manages [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) that point to the host pods running the workload, so cluster-internal DNS (e.g. `my-service.default.svc.cluster.local`) resolves to the correct pods automatically.
 
 By the end, you will have a workload reachable by name from anywhere in the cluster.
 

--- a/docs/recipes/expose-workload-via-kubernetes-service.mdx
+++ b/docs/recipes/expose-workload-via-kubernetes-service.mdx
@@ -5,7 +5,7 @@ description: 'Route cluster traffic to a workload through a Kubernetes Service a
 
 This recipe shows how to expose a wasmCloud workload to other services in your Kubernetes cluster using a standard [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service). The operator manages [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) that point to the host pods running the workload, so cluster-internal DNS (e.g. `my-service.default.svc.cluster.local`) resolves to the correct pods automatically.
 
-By the end, you will have a workload reachable by name from anywhere in the cluster.
+By the end, you will have a wasmCloud workload reachable by DNS name from anywhere in the cluster.
 
 ## Prerequisites
 

--- a/docs/recipes/index.mdx
+++ b/docs/recipes/index.mdx
@@ -1,0 +1,16 @@
+---
+title: 'Recipes'
+sidebar_position: 6
+---
+
+# Recipes
+
+Recipes are task-oriented guides for common deployment and configuration scenarios on wasmCloud. Each recipe focuses on a single goal, provides a complete working example, and explains the key decisions along the way.
+
+Recipes assume familiarity with the [Quickstart](../quickstart/index.mdx), the [Developer Guide](../wash/developer-guide/index.mdx), and the basics of the [Kubernetes Operator](../kubernetes-operator/index.mdx).
+
+| Recipe | Description |
+|---|---|
+| [TLS with Bring-Your-Own Certificates](./tls-bring-your-own-certificates.mdx) | Serve HTTPS from a wasmCloud host group using your own TLS certificates |
+| [Expose a Workload via Kubernetes Service](./expose-workload-via-kubernetes-service.mdx) | Route cluster traffic to a workload through a Kubernetes Service and EndpointSlice |
+| [Inject Configuration from ConfigMaps and Secrets](./inject-configuration-from-configmaps-and-secrets.mdx) | Provide runtime configuration to a component from inline values, ConfigMaps, and Secrets |

--- a/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
+++ b/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
@@ -1,0 +1,256 @@
+---
+title: 'Inject Configuration from ConfigMaps and Secrets'
+description: 'Provide runtime configuration to a component from inline values, ConfigMaps, and Secrets'
+---
+
+This recipe walks through providing runtime configuration to a wasmCloud component from three sources: inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. All three are delivered to the component through the same interface, `wasi:cli/environment`, so the component reads them the same way regardless of source.
+
+By the end, you will have a component that reads configuration values from all three sources, with a clear understanding of how precedence works when keys overlap.
+
+## Prerequisites
+
+- A Kubernetes cluster with wasmCloud installed via the [Helm chart](../kubernetes-operator/index.mdx)
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- A component that reads `wasi:cli/environment` (see [Configuration](../wash/developer-guide/language-support/typescript/configuration.mdx) for a TypeScript walkthrough, or use the example below)
+
+## How it works
+
+The `localResources.environment` field on a component accepts three sub-fields:
+
+| Field | Source | Precedence |
+|---|---|---|
+| `config` | Inline key-value pairs in the manifest | Lowest |
+| `configFrom` | References to Kubernetes ConfigMaps | Middle |
+| `secretFrom` | References to Kubernetes Secrets | Highest |
+
+All keys from all sources are merged into a single set of environment variables. When the same key appears in more than one source, the source with higher precedence wins. Within a single source (e.g. multiple ConfigMaps in `configFrom`), the last entry in the list wins.
+
+The component reads the merged values by calling `getEnvironment()` from `wasi:cli/environment`, which returns all key-value pairs as an array.
+
+## Step 1: Create the ConfigMap
+
+Create a ConfigMap with non-sensitive application configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: default
+data:
+  APP_NAME: "My Service"
+  LOG_LEVEL: "info"
+  UPSTREAM_URL: "https://api.example.com"
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: default
+data:
+  APP_NAME: "My Service"
+  LOG_LEVEL: "info"
+  UPSTREAM_URL: "https://api.example.com"
+EOF
+```
+
+## Step 2: Create the Secret
+
+Create a Secret for sensitive values:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: default
+type: Opaque
+stringData:
+  API_KEY: "sk-example-key-12345"
+  DB_PASSWORD: "supersecret"
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: default
+type: Opaque
+stringData:
+  API_KEY: "sk-example-key-12345"
+  DB_PASSWORD: "supersecret"
+EOF
+```
+
+Secret values are delivered to the component as plain strings. No base64 decoding is required in your component code.
+
+## Step 3: Deploy the workload with all three sources
+
+Create a `WorkloadDeployment` that combines inline values, the ConfigMap, and the Secret:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: configured-app
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: http-component
+          image: ghcr.io/wasmcloud/components/hello-world:0.1.0
+          localResources:
+            environment:
+              config:
+                REGION: "us-east-1"
+                LOG_LEVEL: "debug"
+              configFrom:
+                - name: app-config
+              secretFrom:
+                - name: app-secrets
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: localhost
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: configured-app
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: http-component
+          image: ghcr.io/wasmcloud/components/hello-world:0.1.0
+          localResources:
+            environment:
+              config:
+                REGION: "us-east-1"
+                LOG_LEVEL: "debug"
+              configFrom:
+                - name: app-config
+              secretFrom:
+                - name: app-secrets
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: localhost
+EOF
+```
+
+## Step 4: Understand precedence
+
+In the manifest above, `LOG_LEVEL` appears in two sources:
+
+- `config` (inline) sets it to `"debug"`
+- `configFrom` references `app-config`, which sets it to `"info"`
+
+Because `configFrom` has higher precedence than `config`, the component receives `LOG_LEVEL=info`.
+
+The full set of values the component receives:
+
+| Key | Value | Source | Why |
+|---|---|---|---|
+| `REGION` | `us-east-1` | `config` | Only appears in inline config |
+| `LOG_LEVEL` | `info` | `configFrom` | ConfigMap overrides inline |
+| `APP_NAME` | `My Service` | `configFrom` | Only appears in ConfigMap |
+| `UPSTREAM_URL` | `https://api.example.com` | `configFrom` | Only appears in ConfigMap |
+| `API_KEY` | `sk-example-key-12345` | `secretFrom` | Only appears in Secret |
+| `DB_PASSWORD` | `supersecret` | `secretFrom` | Only appears in Secret |
+
+If `app-secrets` also contained a `LOG_LEVEL` key, the Secret value would win over both the inline and ConfigMap values.
+
+## Reading configuration in component code
+
+### Rust
+
+Use the `wasi:cli/environment` bindings to read environment variables:
+
+```rust
+fn get_config() -> std::collections::HashMap<String, String> {
+    wasi::cli::environment::get_environment()
+        .into_iter()
+        .collect()
+}
+```
+
+### TypeScript
+
+Import `getEnvironment` from `wasi:cli/environment`:
+
+```typescript
+import { getEnvironment } from 'wasi:cli/environment@0.2.3';
+
+const config = Object.fromEntries(getEnvironment());
+const region = config['REGION'] ?? 'us-west-2';
+const apiKey = config['API_KEY'];
+```
+
+Call `getEnvironment()` inside route handlers rather than at module scope. See the [Configuration guide](../wash/developer-guide/language-support/typescript/configuration.mdx) for a full TypeScript walkthrough including Hono integration.
+
+## Multiple ConfigMaps and Secrets
+
+You can reference multiple ConfigMaps and multiple Secrets. Within each list, the last entry wins on key conflicts:
+
+```yaml
+localResources:
+  environment:
+    configFrom:
+      - name: base-config       # loaded first
+      - name: override-config   # wins on conflicts
+    secretFrom:
+      - name: shared-secrets    # loaded first
+      - name: app-secrets       # wins on conflicts
+```
+
+This is useful for layering a shared base configuration with per-application overrides.
+
+## Development workflow
+
+During local development with `wash dev`, `localResources.environment` defaults to empty. Provide fallback defaults in your component code so the component runs correctly without configuration:
+
+```typescript
+const config = Object.fromEntries(getEnvironment());
+const region = config['REGION'] ?? 'us-west-2';
+const logLevel = config['LOG_LEVEL'] ?? 'debug';
+```
+
+Test configuration-dependent behavior by deploying to a Kubernetes environment with the full manifest.
+
+## Clean up
+
+```shell
+kubectl delete workloaddeployment configured-app
+kubectl delete configmap app-config
+kubectl delete secret app-secrets
+```
+
+## Related documentation
+
+- [Secrets and Configuration Management](../kubernetes-operator/operator-manual/secrets-and-configuration.mdx) for a complete reference on `localResources.environment`
+- [Configuration (TypeScript)](../wash/developer-guide/language-support/typescript/configuration.mdx) for a full walkthrough of reading configuration in TypeScript
+- [Custom Resource Definitions](../kubernetes-operator/crds.mdx) for the full CRD field reference
+- [Roles and Role Bindings](../kubernetes-operator/operator-manual/roles-and-rolebindings.mdx) for RBAC considerations when referencing Secrets

--- a/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
+++ b/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
@@ -25,7 +25,7 @@ The `localResources.environment` field on a component accepts three sub-fields:
 
 All keys from all sources are merged into a single set of environment variables. When the same key appears in more than one source, the source with higher precedence wins. Within a single source (e.g. multiple ConfigMaps in `configFrom`), the last entry in the list wins.
 
-The component reads the merged values by calling `getEnvironment()` from `wasi:cli/environment`, which returns all key-value pairs as an array.
+Components can read the merged values by calling `getEnvironment()` (a part of the [`wasi:cli/environment` interface](https://github.com/WebAssembly/WASI/tree/main/proposals/cli)), which returns all key-value pairs as an array.
 
 ## Step 1: Create the ConfigMap
 

--- a/docs/recipes/tls-bring-your-own-certificates.mdx
+++ b/docs/recipes/tls-bring-your-own-certificates.mdx
@@ -1,0 +1,281 @@
+---
+title: 'TLS with Bring-Your-Own Certificates'
+description: 'Serve HTTPS from a wasmCloud host group using your own TLS certificates'
+---
+
+This recipe shows how to configure a wasmCloud host group to serve HTTPS using TLS certificates you provide. By the end, you will have a kind cluster running wasmCloud with a host group that terminates TLS using a certificate stored in a Kubernetes Secret.
+
+## Prerequisites
+
+- A Kubernetes cluster (this recipe uses [kind](https://kind.sigs.k8s.io/))
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [Helm](https://helm.sh/docs) v3.8.0+
+- A TLS certificate and private key (self-signed or CA-issued)
+
+If you do not already have a certificate, you can generate a self-signed one for testing:
+
+```shell
+openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 365 -nodes \
+  -subj "/CN=example.com" \
+  -addext "subjectAltName=DNS:example.com,DNS:localhost,DNS:*.default.svc.cluster.local"
+```
+
+You will also need a CA certificate. For self-signed certificates, the certificate itself serves as the CA:
+
+```shell
+cp tls.crt ca.crt
+```
+
+## Step 1: Create the cluster
+
+Create a kind cluster with port 30443 mapped for HTTPS ingress:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30443
+        hostPort: 8443
+        protocol: TCP
+```
+
+Save this as `kind-config.yaml` and create the cluster:
+
+```shell
+kind create cluster --config kind-config.yaml
+```
+
+## Step 2: Create the TLS Secret
+
+Store your certificate, key, and CA certificate in a Kubernetes Secret:
+
+```shell
+kubectl create secret generic byoc-cert \
+  --from-file=tls.crt=tls.crt \
+  --from-file=tls.key=tls.key \
+  --from-file=ca.crt=ca.crt
+```
+
+The Secret must contain three keys: `tls.crt`, `tls.key`, and `ca.crt`. The wasmCloud host reads all three when starting its HTTPS listener.
+
+## Step 3: Install wasmCloud with TLS enabled
+
+Create a `values.yaml` file that configures the host group to use your certificate:
+
+```yaml
+global:
+  tls:
+    enabled: true
+
+runtime:
+  hostGroups:
+    - name: default
+      replicas: 1
+      service:
+        type: ClusterIP
+      http:
+        enabled: true
+        port: 8443
+        tls:
+          enabled: true
+          certificate:
+            secretName: "byoc-cert"
+            generate:
+              enabled: false
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "512Mi"
+          cpu: "500m"
+```
+
+Key fields:
+
+- `global.tls.enabled: true` enables TLS for the platform's NATS connections and certificate infrastructure.
+- `http.tls.enabled: true` tells the host group to serve HTTPS instead of HTTP.
+- `http.tls.certificate.secretName` points to the Secret created in Step 2.
+- `http.tls.certificate.generate.enabled: false` disables auto-generated certificates so the host uses your Secret.
+- `http.port: 8443` sets the HTTPS listen port on the host pod.
+
+Install with Helm:
+
+```shell
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  -f values.yaml
+```
+
+Wait for the pods to start:
+
+```shell
+kubectl rollout status deploy -l app.kubernetes.io/instance=wasmcloud -n default
+```
+
+## Step 4: Expose the host group with a NodePort Service
+
+Create a Service that routes external traffic to the host group on port 8443:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: wasmcloud-https
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    wasmcloud.com/hostgroup: default
+    wasmcloud.com/name: hostgroup
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      nodePort: 30443
+      protocol: TCP
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: wasmcloud-https
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    wasmcloud.com/hostgroup: default
+    wasmcloud.com/name: hostgroup
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      nodePort: 30443
+      protocol: TCP
+EOF
+```
+
+The `nodePort: 30443` maps to `hostPort: 8443` on the kind node (from Step 1), making the host group reachable at `https://localhost:8443` on your machine.
+
+## Step 5: Deploy a workload and verify
+
+Deploy a simple hello-world component:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: hello-world
+          image: ghcr.io/wasmcloud/components/hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: example.com
+```
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: hello-world
+          image: ghcr.io/wasmcloud/components/hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: example.com
+EOF
+```
+
+Wait for the workload to become ready:
+
+```shell
+kubectl get workloaddeployments --watch
+```
+
+Send an HTTPS request. Use `-k` to skip certificate verification (for self-signed certificates) and set the `Host` header to match the `host` value in the manifest:
+
+```shell
+curl -k -H "Host: example.com" https://localhost:8443
+```
+
+You should see:
+
+```text
+Hello from wasmCloud!
+```
+
+To verify that TLS is active, add `-v` to the curl command:
+
+```shell
+curl -kv -H "Host: example.com" https://localhost:8443
+```
+
+The output should include a TLS handshake showing the certificate's common name:
+
+```text
+* Server certificate:
+*  subject: CN=example.com
+```
+
+## Using auto-generated certificates
+
+If you do not have your own certificates, the Helm chart can generate self-signed certificates automatically. Replace the `http.tls.certificate` section in your `values.yaml`:
+
+```yaml
+http:
+  tls:
+    enabled: true
+    certificate:
+      secretName: ""
+      generate:
+        enabled: true
+        validity: 365
+        commonName: "example.com"
+        domains:
+          - "localhost"
+          - "*.example.com"
+          - "hostgroup-default.default.svc.cluster.local"
+```
+
+When `generate.enabled` is `true` and `secretName` is empty, the chart creates a self-signed certificate with the specified common name and SANs. This is useful for development and testing.
+
+## Clean up
+
+```shell
+kubectl delete workloaddeployment hello-world
+kubectl delete svc wasmcloud-https
+helm uninstall wasmcloud
+kind delete cluster
+```
+
+## Related documentation
+
+- [Operator and Gateway Overview](../kubernetes-operator/operator-manual/overview.mdx)
+- [Custom Resource Definitions](../kubernetes-operator/crds.mdx)
+- [Helm chart values reference](https://github.com/wasmCloud/wasmCloud/blob/main/charts/runtime-operator/values.yaml)

--- a/docs/recipes/tls-bring-your-own-certificates.mdx
+++ b/docs/recipes/tls-bring-your-own-certificates.mdx
@@ -3,7 +3,9 @@ title: 'TLS with Bring-Your-Own Certificates'
 description: 'Serve HTTPS from a wasmCloud host group using your own TLS certificates'
 ---
 
-This recipe shows how to configure a wasmCloud host group to serve HTTPS using TLS certificates you provide. By the end, you will have a kind cluster running wasmCloud with a host group that terminates TLS using a certificate stored in a Kubernetes Secret.
+This recipe shows how to configure a wasmCloud host group to serve HTTPS using TLS certificates you provide. 
+
+By the end, you will have a kind cluster running wasmCloud with a host group that terminates TLS using a certificate stored in a Kubernetes Secret.
 
 ## Prerequisites
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -143,6 +143,16 @@ const sidebars = {
       ],
     },
     'examples',
+    {
+      type: 'category',
+      label: 'Recipes',
+      link: { type: 'doc', id: 'recipes/index' },
+      items: [
+        'recipes/tls-bring-your-own-certificates',
+        'recipes/expose-workload-via-kubernetes-service',
+        'recipes/inject-configuration-from-configmaps-and-secrets',
+      ],
+    },
 
     {
       type: 'html',


### PR DESCRIPTION
Adds a "Recipes" section to provide task-oriented guides for common deployment and configuration scenarios on wasmCloud. Starts off with three recipes:

* TLS with Bring-Your-Own Certificates
* Expose a Workload via Kubernetes Service
* Inject Configuration from ConfigMaps and Secrets

Also updates several version references to 2.0.3. 