### PR TITLE
docs: update for wasmCloud 2.0.3

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -135,10 +135,11 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
 
 ### Install the wasmCloud operator
 
-Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml):
+Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml). The overlay disables the deprecated Runtime Gateway by default — HTTP traffic is routed by the operator via EndpointSlices tied to standard Kubernetes Services:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
+helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
 Verify the deployment:
@@ -151,7 +152,7 @@ Once all pods are running, you're ready to deploy a Wasm workload.
 
 ### Deploy a Wasm workload
 
-You can deploy a "Hello world" Wasm workload from a [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) with this `kubectl` command:
+Apply the [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml), which contains a `NodePort` Service and a `WorkloadDeployment` that references it by name. The operator creates an EndpointSlice for the Service pointing at the host pods running the workload, so the NodePort on port 30950 (mapped to host port 80 by the kind cluster config) reaches the component directly:
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml
@@ -170,10 +171,11 @@ For more information on each of these steps, see [Kubernetes Operator](./kuberne
 
 ## Clean up
 
-Delete the workload deployment:
+Delete the workload deployment and its Service:
 
 ```shell
 kubectl delete workloaddeployment hello-world
+kubectl delete service hello-world
 ```
 
 Uninstall wasmCloud:

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -21,12 +21,17 @@ Along with the wasmCloud operator, the wasmCloud platform on Kubernetes consists
 
 * [**Custom resource definitions (CRDs)**](crds.mdx) for wasmCloud infrastructure and Wasm workloads.
 * [**wasmCloud host(s)**](../glossary.mdx#host) - Sandboxed runtime environments for WebAssembly components. (By default, these are `wash` binaries using the `wash host` command to run a [cluster host (washlet)](../runtime/washlet.mdx) that surfaces the `wash-runtime` API over NATS.)
-* [**Runtime Gateway**](./operator-manual/overview.mdx#runtime-gateway) - HTTP reverse proxy that routes incoming requests to the appropriate wasmCloud host based on deployed workloads. Exposed as a Kubernetes Service.
 * [**NATS with JetStream**](../glossary.mdx#nats) - CNCF project that provides a connective layer for transport between operator and hosts, along with built-in object storage through JetStream. NATS carries all control-plane traffic to the host (the host never communicates directly with the Kubernetes API). The operator sends workload start/stop requests to individual hosts via NATS subjects, and hosts self-register by publishing heartbeat messages the operator subscribes to. The Helm chart bundles NATS automatically—you can also connect an existing NATS cluster by setting `nats.enabled: false` and pointing the operator at your endpoint.
+
+HTTP traffic reaches workloads through standard Kubernetes Services: the operator manages an EndpointSlice for each user-defined Service referenced by a workload, so cluster DNS (e.g. `my-svc.default.svc.cluster.local`) resolves directly to the host pods. See [Expose a Workload via Kubernetes Service](../recipes/expose-workload-via-kubernetes-service.mdx) for the full pattern.
+
+:::note[Runtime Gateway deprecated in 2.0.3]
+Earlier releases included a separate Runtime Gateway deployment that proxied HTTP traffic to workloads. The gateway is deprecated as of 2.0.3 and will be removed in a future release; routing is now handled by the operator via EndpointSlices. The chart still installs a gateway pod by default for backwards compatibility — set `gateway.enabled: false` to skip it.
+:::
 
 The entire platform can be deployed with [Helm](https://helm.sh/docs) using the [**wasmCloud operator Helm chart**](https://github.com/wasmCloud/wasmCloud/tree/main/charts/runtime-operator). (NATS and hosts can also be installed separately, if you wish.)
 
-For a detailed breakdown of each component's responsibilities and the request flow, see the [Operator and Gateway Overview](./operator-manual/overview.mdx).
+For a detailed breakdown of each component's responsibilities and the request flow, see the [Operator Overview](./operator-manual/overview.mdx). For commonly-overridden chart values, see the [Helm Values Reference](./operator-manual/helm-values.mdx).
 
 ## Get started with the wasmCloud operator 
 
@@ -101,14 +106,13 @@ Use Helm to install the wasmCloud operator from an OCI chart image:
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
-  --set gateway.service.type=LoadBalancer
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
   </TabItem>
   <TabItem value="kind" label="kind">
 
-The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the Runtime Gateway as a NodePort service on port 30950, which the kind cluster config maps to host port 80:
+The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the host HTTP port to 80, which the kind cluster config maps to host port 80 via a NodePort Service:
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
@@ -118,29 +122,23 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
   </TabItem>
   <TabItem value="k3d" label="k3d">
 
-k3d supports `LoadBalancer` services natively, so we override the gateway service type:
-
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
-  --set gateway.service.type=LoadBalancer
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
   </TabItem>
   <TabItem value="k3s" label="k3s">
 
-k3s includes a built-in load balancer (Klipper), so we override the gateway service type:
-
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
-  --set gateway.service.type=LoadBalancer
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
   </TabItem>
 </Tabs>
 
-Along with the wasmCloud operator, Runtime Gateway, wasmCloud CRDs, and NATS, the Helm chart will deploy **three wasmCloud hosts** using the [`wasmcloud/wash`](https://github.com/wasmCloud/wasmCloud/pkgs/container/wash) container image.
+Along with the wasmCloud operator, wasmCloud CRDs, and NATS, the Helm chart will deploy **three wasmCloud hosts** using the [`wasmcloud/wash`](https://github.com/wasmCloud/wasmCloud/pkgs/container/wash) container image.
 
 You can build your own hosts that provide extended capabilities via [host plugins](../glossary.mdx#host-plugin). 
 
@@ -158,9 +156,20 @@ Once all pods are running, you're ready to deploy a Wasm workload.
 
 ### Deploy a Wasm component
 
-Use a [`WorkloadDeployment`](./crds.mdx#workloaddeployment) manifest to deploy a Wasm component workload to your cluster:
+Deploying a Wasm component that handles HTTP traffic takes two resources: a Kubernetes `Service` that exposes the component, and a [`WorkloadDeployment`](./crds.mdx#workloaddeployment) that references the Service. The operator creates an EndpointSlice for the Service pointing at whichever host pods are running the workload.
 
 ```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+---
 apiVersion: runtime.wasmcloud.dev/v1alpha1
 kind: WorkloadDeployment
 metadata:
@@ -171,6 +180,9 @@ spec:
     spec:
       hostSelector:
         hostgroup: default
+      kubernetes:
+        service:
+          name: hello-world
       components:
         - name: hello-world
           image: ghcr.io/wasmcloud/components/hello-world:0.1.0
@@ -179,26 +191,21 @@ spec:
           package: http
           interfaces:
             - incoming-handler
-          config:
-            host: localhost
 ```
 
-This manifest deploys a simple "Hello world!" component that uses the `wasi:http` interface to the `default` hostgroup, making it available to call via HTTP from outside the cluster. 
+This manifest deploys a simple "Hello world!" component that uses the `wasi:http` interface, scheduled on the `default` hostgroup and reachable inside the cluster at `hello-world.default.svc.cluster.local`.
 
-You can deploy from the [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) with this `kubectl` command:
-
-```shell
-kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml
-```
+For a kind-optimized NodePort variant that answers `curl localhost` on port 80, see the [wasmCloud-hosted hello-world manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) used by the [Installation](../installation.mdx#deploy-a-wasm-workload) guide.
 
 :::note[]
-Learn more about `WorkloadDeployments` and other wasmCloud resources in the [Custom Resource Definitions (CRDs) section](./crds.mdx).
+Learn more about `WorkloadDeployments` and other wasmCloud resources in the [Custom Resource Definitions (CRDs) section](./crds.mdx). For the full Service-routing walk-through, see [Expose a Workload via Kubernetes Service](../recipes/expose-workload-via-kubernetes-service.mdx).
 :::
 
-Now you can use `curl` to invoke the component with an HTTP request:
+Verify the component is reachable from inside the cluster:
 
 ```shell
-curl localhost -i
+kubectl run curl --rm -it --image=curlimages/curl --restart=Never -- \
+  curl -s http://hello-world.default.svc.cluster.local
 ```
 ```text
 Hello from wasmCloud!
@@ -206,10 +213,11 @@ Hello from wasmCloud!
 
 ## Clean up
 
-Delete the workload deployment:
+Delete the workload deployment and its Service:
 
 ```shell
 kubectl delete workloaddeployment hello-world
+kubectl delete service hello-world
 ```
 
 Uninstall wasmCloud:

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -1,0 +1,161 @@
+---
+title: 'Helm Values Reference'
+description: 'Commonly-used configuration values for the wasmCloud runtime-operator Helm chart'
+sidebar_position: 3
+---
+
+This page documents the configuration values you are most likely to override when installing the [`runtime-operator` Helm chart](https://github.com/wasmCloud/wasmCloud/tree/main/charts/runtime-operator). For the authoritative list of every value the chart supports, run:
+
+```shell
+helm show values oci://ghcr.io/wasmcloud/charts/runtime-operator --version <version>
+```
+
+## Top-level structure
+
+The chart's `values.yaml` is organized into five top-level sections:
+
+| Section | Purpose |
+|---|---|
+| `global` | Settings that apply across all components (image registry, TLS, image pull secrets) |
+| `nats` | The bundled NATS server — set `enabled: false` to connect an external NATS cluster instead |
+| `operator` | The wasmCloud runtime-operator deployment |
+| `gateway` | **Deprecated in 2.0.3.** Legacy runtime-gateway. Set `enabled: false` to skip installing it |
+| `runtime` | Host group deployments (pods running the `wash` host binary) |
+
+## `global`
+
+### `global.image.registry`
+
+Override the container image registry for all components at once. Useful for air-gapped or mirrored deployments.
+
+```yaml
+global:
+  image:
+    registry: myregistry.example.com
+```
+
+See [Private Registries and Air-Gapped Deployments](./private-registries.mdx) for the full mirroring workflow.
+
+### `global.tls.enabled`
+
+Introduced in 2.0.3. Set to `false` to disable TLS for NATS connections and skip certificate generation. Intended for clusters where a service mesh (e.g. Istio, Linkerd) provides mTLS between pods.
+
+```yaml
+global:
+  tls:
+    enabled: false
+```
+
+When `global.tls.enabled` is `false`, the chart ignores `global.certificates.generate` — no self-signed certs are created and NATS runs plaintext.
+
+### `global.certificates.generate`
+
+Controls whether the chart generates self-signed TLS certificates for NATS and the control plane. Set to `false` when bringing your own certificate secrets. See the [TLS: bring your own certificates](../../recipes/tls-bring-your-own-certificates.mdx) recipe for the full BYOC flow.
+
+## `operator`, `nats`, `runtime` — pod labels and annotations
+
+Introduced in 2.0.3. Each deployment accepts `podLabels` and `podAnnotations` that are merged into the pod template. This is most commonly used for service mesh injection:
+
+```yaml
+operator:
+  podLabels:
+    sidecar.istio.io/inject: "true"
+  podAnnotations:
+    proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
+
+nats:
+  podLabels:
+    sidecar.istio.io/inject: "true"
+
+runtime:
+  podLabels:
+    sidecar.istio.io/inject: "true"
+```
+
+## `operator`
+
+### `operator.watchNamespaces`
+
+By default, the operator watches every namespace in the cluster. Set `watchNamespaces` to a list of namespace names to scope it down:
+
+```yaml
+operator:
+  watchNamespaces:
+    - team-a
+    - team-b
+```
+
+When `watchNamespaces` is populated, the chart generates namespace-scoped `Role` and `RoleBinding` resources for each listed namespace (instead of a single `ClusterRole`).
+
+### `operator.image.tag`
+
+Defaults to the chart's `appVersion`. Override only when you need to pin to a specific operator build that differs from the chart release:
+
+```yaml
+operator:
+  image:
+    tag: "2.0.3"
+```
+
+The same pattern applies to `gateway.image.tag` and `runtime.image.tag`.
+
+## `gateway` (deprecated)
+
+:::warning[Deprecated]
+The runtime-gateway is deprecated as of 2.0.3. HTTP routing is now handled by the runtime-operator via EndpointSlices tied to user-defined Kubernetes Services. See [Expose a Workload via Kubernetes Service](../../recipes/expose-workload-via-kubernetes-service.mdx) for the replacement pattern.
+
+To skip installing the gateway, set `gateway.enabled: false`.
+:::
+
+```yaml
+gateway:
+  enabled: false
+```
+
+## `runtime`
+
+### `runtime.hostGroups`
+
+A host group is a `Deployment` of pods running the `wash` host. You can define multiple groups to isolate workloads or provide specialized capabilities (e.g. WebGPU-enabled hosts):
+
+```yaml
+runtime:
+  hostGroups:
+    - name: default
+      replicas: 3
+      http:
+        enabled: true
+        port: 80
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "512Mi"
+          cpu: "500m"
+    - name: gpu
+      replicas: 1
+      webgpu:
+        enabled: true
+```
+
+`WorkloadDeployment` manifests target a group via `spec.template.spec.hostSelector.hostgroup`.
+
+### `runtime.hostGroups[].http.port`
+
+Starting in 2.0.3, this value is honored by the host (it was previously hardcoded). This is the port the host's HTTP server listens on inside the pod, and the port the operator populates into each managed EndpointSlice. The upstream chart default is `9191`; the [`values.local.yaml`](https://github.com/wasmCloud/wasmCloud/blob/main/charts/runtime-operator/values.local.yaml) overlay overrides it to `80` for local development.
+
+### `runtime.hostGroups[].webgpu.enabled`
+
+Enables the WebGPU plugin on hosts in the group. Requires a host image built with the `wasi-webgpu` feature.
+
+### `runtime.image.tag`
+
+Starting in 2.0.3, this value defaults to the chart's `appVersion` (previously defaulted to a hardcoded tag). Leave unset to track the chart release.
+
+## Related documentation
+
+- [Kubernetes Operator introduction](../index.mdx) — install and deploy walk-through
+- [Private Registries](./private-registries.mdx) — mirroring images for air-gapped deployments
+- [TLS: bring your own certificates](../../recipes/tls-bring-your-own-certificates.mdx)
+- [Expose a Workload via Kubernetes Service](../../recipes/expose-workload-via-kubernetes-service.mdx)

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -10,6 +10,10 @@ toc_max_heading_level: 2
 
 The wasmCloud repository includes a ready-to-use K3s setup that spins up the entire wasmCloud platform—Kubernetes, NATS, the operator, gateway, and a host—with a single `docker compose up`.
 
+:::note[Runtime Gateway deprecated in 2.0.3]
+The Compose setup described on this page still uses the **Runtime Gateway** to accept HTTP traffic on port 80. The gateway is deprecated as of 2.0.3 and will be removed in a future release; on a full Kubernetes cluster, HTTP routing is now handled by the operator via EndpointSlices tied to standard Kubernetes Services ([see recipe](../../recipes/expose-workload-via-kubernetes-service.mdx)). The gateway remains in this example because Docker Compose doesn't implement the Kubernetes Service/EndpointSlice model itself.
+:::
+
 ## When to use K3s
 
 | Use case | Why K3s works well |

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -1,15 +1,18 @@
 ---
-title: 'Operator and Gateway Overview'
-description: 'Overview of the WasmCloud Operator and Gateway Deployments'
+title: 'Operator Overview'
+description: 'Overview of the wasmCloud operator and its components on Kubernetes'
 sidebar_position: 1
 ---
 
-There are four primary deployments that comprise wasmCloud in a Kubernetes system:
+There are three primary deployments that comprise wasmCloud in a Kubernetes cluster:
 
-1. **wasmCloud Operator** — watches for workload CRDs and schedules Wasm workloads onto hosts
-2. **Runtime Gateway** — routes incoming HTTP traffic to deployed Wasm workloads
-3. **Host Group** — a pool of pods running [cluster hosts (washlets)](../../runtime/washlet.mdx) that execute Wasm components
-4. **NATS** — message broker providing the control-plane transport between the operator and hosts
+1. **wasmCloud Operator** — watches workload CRDs, schedules Wasm workloads onto hosts, and manages EndpointSlices for user-defined Services
+2. **Host Group** — a pool of pods running [cluster hosts (washlets)](../../runtime/washlet.mdx) that execute Wasm components
+3. **NATS** — message broker providing the control-plane transport between the operator and hosts
+
+:::note[Runtime Gateway deprecated in 2.0.3]
+Earlier releases included a separate **Runtime Gateway** deployment that proxied HTTP traffic to workloads. The gateway is deprecated as of 2.0.3 and is scheduled for removal. HTTP routing is now handled natively by Kubernetes Services: the operator manages an EndpointSlice for each Service referenced by a workload, so requests arriving through standard Kubernetes Service DNS reach the right host pods without any wasmCloud-specific ingress. The gateway pod is still installed by the chart for backwards compatibility; set `gateway.enabled: false` to skip it.
+:::
 
 ## Architecture
 
@@ -21,22 +24,13 @@ The wasmCloud operator (`runtime-operator`) is the control-plane entity that wat
 
 - **Watching CRDs**: Monitors `WorkloadDeployment`, `WorkloadReplicaSet`, `Workload`, `Host`, and `Artifact` resources across all (or configured) namespaces.
 - **Scheduling workloads**: Reads the `WorkloadDeployment` spec and selects a `Host` that matches the `hostSelector` criteria, then creates the appropriate child resources to run the Wasm component.
+- **EndpointSlice management**: For workloads that reference a Kubernetes Service via `spec.kubernetes.service.name`, the operator creates and maintains an EndpointSlice pointing to the pod IPs of the hosts running the workload. It also registers Service DNS aliases with the host's HTTP router so requests arriving via cluster DNS reach the correct component.
 - **Host communication**: Sends workload start/stop requests and polls host health over NATS, using the `runtime.host.<hostID>.<operation>` subject pattern (e.g. `runtime.host.<hostID>.workload.start`).
 - **Status reporting**: Updates the `status` subresource of each CRD to reflect whether scheduling succeeded or failed, and surfaces Kubernetes events for observability.
 - **Leader election**: When enabled and running with multiple replicas, uses a `coordination.k8s.io/v1` Lease in the operator's own namespace to elect a single active instance and avoid split-brain reconciliation.
 - **Metrics endpoint**: Exposes a `/metrics` endpoint (Prometheus format) protected by Kubernetes token review and subject access review, suitable for scraping by monitoring tools.
 
 The operator runs with the `wasmcloud-runtime-operator` ServiceAccount. See [Roles and Role Bindings](./roles-and-rolebindings.mdx) for the full set of permissions required.
-
-## Runtime Gateway
-
-The Runtime Gateway acts as a reverse proxy that routes incoming HTTP traffic to the appropriate Wasm workload running on a host. Its responsibilities include:
-
-- **Traffic routing**: Listens on a configurable port and forwards HTTP requests to the Wasm component that registered the matching route.
-- **Host discovery**: Watches `Host` and `Workload` CRDs (read-only) to maintain an up-to-date routing table as workloads are deployed or removed.
-- **Service integration**: Exposed via a Kubernetes `Service`, allowing you to configure `NodePort`, `LoadBalancer`, or `ClusterIP` access depending on your environment.
-
-The gateway runs with the `wasmcloud-runtime-operator-gateway` ServiceAccount, which has read-only access to `Host` and `Workload` resources. It cannot modify cluster state.
 
 ## Host group
 
@@ -61,17 +55,20 @@ The Helm chart bundles NATS with JetStream enabled (`nats.enabled: true` by defa
 
 ## Request flow
 
-When a `WorkloadDeployment` is applied:
+When a `WorkloadDeployment` that references a Kubernetes Service is applied:
 
 1. The **wasmCloud operator** detects the new CRD, selects a matching host from the host group, and sends a workload start request to the host **via NATS** (`runtime.host.<hostID>.workload.start`).
-2. The operator updates the `WorkloadDeployment` status to reflect the scheduling outcome.
-3. The **Runtime Gateway** observes the new `Workload` resource via the Kubernetes API and adds a routing rule for HTTP traffic.
-4. Incoming HTTP requests hit the Gateway's Service, which forwards them directly to the appropriate host pod (by pod IP), where the **wash runtime** executes the Wasm component.
+2. The operator injects the Service's DNS aliases (e.g. `my-svc`, `my-svc.default`, `my-svc.default.svc`) into the host's HTTP router so incoming requests with a matching `Host` header route to this component.
+3. The operator creates and maintains an **EndpointSlice** owned by the referenced Service, populated with the pod IPs of the hosts running the workload.
+4. Incoming HTTP requests resolve the Service's ClusterIP via standard Kubernetes DNS and are forwarded by kube-proxy to the host pod IPs in the EndpointSlice, where the **wash runtime** executes the Wasm component.
+
+See the [Expose a Workload via Kubernetes Service](../../recipes/expose-workload-via-kubernetes-service.mdx) recipe for a step-by-step walk-through.
 
 ## Related documentation
 
 - [Custom Resource Definitions (CRDs)](../crds.mdx) — describes the `WorkloadDeployment`, `Host`, `Workload`, and other resources
-- [Roles and Role Bindings](./roles-and-rolebindings.mdx) — details the RBAC permissions required by the operator and gateway
+- [Helm Values Reference](./helm-values.mdx) — commonly-overridden configuration values
+- [Roles and Role Bindings](./roles-and-rolebindings.mdx) — details the RBAC permissions required by the operator
 - [Filesystems and Volumes](./filesystems-and-volumes.mdx) — how to mount volumes into host pods
 - [Secrets and Configuration Management](./secrets-and-configuration.mdx) — supplying environment variables, ConfigMaps, and Secrets to components
 - [Private Registries](./private-registries.mdx) — how to pull Wasm component images from private OCI registries

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -258,7 +258,7 @@ These are the image-related values you can configure:
 | `gateway.image.repository` | `wasmcloud/runtime-gateway` | Gateway image repository |
 | `runtime.image.registry` | `ghcr.io` | Runtime host image registry |
 | `runtime.image.repository` | `wasmcloud/wash` | Runtime host image repository |
-| `runtime.image.tag` | `2.0.3` | Runtime host image tag |
+| `runtime.image.tag` | Chart `appVersion` | Runtime host image tag (defaulted to the chart's `appVersion` starting in 2.0.3) |
 | `nats.image.registry` | `docker.io` | NATS image registry |
 | `nats.image.repository` | `nats` | NATS image repository |
 | `nats.image.tag` | `2.11.3-alpine` | NATS image tag |

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -228,19 +228,22 @@ sudo chown $USER ~/.kube/config
 
 Use Helm to install the wasmCloud operator:
 
+:::note[Runtime Gateway deprecated in 2.0.3]
+The tutorial below routes HTTP traffic through a Kubernetes Service whose EndpointSlice the operator manages directly. The earlier **Runtime Gateway** component that proxied traffic to workloads is deprecated as of 2.0.3 and will be removed in a future release; the local-dev overlay (`values.local.yaml`) disables it by default.
+:::
+
 <Tabs groupId="k8s-env" queryString>
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
-  --set gateway.service.type=LoadBalancer
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
   </TabItem>
   <TabItem value="kind" label="kind">
 
-The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the Runtime Gateway as a NodePort service on port 30950, which the kind cluster config maps to host port 80:
+The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures each host's HTTP listener on port 80. The kind cluster config maps container port 30950 to host port 80, so any NodePort Service on port 30950 will be reachable at `localhost`:
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
@@ -250,23 +253,21 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
   </TabItem>
   <TabItem value="k3d" label="k3d">
 
-k3d supports `LoadBalancer` services natively, so we override the gateway service type:
+k3d supports `LoadBalancer` services natively and we started the cluster with port 80 mapped to the load balancer:
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
-  --set gateway.service.type=LoadBalancer
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
   </TabItem>
   <TabItem value="k3s" label="k3s">
 
-k3s includes a built-in load balancer (Klipper), so we override the gateway service type:
+k3s includes a built-in load balancer (Klipper) that binds `LoadBalancer` services to node ports:
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml \
-  --set gateway.service.type=LoadBalancer
+  -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
   </TabItem>
@@ -280,53 +281,29 @@ kubectl rollout status deploy -l app.kubernetes.io/instance=wasmcloud -n default
 
 ## Deploy Wasm workload
 
-Now we'll deploy our Wasm application using a [`WorkloadDeployment`](../kubernetes-operator/crds.mdx#workloaddeployment) manifest.
+We'll deploy the Wasm application with two resources: a Kubernetes `Service` that receives HTTP traffic, and a [`WorkloadDeployment`](../kubernetes-operator/crds.mdx#workloaddeployment) that references the Service and tells the operator to schedule the component onto a host. The operator maintains an EndpointSlice for the Service pointing at the host pods running the workload, so standard Kubernetes DNS and routing reach the component directly.
 
 :::info[wasmCloud security model]
 wasmCloud components are **deny-by-default**: a component cannot use any capability—HTTP, key-value storage, logging, or any other—unless the host is explicitly told to allow it. The `hostInterfaces` field in a workload manifest is the allowlist. Each entry names an interface package that the host will make available to the component. Any interface not listed is silently unavailable, regardless of what the component's WIT file imports.
 :::
 
-Run the following script in your terminal to create a file called `deployment.yaml` containing a manifest.
+Run the following script in your terminal to create a file called `deployment.yaml` containing both manifests.
+
+<Tabs groupId="k8s-env" queryString>
+  <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
 cat > deployment.yaml << 'EOF'
-  apiVersion: runtime.wasmcloud.dev/v1alpha1
-  kind: WorkloadDeployment
-  metadata:
-    name: http-hello-world
-  spec:
-    replicas: 1
-    template:
-      spec:
-        hostSelector:
-          hostgroup: default
-        components:
-          - name: http-hello-world
-            image: ghcr.io/<namespace>/http-hello-world:0.1.0
-        hostInterfaces:
-          - namespace: wasi
-            package: http
-            interfaces:
-              - incoming-handler
-            config:
-              host: localhost
-          - namespace: wasi
-            package: keyvalue
-            interfaces:
-              - atomics
-              - store
-EOF
-```
-
-This is a deployment manifest for a [Kubernetes custom resource](../kubernetes-operator/crds.mdx). For the purposes of this quickstart, the most important fields to highlight in the specification are:
-
-- `hostSelector.hostgroup`: Selects which pool of wasmCloud hosts runs this workload. The Helm chart installs three host pods labelled `hostgroup: default`—this is the correct target for most deployments. Custom host groups can be created to isolate workloads or provide specialized capabilities.
-- `components.image`: This defines the registry address we will use to fetch our Wasm image.
-- `hostInterfaces`: These declare which capability interfaces the host will make available to the component. **Without an explicit entry here, the component cannot access that capability.** Since the HTTP and key-value capabilities use [well-known built-in interfaces](../overview/interfaces.mdx), all we have to do is list them.
-
-Open the file and update the image name with the correct registry address. If you're using GitHub Packages, that means replacing `<namespace>` with your GitHub namespace.
-
-```yaml {13}
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-hello-world
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+---
 apiVersion: runtime.wasmcloud.dev/v1alpha1
 kind: WorkloadDeployment
 metadata:
@@ -337,6 +314,54 @@ spec:
     spec:
       hostSelector:
         hostgroup: default
+      kubernetes:
+        service:
+          name: http-hello-world
+      components:
+        - name: http-hello-world
+          image: ghcr.io/<namespace>/http-hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+        - namespace: wasi
+          package: keyvalue
+          interfaces:
+            - atomics
+            - store
+EOF
+```
+
+  </TabItem>
+  <TabItem value="kind" label="kind">
+
+```shell
+cat > deployment.yaml << 'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-hello-world
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      protocol: TCP
+      nodePort: 30950
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: http-hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      kubernetes:
+        service:
+          name: http-hello-world
       components:
         - name: http-hello-world
           image: ghcr.io/<namespace>/http-hello-world:0.1.0
@@ -352,7 +377,112 @@ spec:
           interfaces:
             - atomics
             - store
+EOF
 ```
+
+  </TabItem>
+  <TabItem value="k3d" label="k3d">
+
+```shell
+cat > deployment.yaml << 'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-hello-world
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: http-hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      kubernetes:
+        service:
+          name: http-hello-world
+      components:
+        - name: http-hello-world
+          image: ghcr.io/<namespace>/http-hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: localhost
+        - namespace: wasi
+          package: keyvalue
+          interfaces:
+            - atomics
+            - store
+EOF
+```
+
+  </TabItem>
+  <TabItem value="k3s" label="k3s">
+
+```shell
+cat > deployment.yaml << 'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-hello-world
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: http-hello-world
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      kubernetes:
+        service:
+          name: http-hello-world
+      components:
+        - name: http-hello-world
+          image: ghcr.io/<namespace>/http-hello-world:0.1.0
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: localhost
+        - namespace: wasi
+          package: keyvalue
+          interfaces:
+            - atomics
+            - store
+EOF
+```
+
+  </TabItem>
+</Tabs>
+
+The manifest has two resources: a Kubernetes [custom resource](../kubernetes-operator/crds.mdx) (`WorkloadDeployment`) that describes the workload, and a standard `Service`. The fields to highlight in the `WorkloadDeployment`:
+
+- `hostSelector.hostgroup`: Selects which pool of wasmCloud hosts runs this workload. The Helm chart installs three host pods labelled `hostgroup: default`—this is the correct target for most deployments. Custom host groups can be created to isolate workloads or provide specialized capabilities.
+- `kubernetes.service.name`: References the Service by name. The operator creates and maintains an EndpointSlice for this Service that points at the host pods running the workload, and registers the Service's DNS names (`http-hello-world`, `http-hello-world.default`, `http-hello-world.default.svc`) with the host's HTTP router. For local development, `config.host: localhost` is added so the component also answers requests whose `Host` header is `localhost`.
+- `components.image`: Defines the registry address we will use to fetch our Wasm image.
+- `hostInterfaces`: Declares which capability interfaces the host will make available to the component. **Without an explicit entry here, the component cannot access that capability.** Since the HTTP and key-value capabilities use [well-known built-in interfaces](../overview/interfaces.mdx), all we have to do is list them.
+
+Open the file and update the image name with the correct registry address. If you're using GitHub Packages, that means replacing `<namespace>` with your GitHub namespace.
 
 Now use `kubectl` to apply the manifest:
 
@@ -372,7 +502,7 @@ Use `curl` to invoke the Wasm workload with an HTTP request:
 OrbStack manages port 80 on macOS, intercepting traffic before it reaches the cluster. Run a port-forward in a separate terminal:
 
 ```shell
-kubectl port-forward svc/runtime-gateway 8080:80
+kubectl port-forward svc/http-hello-world 8080:80
 ```
 
 Then substitute `localhost:8080` for `localhost` in the hello-world command, and use `-H "Host: blobby.localhost.direct" http://localhost:8080/...` in place of `http://blobby.localhost.direct/...` in the Blobby commands further below.
@@ -389,10 +519,30 @@ Hello x1, World!
 
 Now let's deploy a more feature-rich example: **Blobby** ("Little Blobby Tables"), a simple file server that demonstrates the [`wasi:blobstore`](https://github.com/WebAssembly/wasi-blobstore) capability alongside `wasi:http`.
 
-The manifest below uses `host: blobby.localhost.direct` to route HTTP traffic — `blobby.localhost.direct` is a public DNS alias for `127.0.0.1`, so no `/etc/hosts` changes are needed. Apply it to deploy the [`blobby-ui`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/blobby) component from a wasmCloud-hosted OCI image:
+Because only one NodePort/LoadBalancer Service can claim the external port at a time, **delete the `http-hello-world` workload and its Service before deploying Blobby**:
+
+```shell
+kubectl delete workloaddeployment http-hello-world
+kubectl delete service http-hello-world
+```
+
+The Blobby manifest routes HTTP traffic on `blobby.localhost.direct`, a public DNS alias for `127.0.0.1`, so no `/etc/hosts` changes are needed. Apply the manifest below to deploy the [`blobby-ui`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/blobby) component alongside a Service of the appropriate type for your environment:
+
+<Tabs groupId="k8s-env" queryString>
+  <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
 kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: blobby
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+---
 apiVersion: runtime.wasmcloud.dev/v1alpha1
 kind: WorkloadDeployment
 metadata:
@@ -401,6 +551,9 @@ spec:
   replicas: 1
   template:
     spec:
+      kubernetes:
+        service:
+          name: blobby
       hostInterfaces:
         - namespace: wasi
           package: http
@@ -425,6 +578,163 @@ spec:
           image: ghcr.io/wasmcloud/components/blobby-ui:0.5.2
 EOF
 ```
+
+  </TabItem>
+  <TabItem value="kind" label="kind">
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: blobby
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      protocol: TCP
+      nodePort: 30950
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: blobby
+spec:
+  replicas: 1
+  template:
+    spec:
+      kubernetes:
+        service:
+          name: blobby
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: blobby.localhost.direct
+        - namespace: wasi
+          package: blobstore
+          version: 0.2.0-draft
+          interfaces:
+            - blobstore
+          config:
+            buckets: blobby
+        - namespace: wasi
+          package: logging
+          version: 0.1.0-draft
+          interfaces:
+            - logging
+      components:
+        - name: blobby
+          image: ghcr.io/wasmcloud/components/blobby-ui:0.5.2
+EOF
+```
+
+  </TabItem>
+  <TabItem value="k3d" label="k3d">
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: blobby
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: blobby
+spec:
+  replicas: 1
+  template:
+    spec:
+      kubernetes:
+        service:
+          name: blobby
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: blobby.localhost.direct
+        - namespace: wasi
+          package: blobstore
+          version: 0.2.0-draft
+          interfaces:
+            - blobstore
+          config:
+            buckets: blobby
+        - namespace: wasi
+          package: logging
+          version: 0.1.0-draft
+          interfaces:
+            - logging
+      components:
+        - name: blobby
+          image: ghcr.io/wasmcloud/components/blobby-ui:0.5.2
+EOF
+```
+
+  </TabItem>
+  <TabItem value="k3s" label="k3s">
+
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: blobby
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: blobby
+spec:
+  replicas: 1
+  template:
+    spec:
+      kubernetes:
+        service:
+          name: blobby
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: blobby.localhost.direct
+        - namespace: wasi
+          package: blobstore
+          version: 0.2.0-draft
+          interfaces:
+            - blobstore
+          config:
+            buckets: blobby
+        - namespace: wasi
+          package: logging
+          version: 0.1.0-draft
+          interfaces:
+            - logging
+      components:
+        - name: blobby
+          image: ghcr.io/wasmcloud/components/blobby-ui:0.5.2
+EOF
+```
+
+  </TabItem>
+</Tabs>
 
 Verify the deployment:
 
@@ -465,10 +775,11 @@ curl -X DELETE http://blobby.localhost.direct/hello.txt
 
 ## Clean up
 
-To remove the deployments created in this tutorial:
+To remove the deployments and their Services created in this tutorial:
 
 ```shell
-kubectl delete workloaddeployment http-hello-world blobby
+kubectl delete workloaddeployment http-hello-world blobby --ignore-not-found
+kubectl delete service http-hello-world blobby --ignore-not-found
 ```
 
 To tear down the cluster entirely:

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -105,4 +105,23 @@ The crate supports the following `cargo` features:
 - `washlet` (default): Washlet support (depends on `oci`)
 - `wasi-webgpu`: WebGPU interface
 - `oci`: OCI registry integration for pulling components
+- `wasip3`: Experimental WASI Preview 3 support (see below)
+
+## WASI Preview 3 (experimental)
+
+As of wasmCloud 2.0.3, the runtime includes an experimental implementation of [WASI Preview 3](https://github.com/WebAssembly/WASI/blob/main/wasip2/README.md) behind the `wasip3` Cargo feature. WASI P3 adds native `async` support to WASI interfaces, replacing the poll-based concurrency model in P2 with futures and streams.
+
+Enable the feature when building `wash-runtime`:
+
+```shell
+cargo build --features wasip3
+```
+
+With `wasip3` enabled, the host registers P3 implementations for the following WASI interfaces alongside the P2 versions:
+
+- `wasi:http` (incoming-handler, outgoing-handler, types)
+- `wasi:sockets/ip-name-lookup`
+- `wasi:sockets/tcp`, `wasi:sockets/udp`
+
+Components targeting either P2 or P3 worlds are compatible with a host built with this flag. The P2 interfaces remain the stable default — P3 support is exposed for early integration testing and will become the default in a future release.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -83,6 +83,7 @@ const sidebars = {
           label: 'Operator Manual',
           items: [
             'kubernetes-operator/operator-manual/overview',
+            'kubernetes-operator/operator-manual/helm-values',
             'kubernetes-operator/operator-manual/cicd',
             'kubernetes-operator/operator-manual/roles-and-rolebindings',
             'kubernetes-operator/operator-manual/secrets-and-configuration',


### PR DESCRIPTION
Brings the docs in line with wasmCloud 2.0.3.

- **Service-based HTTP routing**: the Runtime Gateway is deprecated; the operator now routes HTTP traffic via EndpointSlices tied to standard Kubernetes Services. Rewrites the quickstart, installation, and Kubernetes Operator pages around a `Service` + `WorkloadDeployment` pattern that uses `spec.template.spec.kubernetes.service.name`.
- **New Helm Values Reference page** under Kubernetes Operator (wired into the sidebar), covering `global.tls.enabled`, pod labels/annotations, `watchNamespaces`, `runtime.hostGroups[].http.port`, and the new `runtime.image.tag` default.
- **Operator Overview rewrite** around the three remaining deployments (operator, host group, NATS) and the EndpointSlice-based request flow.
- **WASI Preview 3 (experimental)** section added to the Runtime page covering the `wasip3` Cargo feature.
- **Lightweight deployments** page gains a gateway-deprecation admonition (the upstream Compose file still ships the gateway because Compose has no EndpointSlice equivalent).
- **2.0.2 → 2.0.3** bumps across the Kubernetes docs, quickstart, installation, CI/CD, and private-registries pages.

~~⚠️ This PR assumes https://github.com/wasmCloud/wasmCloud/pull/5067 is merged first.~~
wasmCloud/wasmCloud PR now merged, this is ready to go