### PR TITLE
docs(rust): add Rust interface guides and async runtime guidance

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -204,9 +204,9 @@ Complete example applications are available in the [`examples/` directory of `wa
 
 A simple HTTP server demonstrating how to handle HTTP requests using the `wstd` async runtime.
 
-- **Source**: [`wasmCloud/wasmCloud — examples/http-hello-world`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/http-hello-world)
+- **Source**: [`wasmCloud/wasmCloud — templates/http-hello-world`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-hello-world)
 - **OCI artifact**: `ghcr.io/wasmcloud/components/hello-world:0.1.0`
-- **Kubernetes manifest**: [`examples/http-hello-world/manifests/workloaddeployment.yaml`](https://github.com/wasmCloud/wasmCloud/blob/main/examples/http-hello-world/manifests/workloaddeployment.yaml)
+- **Kubernetes manifest**: [`templates/http-hello-world/manifests/workloaddeployment.yaml`](https://github.com/wasmCloud/wasmCloud/blob/main/templates/http-hello-world/manifests/workloaddeployment.yaml)
 - **Interfaces**: Exports `wasi:http/incoming-handler`
 
 #### Blobby

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -152,10 +152,10 @@ Once all pods are running, you're ready to deploy a Wasm workload.
 
 ### Deploy a Wasm workload
 
-Apply the [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml), which contains a `NodePort` Service and a `WorkloadDeployment` that references it by name. The operator creates an EndpointSlice for the Service pointing at the host pods running the workload, so the NodePort on port 30950 (mapped to host port 80 by the kind cluster config) reaches the component directly:
+Apply the [wasmCloud-hosted manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/templates/http-hello-world/manifests/workloaddeployment.yaml), which contains a `NodePort` Service and a `WorkloadDeployment` that references it by name. The operator creates an EndpointSlice for the Service pointing at the host pods running the workload, so the NodePort on port 30950 (mapped to host port 80 by the kind cluster config) reaches the component directly:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/templates/http-hello-world/manifests/workloaddeployment.yaml
 ```
 
 Use `curl` to invoke the Wasm workload with an HTTP request:

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -195,7 +195,7 @@ spec:
 
 This manifest deploys a simple "Hello world!" component that uses the `wasi:http` interface, scheduled on the `default` hostgroup and reachable inside the cluster at `hello-world.default.svc.cluster.local`.
 
-For a kind-optimized NodePort variant that answers `curl localhost` on port 80, see the [wasmCloud-hosted hello-world manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/examples/http-hello-world/manifests/workloaddeployment.yaml) used by the [Installation](../installation.mdx#deploy-a-wasm-workload) guide.
+For a kind-optimized NodePort variant that answers `curl localhost` on port 80, see the [wasmCloud-hosted hello-world manifest](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/templates/http-hello-world/manifests/workloaddeployment.yaml) used by the [Installation](../installation.mdx#deploy-a-wasm-workload) guide.
 
 :::note[]
 Learn more about `WorkloadDeployments` and other wasmCloud resources in the [Custom Resource Definitions (CRDs) section](./crds.mdx). For the full Service-routing walk-through, see [Expose a Workload via Kubernetes Service](../recipes/expose-workload-via-kubernetes-service.mdx).

--- a/docs/overview/workloads/index.mdx
+++ b/docs/overview/workloads/index.mdx
@@ -13,7 +13,7 @@ A wasmCloud **workload** is an application-level abstraction that consists of on
 ![Workload diagram](../../images/workload-diagram.png)
 
 - **Components** are portable, interoperable binaries (`.wasm` files) that implement stateless logic, typically enacting the core logic of an application (for example, the API for a web application), while leaving stateful or reusable functionality (e.g., key-value storage or HTTP) to [services](./services.mdx), [hosts](../hosts/index.mdx), and [host plugins](../hosts/plugins.mdx).
-  * You can find a simple example of a Rust-based "Hello world!" component in [`wash/examples`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/http-hello-world).
+  * You can find a simple example of a Rust-based "Hello world!" component in [`wasmCloud/templates`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-hello-world).
 
 - **Services** are persistent, stateful Wasm binaries that can act as `localhost` within the workload boundary and provide long-running processes.
   * You can find a simple example of a Rust-based cron service in [`wash/examples`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/cron-service).

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -380,14 +380,14 @@ Now that we've installed `wash` and our language toolchain, it's time to create 
 In your terminal, run:
 
 ```shell
-wash new https://github.com/wasmCloud/wasmCloud.git --name http-hello-world --subfolder examples/http-hello-world
+wash new https://github.com/wasmCloud/wasmCloud.git --name http-hello-world --subfolder templates/http-hello-world
 ```
 
 This command...
 
 * Creates a new project named `http-hello-world`...
 * Based on a template found in the [`wasmCloud/wasmCloud`](https://github.com/wasmCloud/wasmCloud) Git repository...
-* In the subfolder `examples/http-hello-world`.
+* In the subfolder `templates/http-hello-world`.
 
 Navigate to the `hello` project directory:
 

--- a/docs/wash/developer-guide/index.mdx
+++ b/docs/wash/developer-guide/index.mdx
@@ -36,14 +36,14 @@ Let's create a component that accepts an HTTP request and responds with "Hello f
 Use `wash new` to create a new component project from an example in a Git repository: 
 
 ```shell
-wash new https://github.com/wasmCloud/wasmCloud.git --name hello --subfolder examples/http-hello-world
+wash new https://github.com/wasmCloud/wasmCloud.git --name hello --subfolder templates/http-hello-world
 ```
 
 This command...
 
 * Creates a new project named `hello`...
-* Based on an example found in the [`wasmCloud/wasmCloud`](https://github.com/wasmCloud/wasmCloud) Git repository...
-* In the subfolder `examples/http-hello-world`
+* Based on a template found in the [`wasmCloud/wasmCloud`](https://github.com/wasmCloud/wasmCloud) Git repository...
+* In the subfolder `templates/http-hello-world`
 </TabItem>
 
 <TabItem value="tinygo" label="TinyGo">

--- a/docs/wash/developer-guide/language-support/rust/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/rust/configuration.mdx
@@ -1,0 +1,244 @@
+---
+title: 'Configuration'
+sidebar_position: 4
+---
+
+You can read runtime configuration values in a Rust component with the [`wasi:cli/environment`](https://github.com/WebAssembly/wasi-cli) interface. Configuration values can be supplied from inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. All arrive through the same interface regardless of source.
+
+This guide walks through reading `wasi:cli/environment` from a Rust component and shows how to provide values via a Kubernetes workload manifest.
+
+## Overview
+
+`wasi:cli/environment` is part of the standard WASI 0.2 suite and is always available in a wasmCloud host. It exposes a `get-environment` function that returns all configuration key-value pairs available to the component. In production, values come from `localResources.environment` in a `Workload` or `WorkloadDeployment` manifest, which accepts inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets.
+
+:::tip[Guidance for operators]
+The [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx) page in the Operator Manual describes how the Kubernetes operator injects values via `wasi:cli/environment`. This guide covers the component author's side: how to read those values in Rust.
+:::
+
+`wasi:cli/environment` is bundled into [`wstd`](https://github.com/bytecodealliance/wstd) through its `wasip2` dependency. You can read configuration directly through `wasi::cli::environment::get_environment` without adding `wit-bindgen` or any new dependency to your `Cargo.toml`. If your component already depends on `wstd` for HTTP, the import is free.
+
+## Step 1: Read configuration values
+
+Add a helper that reads all key-value pairs into a `HashMap` for convenient lookup:
+
+```rust title="src/lib.rs"
+use std::collections::HashMap;
+use wstd::http::{Body, Request, Response};
+
+fn load_config() -> HashMap<String, String> {
+    wstd::wasi::cli::environment::get_environment()
+        .into_iter()
+        .collect()
+}
+
+#[wstd::http_server]
+async fn main(_req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    let config = load_config();
+
+    let app_name = config
+        .get("APP_NAME")
+        .cloned()
+        .unwrap_or_else(|| "My App (dev)".to_string());
+    let upstream_url = config
+        .get("UPSTREAM_URL")
+        .cloned()
+        .unwrap_or_else(|| "http://localhost:9090".to_string());
+
+    let body = format!("app={app_name}\nupstream={upstream_url}\n");
+    Ok(Response::new(Body::from(body)))
+}
+```
+
+Call `get_environment()` (or your `load_config` helper) inside each request handler rather than at module scope. Configuration is stable for the lifetime of an invocation, but reading at module scope can run before the host has finished injecting values.
+
+### Synchronous API
+
+`get_environment` is synchronous in WIT. It returns `Vec<(String, String)>` directly without an `async` wrapper. Your handler can be synchronous or asynchronous — the call works the same way either way.
+
+## Step 2: Provide configuration values
+
+### In production (Kubernetes manifests)
+
+All configuration values are delivered to the component through the `localResources.environment` field in a `Workload` or `WorkloadDeployment` manifest. Three sources are supported and can be combined.
+
+#### Inline values
+
+The simplest approach: provide key-value pairs directly in the manifest:
+
+```yaml
+components:
+  - name: http-component
+    image: ghcr.io/your-org/your-component:latest
+    localResources:
+      environment:
+        config:
+          APP_NAME: My Service
+          UPSTREAM_URL: https://api.example.com
+```
+
+Inline values are suitable for non-sensitive configuration that is safe to store in version control.
+
+#### From a Kubernetes ConfigMap
+
+Reference a ConfigMap by name. Each key in the ConfigMap becomes a configuration value in the component:
+
+```yaml
+components:
+  - name: http-component
+    image: ghcr.io/your-org/your-component:latest
+    localResources:
+      environment:
+        configFrom:
+          - name: app-config
+```
+
+Create the ConfigMap separately:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: default
+data:
+  APP_NAME: My Service
+  UPSTREAM_URL: https://api.example.com
+```
+
+#### From a Kubernetes Secret
+
+Reference a Secret by name for sensitive values such as API keys or credentials:
+
+```yaml
+components:
+  - name: http-component
+    image: ghcr.io/your-org/your-component:latest
+    localResources:
+      environment:
+        secretFrom:
+          - name: app-secrets
+```
+
+Secret values are delivered to the component as plain strings. No decoding is required in your component code.
+
+#### Combining sources
+
+All three sources can be used together. When the same key appears in multiple sources, the order of precedence (lowest to highest) is: `config` → `configFrom` → `secretFrom`.
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      components:
+        - name: http-component
+          image: ghcr.io/your-org/your-component:latest
+          localResources:
+            environment:
+              config:
+                APP_NAME: My Service           # inline (lowest precedence)
+              configFrom:
+                - name: app-config             # non-sensitive config from ConfigMap
+              secretFrom:
+                - name: app-secrets            # sensitive values from Secret (highest precedence)
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            address: '0.0.0.0:8080'
+```
+
+:::tip
+For a complete reference to `localResources.environment` fields, including precedence rules and RBAC considerations, see [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx).
+:::
+
+### During development (`wash dev`)
+
+`wash dev` provides the `wasi:cli/environment` interface, but `localResources.environment` defaults to empty. There is currently no mechanism in `.wash/config.yaml` or the `wash dev` CLI to inject test configuration values into a component locally.
+
+The practical approach for development is to supply fallback defaults in your component code, as shown in the example above. This lets your component run correctly during `wash dev` while reading real values in production.
+
+## Build and verify
+
+```shell
+wash dev
+```
+
+`wash dev` builds the component and serves it on `http://localhost:8000`. With no configuration injected, your fallback defaults take effect:
+
+```shell
+curl http://localhost:8000
+```
+
+```text
+app=My App (dev)
+upstream=http://localhost:9090
+```
+
+To verify the import is correctly declared, inspect the built component:
+
+```shell
+wasm-tools component wit target/wasm32-wasip2/release/<crate>.wasm | grep environment
+```
+
+You should see a line like `import wasi:cli/environment@0.2.x`. The exact patch version is governed by the `wasip2` crate version that `wstd` resolves to.
+
+## Without `wstd`: the `wit-bindgen` path
+
+If your component does not use `wstd`, you can still call `wasi:cli/environment` by generating bindings with `wit-bindgen`:
+
+```wit title="wit/world.wit"
+package wasmcloud:my-component;
+
+world my-component {
+  import wasi:cli/environment@0.2.2;
+
+  export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+```rust title="src/lib.rs"
+mod bindings {
+    wit_bindgen::generate!({ generate_all });
+}
+
+use bindings::wasi::cli::environment::get_environment;
+
+let config: std::collections::HashMap<String, String> = get_environment().into_iter().collect();
+```
+
+The function name and signature are identical to the `wstd`-bundled path. Choose whichever fits your existing setup.
+
+## Summary: checklist for adding configuration
+
+1. **Read configuration through `wasi::cli::environment::get_environment`**. If you depend on `wstd`, the function is already available under `wstd::wasi::cli::environment::get_environment`. Otherwise, declare the import in `wit/world.wit` and generate bindings with `wit-bindgen`.
+2. **Call `get_environment()` inside request handlers**, not at module scope.
+3. **Collect into a `HashMap`** for ergonomic key lookup: `get_environment().into_iter().collect::<HashMap<_, _>>()`.
+4. **Provide fallback defaults** with `unwrap_or_else` for every value your component reads. This keeps the component functional during `wash dev` when no configuration is injected.
+5. **In production**, provide values via `localResources.environment` in your Kubernetes manifest, using `config:`, `configFrom:`, or `secretFrom:` as appropriate.
+
+## API reference: `wasi:cli/environment` functions
+
+For the upstream WIT definitions, see the [`wasi:cli` 0.2.x interfaces](https://github.com/WebAssembly/wasi-cli/tree/main/wit) in the `WebAssembly/wasi-cli` repository.
+
+| Function | Signature | Description |
+|---|---|---|
+| `get_environment` | `fn() -> Vec<(String, String)>` | Returns all configuration key-value pairs. Returns an empty `Vec` if no configuration has been provided to the component. |
+| `get_arguments` | `fn() -> Vec<String>` | Returns POSIX-style command-line arguments. Not used for configuration. |
+| `initial_cwd` | `fn() -> Option<String>` | Returns the initial working directory. Not used for configuration. |
+
+## Further reading
+
+- [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx) — operator reference for `localResources.environment`, ConfigMaps, and Secrets
+- [Rust Language Guide](./index.mdx) — toolchain overview, HTTP patterns, async runtime guidance, and crate compatibility
+- [Key-Value Storage](./key-value-storage.mdx) — persistent key-value storage for component state
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/docs/wash/developer-guide/language-support/rust/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/rust/configuration.mdx
@@ -63,7 +63,7 @@ Call `get_environment()` (or your `load_config` helper) inside each request hand
 
 ### Synchronous API
 
-`get_environment` is synchronous in WIT. It returns `Vec<(String, String)>` directly without an `async` wrapper. Your handler can be synchronous or asynchronous — the call works the same way either way.
+`get_environment` is synchronous in WIT. It returns `Vec<(String, String)>` directly without an `async` wrapper. The call works the same way whether your handler is synchronous or asynchronous.
 
 ## Step 3: Provide configuration values
 
@@ -164,8 +164,10 @@ spec:
           interfaces:
             - incoming-handler
           config:
-            address: '0.0.0.0:8080'
+            host: my-app.example.com
 ```
+
+The `host:` value is the HTTP `Host` header the wasmCloud host uses to route requests to this workload. If you want to override the listen address instead, use `address: '0.0.0.0:8080'`. See [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx) for the full `hostInterfaces` reference.
 
 :::tip
 For a complete reference to `localResources.environment` fields, including precedence rules and RBAC considerations, see [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx).

--- a/docs/wash/developer-guide/language-support/rust/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/rust/configuration.mdx
@@ -15,9 +15,17 @@ This guide walks through reading `wasi:cli/environment` from a Rust component an
 The [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx) page in the Operator Manual describes how the Kubernetes operator injects values via `wasi:cli/environment`. This guide covers the component author's side: how to read those values in Rust.
 :::
 
-`wasi:cli/environment` is bundled into [`wstd`](https://github.com/bytecodealliance/wstd) through its `wasip2` dependency. You can read configuration directly through `wasi::cli::environment::get_environment` without adding `wit-bindgen` or any new dependency to your `Cargo.toml`. If your component already depends on `wstd` for HTTP, the import is free.
+`wasi:cli/environment` is provided by the [`wasip2`](https://crates.io/crates/wasip2) crate maintained by the Bytecode Alliance. `wstd` already depends on `wasip2` internally, but does not re-export it publicly, so you add `wasip2` as a direct dependency and call `wasip2::cli::environment::get_environment` from your handler. No `wit-bindgen` setup is required.
 
-## Step 1: Read configuration values
+## Step 1: Add the dependency
+
+```toml title="Cargo.toml"
+[dependencies]
+wasip2 = "1.0"
+wstd = "0.6"
+```
+
+## Step 2: Read configuration values
 
 Add a helper that reads all key-value pairs into a `HashMap` for convenient lookup:
 
@@ -26,7 +34,7 @@ use std::collections::HashMap;
 use wstd::http::{Body, Request, Response};
 
 fn load_config() -> HashMap<String, String> {
-    wstd::wasi::cli::environment::get_environment()
+    wasip2::cli::environment::get_environment()
         .into_iter()
         .collect()
 }
@@ -55,7 +63,7 @@ Call `get_environment()` (or your `load_config` helper) inside each request hand
 
 `get_environment` is synchronous in WIT. It returns `Vec<(String, String)>` directly without an `async` wrapper. Your handler can be synchronous or asynchronous — the call works the same way either way.
 
-## Step 2: Provide configuration values
+## Step 3: Provide configuration values
 
 ### In production (Kubernetes manifests)
 
@@ -192,9 +200,9 @@ wasm-tools component wit target/wasm32-wasip2/release/<crate>.wasm | grep enviro
 
 You should see a line like `import wasi:cli/environment@0.2.x`. The exact patch version is governed by the `wasip2` crate version that `wstd` resolves to.
 
-## Without `wstd`: the `wit-bindgen` path
+## Alternative: the `wit-bindgen` path
 
-If your component does not use `wstd`, you can still call `wasi:cli/environment` by generating bindings with `wit-bindgen`:
+If you would rather not depend on `wasip2` directly, you can declare the import in your WIT world and generate bindings with `wit-bindgen`:
 
 ```wit title="wit/world.wit"
 package wasmcloud:my-component;
@@ -216,12 +224,12 @@ use bindings::wasi::cli::environment::get_environment;
 let config: std::collections::HashMap<String, String> = get_environment().into_iter().collect();
 ```
 
-The function name and signature are identical to the `wstd`-bundled path. Choose whichever fits your existing setup.
+The function name and signature are identical to the `wasip2` crate path. Choose whichever fits your existing setup.
 
 ## Summary: checklist for adding configuration
 
-1. **Read configuration through `wasi::cli::environment::get_environment`**. If you depend on `wstd`, the function is already available under `wstd::wasi::cli::environment::get_environment`. Otherwise, declare the import in `wit/world.wit` and generate bindings with `wit-bindgen`.
-2. **Call `get_environment()` inside request handlers**, not at module scope.
+1. **Add `wasip2 = "1.0"` to `Cargo.toml`** (or use `wit-bindgen` if you prefer to declare the import in your WIT world).
+2. **Call `wasip2::cli::environment::get_environment()` inside request handlers**, not at module scope.
 3. **Collect into a `HashMap`** for ergonomic key lookup: `get_environment().into_iter().collect::<HashMap<_, _>>()`.
 4. **Provide fallback defaults** with `unwrap_or_else` for every value your component reads. This keeps the component functional during `wash dev` when no configuration is injected.
 5. **In production**, provide values via `localResources.environment` in your Kubernetes manifest, using `config:`, `configFrom:`, or `secretFrom:` as appropriate.

--- a/docs/wash/developer-guide/language-support/rust/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/rust/configuration.mdx
@@ -9,7 +9,7 @@ This guide walks through reading `wasi:cli/environment` from a Rust component an
 
 ## Overview
 
-`wasi:cli/environment` is part of the standard WASI 0.2 suite and is always available in a wasmCloud host. It exposes a `get-environment` function that returns all configuration key-value pairs available to the component. In production, values come from `localResources.environment` in a `Workload` or `WorkloadDeployment` manifest, which accepts inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets.
+`wasi:cli/environment` is part of the standard WASI P2 suite and is always available in a wasmCloud host. It exposes a `get-environment` function that returns all configuration key-value pairs available to the component. In production, values come from `localResources.environment` in a `Workload` or `WorkloadDeployment` manifest, which accepts inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets.
 
 :::tip[Guidance for operators]
 The [Secrets and Configuration Management](../../../../kubernetes-operator/operator-manual/secrets-and-configuration.mdx) page in the Operator Manual describes how the Kubernetes operator injects values via `wasi:cli/environment`. This guide covers the component author's side: how to read those values in Rust.
@@ -19,7 +19,9 @@ The [Secrets and Configuration Management](../../../../kubernetes-operator/opera
 
 ## Step 1: Add the dependency
 
-```toml title="Cargo.toml"
+In `Cargo.toml`:
+
+```toml
 [dependencies]
 wasip2 = "1.0"
 wstd = "0.6"
@@ -27,9 +29,9 @@ wstd = "0.6"
 
 ## Step 2: Read configuration values
 
-Add a helper that reads all key-value pairs into a `HashMap` for convenient lookup:
+In `src/lib.rs`, add a helper that reads all key-value pairs into a `HashMap` for convenient lookup:
 
-```rust title="src/lib.rs"
+```rust
 use std::collections::HashMap;
 use wstd::http::{Body, Request, Response};
 
@@ -202,9 +204,11 @@ You should see a line like `import wasi:cli/environment@0.2.x`. The exact patch 
 
 ## Alternative: the `wit-bindgen` path
 
-If you would rather not depend on `wasip2` directly, you can declare the import in your WIT world and generate bindings with `wit-bindgen`:
+If you would rather not depend on `wasip2` directly, you can declare the import in your WIT world and generate bindings with `wit-bindgen`.
 
-```wit title="wit/world.wit"
+In `wit/world.wit`:
+
+```wit
 package wasmcloud:my-component;
 
 world my-component {
@@ -214,7 +218,9 @@ world my-component {
 }
 ```
 
-```rust title="src/lib.rs"
+In `src/lib.rs`:
+
+```rust
 mod bindings {
     wit_bindgen::generate!({ generate_all });
 }

--- a/docs/wash/developer-guide/language-support/rust/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/rust/filesystem.mdx
@@ -377,12 +377,11 @@ The function and type names are identical between paths.
 
 ## Summary: checklist for adding filesystem access
 
-1. **Decide on the binding path**. The simplest option is to add `wasip2 = "1.0"` to `Cargo.toml` and read filesystem types from `wasip2::filesystem::*`. Otherwise, declare the imports in `wit/world.wit` and use `wit_bindgen::generate!`.
+1. **Decide on the binding path**. The simplest option is to add `wasip2 = "1.0"` to `Cargo.toml` and read filesystem types from `wasip2::filesystem::*`. Otherwise, declare the imports in `wit/world.wit` and use `wit_bindgen::generate!` (any 0.4x release works).
 2. **Use `get_directories()`** to discover preopened mounts. Look up the descriptor whose mount path matches the directory you need.
 3. **Open files with `open_at`** using the appropriate `OpenFlags` and `DescriptorFlags` bitflags.
 4. **Read with `file.read(length, offset)`** and write with `file.write(buffer, offset)`. Both return `Result` types.
 5. **Configure volumes** in `.wash/config.yaml` for local development or in a WorkloadDeployment manifest for production.
-6. **No bundler or generator changes needed** — `wstd` already brings the bindings, and `wit-bindgen` generates them when you ask for `generate_all`.
 
 ## API reference: `wasi:filesystem` operations used
 

--- a/docs/wash/developer-guide/language-support/rust/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/rust/filesystem.mdx
@@ -24,7 +24,9 @@ Components have **no filesystem access by default**. Directories must be explici
 
 `wasi:filesystem` is provided by the [`wasip2`](https://crates.io/crates/wasip2) crate maintained by the Bytecode Alliance. `wstd` already depends on `wasip2` internally but does not re-export it publicly, so you add `wasip2` as a direct dependency. The examples below use this path. A `wit-bindgen` variant is described at the end.
 
-```toml title="Cargo.toml"
+In `Cargo.toml`:
+
+```toml
 [dependencies]
 wasip2 = "1.0"
 wstd = "0.6"
@@ -34,7 +36,9 @@ wstd = "0.6"
 
 `get_directories` returns a `Vec<(Descriptor, String)>`. Each tuple pairs a directory descriptor with its mount path inside the component:
 
-```rust title="src/lib.rs"
+In `src/lib.rs`:
+
+```rust
 use wasip2::filesystem::preopens::get_directories;
 use wasip2::filesystem::types::Descriptor;
 
@@ -136,7 +140,7 @@ fn list_entries(dir: &Descriptor) -> Result<Vec<Entry>, String> {
 
 Putting it together with `wstd-axum`:
 
-```rust title="src/lib.rs"
+```rust
 use axum::{
     Json, Router,
     extract::Path,
@@ -265,7 +269,7 @@ impl IntoResponse for AppError {
 
 The `Cargo.toml` for this pattern:
 
-```toml title="Cargo.toml"
+```toml
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["json", "matched-path"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -279,7 +283,7 @@ wstd-axum = "0.6"
 
 To mount a host directory into the component during development, add a `volumes` entry to `.wash/config.yaml`:
 
-```yaml title=".wash/config.yaml"
+```yaml
 build:
   command: cargo build --target wasm32-wasip2 --release
   component_path: target/wasm32-wasip2/release/<crate>.wasm
@@ -345,7 +349,9 @@ Important notes:
 
 If you would rather declare the imports in your WIT world and generate bindings with `wit-bindgen`:
 
-```wit title="wit/world.wit"
+In `wit/world.wit`:
+
+```wit
 package wasmcloud:my-component;
 
 world my-component {
@@ -356,7 +362,9 @@ world my-component {
 }
 ```
 
-```rust title="src/lib.rs"
+In `src/lib.rs`:
+
+```rust
 mod bindings {
     wit_bindgen::generate!({ generate_all });
 }

--- a/docs/wash/developer-guide/language-support/rust/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/rust/filesystem.mdx
@@ -22,15 +22,21 @@ This is different from key-value or blob storage. Instead of storing data in an 
 Components have **no filesystem access by default**. Directories must be explicitly mounted via volume configuration in `wash dev` or via `volumeMounts` in a WorkloadDeployment manifest. A component can only access the directories that have been preopened for it; it cannot traverse outside those mount points. For details on deploying with volumes, see [Filesystems and Volumes](../../../../kubernetes-operator/operator-manual/filesystems-and-volumes.mdx).
 :::
 
-`wasi:filesystem` is bundled into [`wstd`](https://github.com/bytecodealliance/wstd) through its `wasip2` dependency, so you can use it without adding `wit-bindgen`. The examples below use the `wstd`-bundled path. A `wit-bindgen` variant is described at the end.
+`wasi:filesystem` is provided by the [`wasip2`](https://crates.io/crates/wasip2) crate maintained by the Bytecode Alliance. `wstd` already depends on `wasip2` internally but does not re-export it publicly, so you add `wasip2` as a direct dependency. The examples below use this path. A `wit-bindgen` variant is described at the end.
 
-## Step 1: Read preopens with `wstd`
+```toml title="Cargo.toml"
+[dependencies]
+wasip2 = "1.0"
+wstd = "0.6"
+```
+
+## Step 1: Read preopens
 
 `get_directories` returns a `Vec<(Descriptor, String)>`. Each tuple pairs a directory descriptor with its mount path inside the component:
 
 ```rust title="src/lib.rs"
-use wstd::wasi::filesystem::preopens::get_directories;
-use wstd::wasi::filesystem::types::Descriptor;
+use wasip2::filesystem::preopens::get_directories;
+use wasip2::filesystem::types::Descriptor;
 
 fn open_preopen(path: &str) -> Option<Descriptor> {
     get_directories()
@@ -58,7 +64,7 @@ File descriptors expose:
 ### Reading a file
 
 ```rust
-use wstd::wasi::filesystem::types::{DescriptorFlags, OpenFlags, PathFlags};
+use wasip2::filesystem::types::{DescriptorFlags, OpenFlags, PathFlags};
 
 fn read_file(dir: &Descriptor, name: &str) -> Result<String, String> {
     let file = dir
@@ -99,7 +105,7 @@ fn write_file(dir: &Descriptor, name: &str, data: &[u8]) -> Result<u64, String> 
 ### Listing entries
 
 ```rust
-use wstd::wasi::filesystem::types::DescriptorType;
+use wasip2::filesystem::types::DescriptorType;
 
 struct Entry {
     name: String,
@@ -139,8 +145,8 @@ use axum::{
     routing::get,
 };
 use serde::Serialize;
-use wstd::wasi::filesystem::preopens::get_directories;
-use wstd::wasi::filesystem::types::{
+use wasip2::filesystem::preopens::get_directories;
+use wasip2::filesystem::types::{
     Descriptor, DescriptorFlags, DescriptorType, OpenFlags, PathFlags,
 };
 
@@ -264,6 +270,7 @@ The `Cargo.toml` for this pattern:
 axum = { version = "0.8", default-features = false, features = ["json", "matched-path"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+wasip2 = "1.0"
 wstd = "0.6"
 wstd-axum = "0.6"
 ```
@@ -334,9 +341,9 @@ Important notes:
 - The `mountPath` in the manifest corresponds to the guest path the component sees in `get_directories()`.
 - You do not need to declare `wasi:filesystem` under `hostInterfaces`.
 
-## Without `wstd`: the `wit-bindgen` path
+## Alternative: the `wit-bindgen` path
 
-If your component does not depend on `wstd`, declare the imports in your WIT world and generate bindings with `wit-bindgen`:
+If you would rather declare the imports in your WIT world and generate bindings with `wit-bindgen`:
 
 ```wit title="wit/world.wit"
 package wasmcloud:my-component;
@@ -362,7 +369,7 @@ The function and type names are identical between paths.
 
 ## Summary: checklist for adding filesystem access
 
-1. **Decide on the binding path**. If your component uses `wstd`, read filesystem types under `wstd::wasi::filesystem::*`. Otherwise, declare the imports in `wit/world.wit` and use `wit_bindgen::generate!`.
+1. **Decide on the binding path**. The simplest option is to add `wasip2 = "1.0"` to `Cargo.toml` and read filesystem types from `wasip2::filesystem::*`. Otherwise, declare the imports in `wit/world.wit` and use `wit_bindgen::generate!`.
 2. **Use `get_directories()`** to discover preopened mounts. Look up the descriptor whose mount path matches the directory you need.
 3. **Open files with `open_at`** using the appropriate `OpenFlags` and `DescriptorFlags` bitflags.
 4. **Read with `file.read(length, offset)`** and write with `file.write(buffer, offset)`. Both return `Result` types.

--- a/docs/wash/developer-guide/language-support/rust/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/rust/filesystem.mdx
@@ -1,0 +1,393 @@
+---
+title: 'Filesystem'
+sidebar_position: 3
+---
+
+You can add filesystem capabilities to a Rust component with the [`wasi:filesystem`](https://github.com/WebAssembly/WASI/tree/main/proposals/filesystem) interface.
+
+This guide walks through adding filesystem access to a Rust component using `wit-bindgen` alongside `wstd`.
+
+## Overview
+
+WebAssembly components run in a sandboxed environment with no default access to the host filesystem. The `wasi:filesystem` interface provides secure, capability-based filesystem access through **preopens**: directories that are explicitly mounted into a component before instantiation.
+
+This is different from key-value or blob storage. Instead of storing data in an abstract store, your component reads and writes files in mounted directories, just as a traditional application would. `wasi:filesystem` is particularly useful for:
+
+- Serving static assets (HTML, CSS, images)
+- Reading data files
+- Writing logs or output files
+- Any workload that needs to interact with files on disk
+
+:::info[Security model]
+Components have **no filesystem access by default**. Directories must be explicitly mounted via volume configuration in `wash dev` or via `volumeMounts` in a WorkloadDeployment manifest. A component can only access the directories that have been preopened for it; it cannot traverse outside those mount points. For details on deploying with volumes, see [Filesystems and Volumes](../../../../kubernetes-operator/operator-manual/filesystems-and-volumes.mdx).
+:::
+
+`wasi:filesystem` is bundled into [`wstd`](https://github.com/bytecodealliance/wstd) through its `wasip2` dependency, so you can use it without adding `wit-bindgen`. The examples below use the `wstd`-bundled path. A `wit-bindgen` variant is described at the end.
+
+## Step 1: Read preopens with `wstd`
+
+`get_directories` returns a `Vec<(Descriptor, String)>`. Each tuple pairs a directory descriptor with its mount path inside the component:
+
+```rust title="src/lib.rs"
+use wstd::wasi::filesystem::preopens::get_directories;
+use wstd::wasi::filesystem::types::Descriptor;
+
+fn open_preopen(path: &str) -> Option<Descriptor> {
+    get_directories()
+        .into_iter()
+        .find(|(_, mount)| mount == path)
+        .map(|(desc, _)| desc)
+}
+```
+
+In the rest of this guide, `open_preopen("/data")` returns the `Descriptor` for the `/data` mount point.
+
+## Step 2: Read and write files
+
+A `Descriptor` is a handle to an open file or directory. Directory descriptors expose:
+
+- `read_directory()` returns a `DirectoryEntryStream`
+- `open_at(...)` opens a file relative to the directory and returns a new `Descriptor`
+- `create_directory_at(name)` creates a subdirectory
+
+File descriptors expose:
+
+- `read(length, offset)` returns `Result<(Vec<u8>, bool), ErrorCode>` (data and EOF flag)
+- `write(buffer, offset)` returns `Result<u64, ErrorCode>` (bytes written)
+
+### Reading a file
+
+```rust
+use wstd::wasi::filesystem::types::{DescriptorFlags, OpenFlags, PathFlags};
+
+fn read_file(dir: &Descriptor, name: &str) -> Result<String, String> {
+    let file = dir
+        .open_at(
+            PathFlags::SYMLINK_FOLLOW,
+            name,
+            OpenFlags::empty(),
+            DescriptorFlags::READ,
+        )
+        .map_err(|e| format!("open: {e:?}"))?;
+    let (bytes, _eof) = file
+        .read(1024 * 1024, 0)
+        .map_err(|e| format!("read: {e:?}"))?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+```
+
+The first parameter to `open_at`, `PathFlags::SYMLINK_FOLLOW`, controls how symbolic links in the path are resolved. The third and fourth parameters are bitflags that control file creation behavior and access mode.
+
+### Writing a file
+
+```rust
+fn write_file(dir: &Descriptor, name: &str, data: &[u8]) -> Result<u64, String> {
+    let file = dir
+        .open_at(
+            PathFlags::SYMLINK_FOLLOW,
+            name,
+            OpenFlags::CREATE | OpenFlags::TRUNCATE,
+            DescriptorFlags::WRITE,
+        )
+        .map_err(|e| format!("open: {e:?}"))?;
+    file.write(data, 0).map_err(|e| format!("write: {e:?}"))
+}
+```
+
+`OpenFlags::CREATE | OpenFlags::TRUNCATE` overwrites an existing file or creates a new one. Use `OpenFlags::CREATE | OpenFlags::EXCLUSIVE` to fail if the file already exists.
+
+### Listing entries
+
+```rust
+use wstd::wasi::filesystem::types::DescriptorType;
+
+struct Entry {
+    name: String,
+    kind: DescriptorType,
+}
+
+fn list_entries(dir: &Descriptor) -> Result<Vec<Entry>, String> {
+    let stream = dir
+        .read_directory()
+        .map_err(|e| format!("read_directory: {e:?}"))?;
+    let mut out = Vec::new();
+    while let Some(entry) = stream
+        .read_directory_entry()
+        .map_err(|e| format!("read_directory_entry: {e:?}"))?
+    {
+        out.push(Entry {
+            name: entry.name,
+            kind: entry.type_,
+        });
+    }
+    Ok(out)
+}
+```
+
+`read_directory_entry` returns `Result<Option<DirectoryEntry>, ErrorCode>`. `Ok(None)` signals end of stream.
+
+## Step 3: A complete file server component
+
+Putting it together with `wstd-axum`:
+
+```rust title="src/lib.rs"
+use axum::{
+    Json, Router,
+    extract::Path,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+};
+use serde::Serialize;
+use wstd::wasi::filesystem::preopens::get_directories;
+use wstd::wasi::filesystem::types::{
+    Descriptor, DescriptorFlags, DescriptorType, OpenFlags, PathFlags,
+};
+
+const PREOPEN: &str = "/data";
+
+#[wstd_axum::http_server]
+fn main() -> Router {
+    Router::new()
+        .route("/", get(list))
+        .route("/files/{name}", get(read).put(write))
+}
+
+#[derive(Serialize)]
+struct Listing {
+    path: String,
+    entries: Vec<EntryInfo>,
+}
+
+#[derive(Serialize)]
+struct EntryInfo {
+    name: String,
+    kind: String,
+}
+
+fn entry_kind(t: DescriptorType) -> &'static str {
+    match t {
+        DescriptorType::Directory => "directory",
+        DescriptorType::RegularFile => "regular-file",
+        DescriptorType::SymbolicLink => "symlink",
+        _ => "other",
+    }
+}
+
+fn open_preopen(path: &str) -> Option<Descriptor> {
+    get_directories()
+        .into_iter()
+        .find(|(_, mount)| mount == path)
+        .map(|(desc, _)| desc)
+}
+
+async fn list() -> Result<Json<Listing>, AppError> {
+    let dir = open_preopen(PREOPEN).ok_or(AppError::no_preopen())?;
+    let stream = dir
+        .read_directory()
+        .map_err(|e| AppError::internal(format!("read_directory: {e:?}")))?;
+    let mut entries = Vec::new();
+    while let Some(entry) = stream
+        .read_directory_entry()
+        .map_err(|e| AppError::internal(format!("read_directory_entry: {e:?}")))?
+    {
+        entries.push(EntryInfo {
+            name: entry.name,
+            kind: entry_kind(entry.type_).to_string(),
+        });
+    }
+    Ok(Json(Listing {
+        path: PREOPEN.to_string(),
+        entries,
+    }))
+}
+
+async fn read(Path(name): Path<String>) -> Result<Vec<u8>, AppError> {
+    let dir = open_preopen(PREOPEN).ok_or(AppError::no_preopen())?;
+    let file = dir
+        .open_at(
+            PathFlags::SYMLINK_FOLLOW,
+            &name,
+            OpenFlags::empty(),
+            DescriptorFlags::READ,
+        )
+        .map_err(|e| AppError::internal(format!("open_at: {e:?}")))?;
+    let (bytes, _eof) = file
+        .read(1024 * 1024, 0)
+        .map_err(|e| AppError::internal(format!("read: {e:?}")))?;
+    Ok(bytes)
+}
+
+async fn write(Path(name): Path<String>, body: axum::body::Bytes) -> Result<StatusCode, AppError> {
+    let dir = open_preopen(PREOPEN).ok_or(AppError::no_preopen())?;
+    let file = dir
+        .open_at(
+            PathFlags::SYMLINK_FOLLOW,
+            &name,
+            OpenFlags::CREATE | OpenFlags::TRUNCATE,
+            DescriptorFlags::WRITE,
+        )
+        .map_err(|e| AppError::internal(format!("open_at: {e:?}")))?;
+    file.write(&body, 0)
+        .map_err(|e| AppError::internal(format!("write: {e:?}")))?;
+    Ok(StatusCode::CREATED)
+}
+
+struct AppError {
+    status: StatusCode,
+    message: String,
+}
+
+impl AppError {
+    fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: msg.into(),
+        }
+    }
+    fn no_preopen() -> Self {
+        Self::internal(format!("no {PREOPEN} preopen mounted"))
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        (self.status, format!("{}\n", self.message)).into_response()
+    }
+}
+```
+
+The `Cargo.toml` for this pattern:
+
+```toml title="Cargo.toml"
+[dependencies]
+axum = { version = "0.8", default-features = false, features = ["json", "matched-path"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wstd = "0.6"
+wstd-axum = "0.6"
+```
+
+## Configure volumes for `wash dev`
+
+To mount a host directory into the component during development, add a `volumes` entry to `.wash/config.yaml`:
+
+```yaml title=".wash/config.yaml"
+build:
+  command: cargo build --target wasm32-wasip2 --release
+  component_path: target/wasm32-wasip2/release/<crate>.wasm
+
+dev:
+  volumes:
+    - host_path: ./testdata
+      guest_path: /data
+```
+
+`host_path` is a directory on your local machine, `guest_path` is where the component sees it. The component's `get_directories()` call will include an entry whose mount string is `/data` and whose descriptor is rooted at `testdata/` in your project.
+
+Create some test data:
+
+```shell
+mkdir -p testdata
+echo "Hello from the filesystem!" > testdata/hello.txt
+```
+
+## Build and verify
+
+```shell
+wash dev
+```
+
+```shell
+# List files in the /data directory
+curl http://localhost:8000/
+
+# Read a file
+curl http://localhost:8000/files/hello.txt
+
+# Write a new file
+curl -X PUT --data-binary 'Hello, filesystem!' http://localhost:8000/files/greeting.txt
+
+# Read the written file back
+curl http://localhost:8000/files/greeting.txt
+```
+
+Expected output:
+
+```text
+{"path":"/data","entries":[{"name":"hello.txt","kind":"regular-file"}]}
+Hello from the filesystem!
+Hello, filesystem!
+```
+
+Written files persist on the host at `testdata/greeting.txt`.
+
+## Production deployment
+
+In a production deployment, filesystem data is provided through Kubernetes Volumes. The volume is first made available to the wasmCloud host, then mounted into the component via a WorkloadDeployment manifest.
+
+For a full walkthrough of deploying with volumes, including host deployments, WorkloadDeployment manifests, and `volumeMounts` configuration, see [Filesystems and Volumes](../../../../kubernetes-operator/operator-manual/filesystems-and-volumes.mdx).
+
+Important notes:
+
+- Volumes are defined at the host level and mounted into components via `localResources.volumeMounts`.
+- The `mountPath` in the manifest corresponds to the guest path the component sees in `get_directories()`.
+- You do not need to declare `wasi:filesystem` under `hostInterfaces`.
+
+## Without `wstd`: the `wit-bindgen` path
+
+If your component does not depend on `wstd`, declare the imports in your WIT world and generate bindings with `wit-bindgen`:
+
+```wit title="wit/world.wit"
+package wasmcloud:my-component;
+
+world my-component {
+  import wasi:filesystem/types@0.2.2;
+  import wasi:filesystem/preopens@0.2.2;
+
+  export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+```rust title="src/lib.rs"
+mod bindings {
+    wit_bindgen::generate!({ generate_all });
+}
+
+use bindings::wasi::filesystem::preopens::get_directories;
+use bindings::wasi::filesystem::types::{Descriptor, DescriptorFlags, OpenFlags, PathFlags};
+```
+
+The function and type names are identical between paths.
+
+## Summary: checklist for adding filesystem access
+
+1. **Decide on the binding path**. If your component uses `wstd`, read filesystem types under `wstd::wasi::filesystem::*`. Otherwise, declare the imports in `wit/world.wit` and use `wit_bindgen::generate!`.
+2. **Use `get_directories()`** to discover preopened mounts. Look up the descriptor whose mount path matches the directory you need.
+3. **Open files with `open_at`** using the appropriate `OpenFlags` and `DescriptorFlags` bitflags.
+4. **Read with `file.read(length, offset)`** and write with `file.write(buffer, offset)`. Both return `Result` types.
+5. **Configure volumes** in `.wash/config.yaml` for local development or in a WorkloadDeployment manifest for production.
+6. **No bundler or generator changes needed** — `wstd` already brings the bindings, and `wit-bindgen` generates them when you ask for `generate_all`.
+
+## API reference: `wasi:filesystem` operations used
+
+| Operation | Signature | Description |
+|-----------|-----------|-------------|
+| `get_directories` | `fn() -> Vec<(Descriptor, String)>` | Returns all preopened directories with their mount paths |
+| `dir.read_directory` | `fn() -> Result<DirectoryEntryStream, ErrorCode>` | Open a stream over the directory's entries |
+| `stream.read_directory_entry` | `fn() -> Result<Option<DirectoryEntry>, ErrorCode>` | Read the next entry; `None` at end |
+| `dir.open_at(path_flags, name, open_flags, descriptor_flags)` | `fn(...) -> Result<Descriptor, ErrorCode>` | Open a file or directory relative to a descriptor |
+| `file.read(length, offset)` | `fn(u64, u64) -> Result<(Vec<u8>, bool), ErrorCode>` | Read bytes from a file; bool is EOF |
+| `file.write(buffer, offset)` | `fn(&[u8], u64) -> Result<u64, ErrorCode>` | Write bytes to a file at offset; returns bytes written |
+| `dir.create_directory_at(name)` | `fn(&str) -> Result<(), ErrorCode>` | Create a subdirectory |
+| `dir.stat_at(path_flags, name)` | `fn(...) -> Result<DescriptorStat, ErrorCode>` | Get file attributes (type, size, timestamps) |
+| `dir.unlink_file_at(name)` | `fn(&str) -> Result<(), ErrorCode>` | Delete a file |
+| `dir.remove_directory_at(name)` | `fn(&str) -> Result<(), ErrorCode>` | Delete an empty directory |
+
+## Further reading
+
+- [Rust Language Guide](./index.mdx) — toolchain overview, HTTP patterns, async runtime guidance, and crate compatibility
+- [Filesystems and Volumes](../../../../kubernetes-operator/operator-manual/filesystems-and-volumes.mdx) — deploying components with volume mounts in Kubernetes
+- [Key-Value Storage](./key-value-storage.mdx) — persistent key-value storage for structured data
+- [Configuration](./configuration.mdx) — read configuration values from ConfigMaps, Secrets, and inline environment variables
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -192,7 +192,7 @@ wstd = "0.6"
 wstd-axum = "0.6"
 ```
 
-The wasmCloud [`http-service`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-service) template demonstrates this pattern end to end.
+The wasmCloud [`http-handler`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-handler) template demonstrates this pattern end to end.
 
 ### Outgoing HTTP requests
 

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -42,7 +42,7 @@ The compiled component is written to `target/wasm32-wasip2/release/<crate_name>.
 `wstd` handles WASI bindings internally through its dependency on the [`wasip2`](https://crates.io/crates/wasip2) crate. For standard HTTP components, `wstd` is the only dependency you need.
 
 :::note[`wstd` is a transitional library]
-`wstd` exists because mainstream async runtimes like `tokio` and `async-std` do not yet support WASI 0.2. Once they do, the `wstd` project recommends migrating to those runtimes. The API is designed to make that migration straightforward.
+`wstd` exists because mainstream async runtimes like `tokio` and `async-std` do not yet provide a complete WASI 0.2 story for HTTP-export components. As of `tokio` 1.51, `tokio` supports `wasm32-wasip2` for raw socket networking via `wasi:sockets`, but it does not yet drive the `wasi:http/incoming-handler` export that wasmCloud HTTP components rely on. Once mainstream runtimes cover that path, the `wstd` project recommends migrating to them. The API is designed to make that migration straightforward.
 :::
 
 Available modules:
@@ -62,6 +62,73 @@ Available modules:
 [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) is a lower-level tool that generates Rust code from WIT interface definitions. You don't need `wit-bindgen` for standard HTTP components — `wstd` handles those bindings internally. However, `wit-bindgen` is essential when you need to use WASI interfaces that aren't included in `wstd`, such as `wasi:keyvalue` or `wasi:config`.
 
 See [Adding custom WASI interfaces](#adding-custom-wasi-interfaces) for details on using `wstd` and `wit-bindgen` together.
+
+## Async runtime: when to use `wstd` vs `tokio`
+
+Both `wstd` and `tokio` 1.51+ compile against `wasm32-wasip2`. Choosing between them comes down to what your component exports, since the two runtimes solve different parts of the problem.
+
+| Use case | Runtime |
+|---|---|
+| Component exports `wasi:http/incoming-handler` (HTTP service) | `wstd` (or [`wstd-axum`](https://docs.rs/wstd-axum) for routing) |
+| Component is a long-running TCP server or client over `wasi:sockets` | `tokio` 1.51+ with `RUSTFLAGS="--cfg tokio_unstable"` |
+| Component uses tokio sync primitives (`Mutex`, `mpsc`, `oneshot`) as in-process utilities | `wstd` for the runtime, with `tokio = { version = "1.51", features = ["sync"] }` as a passive dependency |
+
+### Why HTTP components stay on `wstd`
+
+Tokio's wasip2 work covers `wasi:sockets` networking. It does not provide a bridge to `wasi:http/incoming-handler`. The `wstd-axum` crate, which adapts an `axum::Router` onto the wasi-http export, explicitly disables `tokio` and `hyper` integrations: a Wasm component receives HTTP through host-imported interfaces, not raw sockets, so the standard tokio-and-hyper path doesn't apply.
+
+Pulling tokio's runtime into an HTTP-export component also expands the WASI capability surface the component demands. The diff below shows the imports of two functionally equivalent components that build cleanly. The first uses `wstd` only; the second initializes a `tokio` current-thread runtime inside an `incoming-handler` implementation.
+
+```text title="wstd-only component (minimal)"
+import wasi:io/poll@0.2.9
+import wasi:io/streams@0.2.9
+import wasi:io/error@0.2.9
+import wasi:http/types@0.2.9
+import wasi:cli/{stderr, environment, exit}@0.2.9
+import wasi:clocks/monotonic-clock@0.2.9
+import wasi:random/insecure-seed@0.2.9
+export wasi:http/incoming-handler@0.2.9
+```
+
+```text title="tokio-runtime-inside-handler component (over-broad)"
+import wasi:http/types@0.2.4
+import wasi:io/{poll, streams, error}@0.2.6
+import wasi:sockets/{network, tcp}@0.2.6
+import wasi:filesystem/{types, preopens}@0.2.6
+import wasi:cli/{environment, exit, stdin, stdout, stderr}@0.2.6
+import wasi:clocks/{monotonic-clock, wall-clock}@0.2.6
+import wasi:random/insecure-seed@0.2.6
+export wasi:http/incoming-handler@0.2.2
+```
+
+The second component imports `wasi:sockets/*` and `wasi:filesystem/*` it never uses, and the version skew between `wasi:http/types@0.2.4` and the `0.2.6` cluster makes it fragile to link against most hosts. Stick to `wstd` (or `wstd-axum`) for any component that exports HTTP.
+
+### When tokio is the right answer
+
+If your component opens raw TCP listeners or connects out over TCP, tokio's wasip2 path is the supported runtime. The wasmCloud [`service-tcp`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/service-tcp) template is the canonical example. Cargo features that work on `wasm32-wasip2`:
+
+- `sync`, `macros`, `rt`, `time`, `io-util`, `net`
+
+Cargo features that do not work on `wasm32-wasip2` today:
+
+- `fs` (no `tokio::fs`)
+- DNS lookups (`tokio::net::lookup_host`)
+- Multi-threading (`rt-multi-thread`)
+- Signal handling
+
+Use `#[tokio::main(flavor = "current_thread")]`. wasip2 is single-threaded.
+
+### Tokio sync primitives inside a `wstd` component
+
+If a library you depend on wants `tokio::sync::Mutex` or you want `mpsc` for in-component fan-out, you can pull tokio in as a passive utility crate without contaminating the WASI import surface:
+
+```toml title="Cargo.toml"
+[dependencies]
+wstd = "0.6"
+tokio = { version = "1.51", features = ["sync"] }
+```
+
+Verified component imports match a `wstd`-only build, byte for byte. Avoid widening to `features = ["full"]` or enabling `rt`/`net`/`fs` in this configuration: that pulls mio into the dep tree and the surface expands as in the second example above.
 
 ## Handling HTTP requests
 
@@ -95,6 +162,33 @@ Key points:
 - Route matching is manual (pattern match on `req.uri().path()`). For complex routing, you can use helper functions or a lightweight router crate.
 - `Response::new()` creates a 200 OK response. Use `Response::builder()` for custom status codes or headers.
 - Handler functions can be `async`, enabling outgoing HTTP calls, key-value operations, or other async work within a request.
+
+### Routing with `wstd-axum`
+
+For anything more involved than a single handler, [`wstd-axum`](https://docs.rs/wstd-axum) lets you write the component using the [`axum`](https://docs.rs/axum) framework. `wstd-axum` adapts an `axum::Router` onto `wasi:http/incoming-handler`:
+
+```rust
+use axum::{Router, routing::get};
+
+#[wstd_axum::http_server]
+fn main() -> Router {
+    Router::new()
+        .route("/", get(|| async { "Hello from wasmCloud!\n" }))
+        .route("/api/greet/{name}", get(|axum::extract::Path(name): axum::extract::Path<String>|
+            async move { format!("Hello, {name}!\n") }))
+}
+```
+
+`Cargo.toml` must opt out of axum's default features and only enable feature flags that don't require `tokio` or `hyper`:
+
+```toml
+[dependencies]
+axum = { version = "0.8", default-features = false, features = ["json", "query", "matched-path"] }
+wstd = "0.6"
+wstd-axum = "0.6"
+```
+
+The wasmCloud [`http-service`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-service) template demonstrates this pattern end to end.
 
 ### Outgoing HTTP requests
 
@@ -354,7 +448,8 @@ Any Rust crate that compiles to `wasm32-wasip2` works inside a Wasm component. T
 
 ### What does not work
 
-- **`tokio`, `async-std`, `smol`** — mainstream async runtimes do not yet support WASI 0.2. `wstd` exists specifically to fill this gap. When these runtimes add WASI 0.2 support, migration from `wstd` is expected to be straightforward.
+- **`tokio` for `wasi:http/incoming-handler` components** — `tokio` 1.51+ supports `wasm32-wasip2` for raw socket networking, but it does not bridge to `wasi:http/incoming-handler`. Use `wstd` (or `wstd-axum`) for HTTP-export components. See [Async runtime: when to use `wstd` vs `tokio`](#async-runtime-when-to-use-wstd-vs-tokio).
+- **`async-std`, `smol`** — these mainstream async runtimes do not yet support WASI 0.2.
 - **Crates that use `std::net` or `std::fs` directly** — these require OS-level syscalls not available in the Wasm sandbox. Use `wstd::net` and WASI filesystem interfaces instead.
 - **Crates with native C dependencies** — anything that links to a C library via `build.rs` (e.g., `openssl-sys`, `libsqlite3-sys`) will not compile for `wasm32-wasip2`.
 - **Crates using threads** — `std::thread` is not available in WASI 0.2. Async concurrency through `wstd` is the alternative.
@@ -372,7 +467,7 @@ Any Rust crate that compiles to `wasm32-wasip2` works inside a Wasm component. T
 Use `wash new` to scaffold a Rust component project:
 
 ```shell
-wash new https://github.com/wasmCloud/wasmCloud.git --name hello --subfolder examples/http-hello-world
+wash new https://github.com/wasmCloud/wasmCloud.git --name hello --subfolder templates/http-hello-world
 ```
 
 ### Development loop
@@ -419,11 +514,24 @@ wasm-tools component wit target/wasm32-wasip2/release/my_component.wasm
 
 This prints the resolved WIT world, showing exactly which interfaces the component imports and exports.
 
+## Working with WASI interfaces
+
+These guides walk through adding WASI interfaces to a Rust component:
+
+- [Key-Value Storage](./key-value-storage.mdx) — replace an in-memory data store with persistent key-value storage
+- [Messaging](./messaging.mdx) — implement communication between components over a messaging interface
+- [Filesystem](./filesystem.mdx) — read and write files from preopened directories
+- [Configuration](./configuration.mdx) — read configuration values injected from Kubernetes ConfigMaps, Secrets, and inline environment variables
+
+The patterns in these guides (declaring WIT imports, generating bindings via `wit-bindgen` alongside `wstd`, handling serialization) apply to any WASI interface you add to a Rust component.
+
 ## Further reading
 
 - [Developer Guide](../../index.mdx?lang=rust) — quickstart tutorial for creating, building, and running a Rust component
+- [wasmCloud Rust templates](https://github.com/wasmCloud/wasmCloud/tree/main/templates) — project templates for the most common starting points
 - [wasmCloud Rust examples](https://github.com/wasmCloud/wasmCloud/tree/main/examples) — example projects in the `wash` repository
 - [`wstd` documentation](https://docs.rs/wstd) — API reference for the async Wasm standard library
+- [`wstd-axum` documentation](https://docs.rs/wstd-axum) — `axum` adapter for `wasi:http/incoming-handler`
 - [`wstd` repository](https://github.com/bytecodealliance/wstd) — source code and examples
 - [`wit-bindgen` documentation](https://docs.rs/wit-bindgen) — API reference for the WIT bindings generator
 - [`wasm32-wasip2` platform support](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip2.html) — Rust target documentation

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -79,7 +79,9 @@ Tokio's wasip2 work covers `wasi:sockets` networking. It does not provide a brid
 
 Pulling tokio's runtime into an HTTP-export component also expands the WASI capability surface the component demands. The diff below shows the imports of two functionally equivalent components that build cleanly. The first uses `wstd` only; the second initializes a `tokio` current-thread runtime inside an `incoming-handler` implementation.
 
-```text title="wstd-only component (minimal)"
+A `wstd`-only component declares only the imports it needs:
+
+```text
 import wasi:io/poll@0.2.9
 import wasi:io/streams@0.2.9
 import wasi:io/error@0.2.9
@@ -90,7 +92,9 @@ import wasi:random/insecure-seed@0.2.9
 export wasi:http/incoming-handler@0.2.9
 ```
 
-```text title="tokio-runtime-inside-handler component (over-broad)"
+A component that initializes a `tokio` runtime inside its `incoming-handler` ends up importing a much broader surface, including sockets and filesystem interfaces it never uses:
+
+```text
 import wasi:http/types@0.2.4
 import wasi:io/{poll, streams, error}@0.2.6
 import wasi:sockets/{network, tcp}@0.2.6
@@ -120,9 +124,9 @@ Use `#[tokio::main(flavor = "current_thread")]`. wasip2 is single-threaded.
 
 ### Tokio sync primitives inside a `wstd` component
 
-If a library you depend on wants `tokio::sync::Mutex` or you want `mpsc` for in-component fan-out, you can pull tokio in as a passive utility crate without contaminating the WASI import surface:
+If a library you depend on wants `tokio::sync::Mutex` or you want `mpsc` for in-component fan-out, you can pull tokio in as a passive utility crate without contaminating the WASI import surface. In `Cargo.toml`:
 
-```toml title="Cargo.toml"
+```toml
 [dependencies]
 wstd = "0.6"
 tokio = { version = "1.51", features = ["sync"] }
@@ -233,7 +237,7 @@ Many draft interfaces like `wasi:keyvalue` are self-contained — they don't sha
 
 **1. Add `wit-bindgen` to `Cargo.toml`:**
 
-```toml title="Cargo.toml"
+```toml
 [package]
 name = "my-component"
 edition = "2024"
@@ -247,9 +251,9 @@ wstd = "0.6"
 wit-bindgen = "0.46.0"
 ```
 
-**2. Declare the imports in your WIT world:**
+**2. Declare the imports in `wit/world.wit`:**
 
-```wit title="wit/world.wit"
+```wit
 package myorg:mycomponent;
 
 world my-world {
@@ -267,9 +271,9 @@ wkg wit fetch
 
 This populates `wit/deps/` with the interface definitions for `wasi:keyvalue`, `wasi:http`, and their transitive dependencies.
 
-**4. Generate bindings and use the interface:**
+**4. Generate bindings and use the interface in `src/lib.rs`:**
 
-```rust title="src/lib.rs"
+```rust
 use wstd::http::{Body, Request, Response};
 
 // Generate bindings for all interfaces in the WIT world.
@@ -357,7 +361,7 @@ my-component/
 
 ### `Cargo.toml`
 
-```toml title="Cargo.toml"
+```toml
 [package]
 name = "my-component"
 version = "0.1.0"
@@ -375,7 +379,9 @@ wstd = "0.6"
 
 ### WIT world
 
-```wit title="wit/world.wit"
+In `wit/world.wit`:
+
+```wit
 package wasmcloud:hello;
 
 world hello {
@@ -415,7 +421,7 @@ The following namespaces are resolved automatically without configuration:
 
 Rust projects use a [project configuration file](../../../config.mdx) at `.wash/config.yaml` that tells `wash` how to build the component:
 
-```yaml title=".wash/config.yaml"
+```yaml
 build:
   command: cargo build --target wasm32-wasip2 --release
   component_path: target/wasm32-wasip2/release/hello_world.wasm
@@ -425,9 +431,9 @@ The `command` field specifies the build command and `component_path` points to t
 
 ### Optimizing binary size
 
-Wasm component binaries can be reduced with standard Cargo release profile settings:
+Wasm component binaries can be reduced with standard Cargo release profile settings. Add the following to `Cargo.toml`:
 
-```toml title="Cargo.toml"
+```toml
 [profile.release]
 opt-level = "z"       # Optimize for size
 lto = true            # Link-time optimization

--- a/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
@@ -21,8 +21,8 @@ By default, a wasmCloud deployment uses NATS JetStream for storage via the built
 A full working example is available as a template:
 ```shell
 wash new https://github.com/wasmCloud/wasmCloud.git \
-  --name http-kv-service \
-  --subfolder templates/http-kv-service
+  --name http-kv-handler \
+  --subfolder templates/http-kv-handler
 ```
 :::
 
@@ -33,10 +33,10 @@ Every capability your component uses must be declared in its WIT world. The `wst
 In `wit/world.wit`:
 
 ```wit
-package wasmcloud:http-kv-service;
+package wasmcloud:http-kv-handler;
 
 // wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro.
-world http-kv-service {
+world http-kv-handler {
   import wasi:keyvalue/store@0.2.0-draft;
 }
 ```
@@ -51,7 +51,7 @@ In `Cargo.toml`:
 
 ```toml
 [package]
-name = "http-kv-service"
+name = "http-kv-handler"
 edition = "2024"
 version = "0.1.0"
 
@@ -73,7 +73,7 @@ In `src/lib.rs`, generate bindings for the `wasi:keyvalue/store` import and call
 
 ```rust
 wit_bindgen::generate!({
-    world: "http-kv-service",
+    world: "http-kv-handler",
     path: "wit",
     generate_all,
 });
@@ -160,7 +160,7 @@ The `generate_all` option tells `wit-bindgen` to generate bindings for every int
 
 Every keyvalue operation goes through a `Bucket` resource returned by `store::open`. The string you pass to `open` is a logical bucket name. The wasmCloud runtime maps it to a physical store based on `.wash/config.yaml` (or the host's `wasi:keyvalue` plugin configuration in production), so the same component code runs against any supported backend without modification.
 
-The shipped [`http-kv-service`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-kv-service) template uses the bucket name as a logical "backend" identifier. Set `BACKEND` in `src/lib.rs` to one of the values below and uncomment the matching block in `.wash/config.yaml`:
+The shipped [`http-kv-handler`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-kv-handler) template uses the bucket name as a logical "backend" identifier. Set `BACKEND` in `src/lib.rs` to one of the values below and uncomment the matching block in `.wash/config.yaml`:
 
 | `BACKEND`     | Required config key            | Example value                    |
 |---------------|--------------------------------|----------------------------------|
@@ -195,9 +195,9 @@ All `wasi:keyvalue/store` calls (`open`, `get`, `set`, `delete`, `exists`, `list
 If you want full control over the HTTP export and prefer not to bring in `wstd`, you can let `wit-bindgen` generate the `wasi:http/incoming-handler` export too. Declare both the keyvalue import and the HTTP export in your WIT world:
 
 ```wit
-package wasmcloud:http-kv-service;
+package wasmcloud:http-kv-handler;
 
-world http-kv-service {
+world http-kv-handler {
   import wasi:keyvalue/store@0.2.0-draft;
 
   export wasi:http/incoming-handler@0.2.2;

--- a/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
@@ -15,12 +15,7 @@ This guide walks through adding `wasi:keyvalue` to a Rust component using `wit-b
 By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Key-Value NATS plugin](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:keyvalue` with a different storage solution.
 :::
 
-In Rust, two pieces collaborate to make this work:
-
-- **`wstd`** handles the `wasi:http/incoming-handler` export via the `#[wstd::http_server]` proc macro
-- **`wit-bindgen`** generates Rust bindings for the keyvalue interface, which `wstd` doesn't provide
-
-These two coexist because draft interfaces like `wasi:keyvalue` are self-contained: they don't share types with `wasi:io` or other standard interfaces, so there are no type conflicts between what `wasip2` (bundled with `wstd`) provides and what `wit-bindgen` generates.
+`wasi:keyvalue` is a draft interface and is not bundled into `wstd`. To use it, your component generates Rust bindings with `wit-bindgen` while still relying on `wstd` to drive the HTTP export. The two coexist because draft interfaces like `wasi:keyvalue` are self-contained: they don't share types with `wasi:io` or other standard interfaces, so there are no type conflicts between what `wasip2` (the crate `wstd` is built on) provides and what `wit-bindgen` generates.
 
 :::tip[Complete example]
 A full working example is available as a template:
@@ -31,27 +26,28 @@ wash new https://github.com/wasmCloud/wasmCloud.git \
 ```
 :::
 
-## Step 1: Declare the WIT imports in `wit/world.wit`
+## Step 1: Declare the WIT import
 
-Every capability your component uses must be declared in its WIT world. Open `wit/world.wit` and add an `import` line for `wasi:keyvalue/store`:
+Every capability your component uses must be declared in its WIT world. The `wstd::http_server` macro provides the `wasi:http/incoming-handler` export, so the world only needs to declare the `wasi:keyvalue/store` import.
 
-```wit {4}
+In `wit/world.wit`:
+
+```wit
 package wasmcloud:http-kv-service;
 
+// wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro.
 world http-kv-service {
   import wasi:keyvalue/store@0.2.0-draft;
-
-  export wasi:http/incoming-handler@0.2.2;
 }
 ```
 
 If you also need atomic operations like `increment`, add `wasi:keyvalue/atomics@0.2.0-draft` as a second import.
 
-When you run `wash dev` or `wash build`, the build pipeline calls `wash wit fetch`, which resolves the WIT package references and downloads their definitions into `wit/deps/`. You don't need to manually fetch any WIT files.
+When you run `wash build`, the build pipeline calls `wash wit fetch`, which resolves the WIT package references and downloads their definitions into `wit/deps/`. If you have not run `wash wit fetch` before, you may need to run it manually the first time before `cargo build` works.
 
-## Step 2: Add `wit-bindgen` to `Cargo.toml`
+## Step 2: Add the dependencies
 
-`wstd` alone does not bring in `wit-bindgen`. Add it as a direct dependency in `Cargo.toml`:
+In `Cargo.toml`:
 
 ```toml
 [package]
@@ -65,14 +61,150 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-wit-bindgen = "0.41"
+wit-bindgen = "0.46"
+wstd = "0.6"
 ```
 
-Note that this template-style `Cargo.toml` does not depend on `wstd` at all, since the component handles the HTTP export directly through `wit-bindgen`-generated bindings rather than through the `#[wstd::http_server]` macro. If you prefer the macro form, add `wstd = "0.6"` and follow the [hybrid pattern](#hybrid-wstd--wit-bindgen-pattern) below.
+Any `wit-bindgen` 0.4x release works; `0.46` is what current `wstd` releases pair cleanly with.
 
 ## Step 3: Generate bindings and use the interface
 
-In `src/lib.rs`, generate bindings for everything in the world (both the `wasi:keyvalue` import and the `wasi:http/incoming-handler` export) with `wit_bindgen::generate!`:
+In `src/lib.rs`, generate bindings for the `wasi:keyvalue/store` import and call them from inside a `#[wstd::http_server]` handler:
+
+```rust
+wit_bindgen::generate!({
+    world: "http-kv-service",
+    path: "wit",
+    generate_all,
+});
+
+use serde::Deserialize;
+use wasi::keyvalue::store::open;
+use wstd::http::{Body, Method, Request, Response, StatusCode};
+
+const BACKEND: &str = "in_memory";
+
+#[derive(Deserialize)]
+struct KvPayload {
+    key: String,
+    value: String,
+}
+
+#[wstd::http_server]
+async fn main(mut req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    match *req.method() {
+        Method::POST => post(&mut req).await,
+        Method::GET => get(&req).await,
+        _ => Response::builder()
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .body(Body::from("Method Not Allowed\n"))
+            .map_err(Into::into),
+    }
+}
+
+async fn post(req: &mut Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    let body_bytes = req.body_mut().contents().await?.to_vec();
+    let payload: KvPayload = serde_json::from_slice(&body_bytes)
+        .map_err(|e| wstd::http::Error::msg(format!("invalid JSON: {e}")))?;
+
+    let bucket = open(BACKEND)
+        .map_err(|e| wstd::http::Error::msg(format!("open bucket: {e:?}")))?;
+    bucket
+        .set(&payload.key, payload.value.as_bytes())
+        .map_err(|e| wstd::http::Error::msg(format!("set: {e:?}")))?;
+
+    Ok(Response::new(Body::from(format!("[{BACKEND}] Stored '{}'\n", payload.key))))
+}
+
+async fn get(req: &Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    let path_and_query = req.uri().path_and_query().map(|p| p.as_str()).unwrap_or("");
+    let Some(key) = parse_query_param(path_and_query, "key") else {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from("Missing required query parameter: key\n"))
+            .map_err(Into::into);
+    };
+
+    let bucket = open(BACKEND)
+        .map_err(|e| wstd::http::Error::msg(format!("open bucket: {e:?}")))?;
+    match bucket
+        .get(&key)
+        .map_err(|e| wstd::http::Error::msg(format!("get: {e:?}")))?
+    {
+        Some(bytes) => Ok(Response::new(Body::from(format!(
+            "[{BACKEND}] {}\n",
+            String::from_utf8_lossy(&bytes)
+        )))),
+        None => Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::from(format!("[{BACKEND}] Key '{key}' not found\n")))
+            .map_err(Into::into),
+    }
+}
+
+fn parse_query_param(path_and_query: &str, param: &str) -> Option<String> {
+    let query = path_and_query.splitn(2, '?').nth(1)?;
+    for pair in query.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        if parts.next()? == param {
+            return parts.next().map(|v| v.to_string());
+        }
+    }
+    None
+}
+```
+
+The `generate_all` option tells `wit-bindgen` to generate bindings for every interface in the world. The `wasi:keyvalue/store` interface lands at `wasi::keyvalue::store`. The HTTP export is still owned by `wstd`'s `#[http_server]` macro, not by `wit-bindgen`.
+
+### Opening a bucket and choosing a backend
+
+Every keyvalue operation goes through a `Bucket` resource returned by `store::open`. The string you pass to `open` is a logical bucket name. The wasmCloud runtime maps it to a physical store based on `.wash/config.yaml` (or the host's `wasi:keyvalue` plugin configuration in production), so the same component code runs against any supported backend without modification.
+
+The shipped [`http-kv-service`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-kv-service) template uses the bucket name as a logical "backend" identifier. Set `BACKEND` in `src/lib.rs` to one of the values below and uncomment the matching block in `.wash/config.yaml`:
+
+| `BACKEND`     | Required config key            | Example value                    |
+|---------------|--------------------------------|----------------------------------|
+| `in_memory`   | *(none, default in `wash dev`)* | —                                |
+| `filesystem`  | `wasi_keyvalue_path`           | `/tmp/keyvalue-store`            |
+| `nats`        | `wasi_keyvalue_nats_url`       | `nats://127.0.0.1:4222`          |
+| `redis`       | `wasi_keyvalue_redis_url`      | `redis://127.0.0.1:6379`         |
+
+The component code is unchanged across backends.
+
+Treat the bucket as a per-request resource and open it inside each handler rather than caching it at module scope.
+
+### Serialization: values are `list<u8>`
+
+`wasi:keyvalue/store` uses `list<u8>` (`Vec<u8>` in Rust) for values. To store structured data, serialize before `set` and deserialize after `get`:
+
+```rust
+let item_bytes = serde_json::to_vec(&item).map_err(|e| format!("serialize: {e}"))?;
+bucket.set(key, &item_bytes).map_err(|e| format!("set: {e:?}"))?;
+
+if let Some(bytes) = bucket.get(key).map_err(|e| format!("get: {e:?}"))? {
+    let item: Item = serde_json::from_slice(&bytes).map_err(|e| format!("deserialize: {e}"))?;
+}
+```
+
+### Synchronous API
+
+All `wasi:keyvalue/store` calls (`open`, `get`, `set`, `delete`, `exists`, `list-keys`) are synchronous in WIT. The `wit-bindgen`-generated bindings expose them as plain functions, not `async fn`. They work just as well from a synchronous handler if your component does not need `async`.
+
+## Alternative: `wit-bindgen`-only (no `wstd`)
+
+If you want full control over the HTTP export and prefer not to bring in `wstd`, you can let `wit-bindgen` generate the `wasi:http/incoming-handler` export too. Declare both the keyvalue import and the HTTP export in your WIT world:
+
+```wit
+package wasmcloud:http-kv-service;
+
+world http-kv-service {
+  import wasi:keyvalue/store@0.2.0-draft;
+
+  export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+Then implement the `Guest` trait directly:
 
 ```rust
 mod bindings {
@@ -84,10 +216,7 @@ mod bindings {
 use bindings::{
     exports::wasi::http::incoming_handler::Guest,
     wasi::{
-        http::types::{
-            Fields, IncomingBody, IncomingRequest, Method, OutgoingBody, OutgoingResponse,
-            ResponseOutparam,
-        },
+        http::types::{Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam},
         keyvalue::store::open,
     },
 };
@@ -96,168 +225,14 @@ struct Component;
 
 impl Guest for Component {
     fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
-        let (status, body) = match request.method() {
-            Method::Post => handle_post(request),
-            Method::Get => handle_get(request),
-            _ => (405u16, "Method Not Allowed\n".to_string()),
-        };
-
-        let response = OutgoingResponse::new(Fields::new());
-        response.set_status_code(status).unwrap();
-        let out_body = response.body().unwrap();
-        ResponseOutparam::set(response_out, Ok(response));
-        let stream = out_body.write().unwrap();
-        stream.blocking_write_and_flush(body.as_bytes()).unwrap();
-        drop(stream);
-        OutgoingBody::finish(out_body, None).unwrap();
+        // ... assemble the response by hand
     }
 }
 
 bindings::export!(Component with_types_in bindings);
 ```
 
-The `generate_all` option tells `wit-bindgen` to generate bindings for every interface in the world: imports, exports, and their transitive dependencies. The `wasi:keyvalue/store` interface lands at `bindings::wasi::keyvalue::store`.
-
-### Opening a bucket
-
-Every keyvalue operation goes through a `Bucket` resource returned by `store::open`:
-
-```rust
-const BUCKET: &str = "default";
-
-fn handle_post(request: IncomingRequest) -> (u16, String) {
-    let bucket = match open(BUCKET) {
-        Ok(b) => b,
-        Err(e) => return (500, format!("open bucket: {e:?}\n")),
-    };
-    // ... use the bucket
-}
-```
-
-The string passed to `open` is a logical bucket name. The wasmCloud runtime maps it to a physical store based on the host's `wasi:keyvalue` plugin configuration. Treat the bucket as a per-request resource and open it inside each handler rather than caching it at module scope.
-
-### Storing a value
-
-`bucket.set` takes a `&str` key and a `&[u8]` value:
-
-```rust
-#[derive(serde::Deserialize)]
-struct KvPayload {
-    key: String,
-    value: String,
-}
-
-fn handle_post(request: IncomingRequest) -> (u16, String) {
-    let body_bytes = match read_body(request) {
-        Ok(b) => b,
-        Err(e) => return (400, format!("read body: {e}\n")),
-    };
-
-    let payload: KvPayload = match serde_json::from_slice(&body_bytes) {
-        Ok(v) => v,
-        Err(e) => return (400, format!("invalid JSON: {e}\n")),
-    };
-
-    let bucket = match open(BUCKET) {
-        Ok(b) => b,
-        Err(e) => return (500, format!("open bucket: {e:?}\n")),
-    };
-
-    match bucket.set(&payload.key, payload.value.as_bytes()) {
-        Ok(()) => (200, format!("Stored '{}'\n", payload.key)),
-        Err(e) => (500, format!("set: {e:?}\n")),
-    }
-}
-```
-
-### Reading a value
-
-`bucket.get` returns `Result<Option<Vec<u8>>, Error>`. `Ok(None)` means the key was not found:
-
-```rust
-fn handle_get(request: IncomingRequest) -> (u16, String) {
-    let path_and_query = request.path_with_query().unwrap_or_default();
-    let key = match parse_query_param(&path_and_query, "key") {
-        Some(k) => k,
-        None => return (400, "Missing required query parameter: key\n".to_string()),
-    };
-
-    let bucket = match open(BUCKET) {
-        Ok(b) => b,
-        Err(e) => return (500, format!("open bucket: {e:?}\n")),
-    };
-
-    match bucket.get(&key) {
-        Ok(Some(bytes)) => (200, format!("{}\n", String::from_utf8_lossy(&bytes))),
-        Ok(None) => (404, format!("Key '{key}' not found\n")),
-        Err(e) => (500, format!("get: {e:?}\n")),
-    }
-}
-```
-
-### Serialization: values are `list<u8>`
-
-`wasi:keyvalue/store` uses `list<u8>` (`Vec<u8>` in Rust) for values. To store structured data, serialize before `set` and deserialize after `get`:
-
-```rust
-let item_bytes = serde_json::to_vec(&item).map_err(|e| format!("serialize: {e}"))?;
-bucket.set(key, &item_bytes).map_err(|e| format!("set: {e:?}"))?;
-
-let bytes = bucket.get(key).map_err(|e| format!("get: {e:?}"))?;
-if let Some(bytes) = bytes {
-    let item: Item = serde_json::from_slice(&bytes).map_err(|e| format!("deserialize: {e}"))?;
-}
-```
-
-### Synchronous API
-
-All `wasi:keyvalue/store` calls (`open`, `get`, `set`, `delete`, `exists`, `list-keys`) are synchronous in WIT. The `wit-bindgen`-generated bindings expose them as plain functions, not `async fn`. Your handlers don't need to be async to use them.
-
-## Hybrid: `wstd` + `wit-bindgen` pattern
-
-If your component already uses `#[wstd::http_server]` and you want to add `wasi:keyvalue` on top, both can coexist. Declare only the new imports in WIT (let `wstd`'s macro provide the HTTP export) and use `wit-bindgen` for the import bindings.
-
-In `wit/world.wit`:
-
-```wit
-package wasmcloud:my-component;
-
-// wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro.
-world my-component {
-  import wasi:keyvalue/store@0.2.0-draft;
-}
-```
-
-In `src/lib.rs`:
-
-```rust
-wit_bindgen::generate!({
-    world: "my-component",
-    path: "wit",
-    generate_all,
-});
-
-use wasi::keyvalue::store::open;
-use wstd::http::{Body, Request, Response};
-
-#[wstd::http_server]
-async fn main(_req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
-    let bucket = open("default")
-        .map_err(|e| wstd::http::Error::msg(format!("open bucket: {e:?}")))?;
-    // ... use bucket
-    Ok(Response::new(Body::from("ok\n")))
-}
-```
-
-In `Cargo.toml`:
-
-```toml
-[dependencies]
-wstd = "0.6"
-wit-bindgen = "0.46"
-```
-
-This gives you `wstd`'s ergonomic HTTP handling and async support alongside the keyvalue interface. See [Adding custom WASI interfaces](./index.mdx#adding-custom-wasi-interfaces) in the language guide for the full pattern, including handling type conflicts when imports overlap with `wasi:io`.
+This gives you the lowest-level WIT API at the cost of more boilerplate. See [Adding custom WASI interfaces](./index.mdx#adding-custom-wasi-interfaces) in the language guide for the full pattern, including handling type conflicts when imports overlap with `wasi:io`.
 
 ## Build and verify
 
@@ -282,27 +257,14 @@ curl "http://localhost:8000?key=missing"
 
 To verify persistence with a non-default backend, pick a backend in `.wash/config.yaml` (filesystem, NATS, Redis), restart the component, and confirm previously stored keys are still readable.
 
-## Choosing a backend
-
-The `BUCKET` constant in `src/lib.rs` is just a logical name; the host runtime selects the actual storage backend based on `.wash/config.yaml`. The [`http-kv-service`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-kv-service) template's `.wash/config.yaml` documents the available backends:
-
-| Backend       | Required config key            | Example value                    |
-|---------------|--------------------------------|----------------------------------|
-| `in_memory`   | *(none, default in `wash dev`)* | —                                |
-| `filesystem`  | `wasi_keyvalue_path`           | `/tmp/keyvalue-store`            |
-| `nats`        | `wasi_keyvalue_nats_url`       | `nats://127.0.0.1:4222`          |
-| `redis`       | `wasi_keyvalue_redis_url`      | `redis://127.0.0.1:6379`         |
-
-The component code is unchanged across backends.
-
 ## Summary: checklist for adding any WIT interface
 
 1. **Add `import` lines to `wit/world.wit`** for the interfaces you need.
-2. **Add `wit-bindgen` to `Cargo.toml`** if it isn't already a dependency.
+2. **Add `wit-bindgen` to `Cargo.toml`** if it is not already a dependency. Any 0.4x release works.
 3. **Generate bindings** with `wit_bindgen::generate!({ generate_all })`. For interfaces that share types with `wasi:io` (like `wasi:blobstore`), use the `with` option to point shared types at `wasip2`'s definitions to avoid duplicates.
-4. **Use the generated functions** under `bindings::wasi::<package>::<interface>::*`.
-5. **Handle serialization** — most WIT interfaces use `list<u8>` (`Vec<u8>`) for binary data; use `serde_json` for structured data.
-6. **No new Rust dependencies needed** beyond `wit-bindgen` itself — WIT interfaces are provided by the runtime, not by crates.io packages.
+4. **Use the generated functions** at `wasi::<package>::<interface>::*` (or `bindings::wasi::<package>::<interface>::*` if you wrap the macro in a module).
+5. **Handle serialization.** Most WIT interfaces use `list<u8>` (`Vec<u8>`) for binary data. Use `serde_json` for structured data.
+6. **Stable WASI 0.2 interfaces** like `wasi:cli/environment` and `wasi:filesystem` are available via the `wasip2` crate without `wit-bindgen`. Draft interfaces like `wasi:keyvalue` need `wit-bindgen`. See [Adding custom WASI interfaces](./index.mdx#adding-custom-wasi-interfaces) for the distinction.
 
 ## API reference: `wasi:keyvalue/store` operations used
 

--- a/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
@@ -1,0 +1,317 @@
+---
+title: 'Key-Value Storage'
+sidebar_position: 1
+---
+
+You can add key-value capabilities to a Rust component with the [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue/) interface.
+
+This guide walks through adding `wasi:keyvalue` to a Rust component using `wit-bindgen` alongside `wstd`. You can use it as a model for adding any WASI interface that isn't bundled into `wstd` directly.
+
+## Overview
+
+`wasi:keyvalue` is a draft WASI interface that gives a component access to a bucket-based key-value store: `open` a bucket, then `get`, `set`, `delete`, `exists`, and `list-keys` against it. The underlying storage is provided by the host runtime, so the same component code runs against any supported backend (in-memory, filesystem, NATS, Redis, and others) without modification.
+
+:::info[]
+By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Key-Value NATS plugin](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:keyvalue` with a different storage solution.
+:::
+
+In Rust, two pieces collaborate to make this work:
+
+- **`wstd`** handles the `wasi:http/incoming-handler` export via the `#[wstd::http_server]` proc macro
+- **`wit-bindgen`** generates Rust bindings for the keyvalue interface, which `wstd` doesn't provide
+
+These two coexist because draft interfaces like `wasi:keyvalue` are self-contained: they don't share types with `wasi:io` or other standard interfaces, so there are no type conflicts between what `wasip2` (bundled with `wstd`) provides and what `wit-bindgen` generates.
+
+:::tip[Complete example]
+A full working example is available as a template:
+```shell
+wash new https://github.com/wasmCloud/wasmCloud.git \
+  --name http-kv-service \
+  --subfolder templates/http-kv-service
+```
+:::
+
+## Step 1: Declare the WIT imports in `wit/world.wit`
+
+Every capability your component uses must be declared in its WIT world. Add an `import` line for `wasi:keyvalue/store`:
+
+```wit title="wit/world.wit" {4}
+package wasmcloud:http-kv-service;
+
+world http-kv-service {
+  import wasi:keyvalue/store@0.2.0-draft;
+
+  export wasi:http/incoming-handler@0.2.2;
+}
+```
+
+If you also need atomic operations like `increment`, add `wasi:keyvalue/atomics@0.2.0-draft` as a second import.
+
+When you run `wash dev` or `wash build`, the build pipeline calls `wash wit fetch`, which resolves the WIT package references and downloads their definitions into `wit/deps/`. You don't need to manually fetch any WIT files.
+
+## Step 2: Add `wit-bindgen` to `Cargo.toml`
+
+`wstd` alone does not bring in `wit-bindgen`. Add it as a direct dependency:
+
+```toml title="Cargo.toml"
+[package]
+name = "http-kv-service"
+edition = "2024"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wit-bindgen = "0.41"
+```
+
+Note that this template-style `Cargo.toml` does not depend on `wstd` at all, since the component handles the HTTP export directly through `wit-bindgen`-generated bindings rather than through the `#[wstd::http_server]` macro. If you prefer the macro form, add `wstd = "0.6"` and follow the [hybrid pattern](#hybrid-wstd--wit-bindgen-pattern) below.
+
+## Step 3: Generate bindings and use the interface
+
+Generate bindings for everything in the world (both the `wasi:keyvalue` import and the `wasi:http/incoming-handler` export) with `wit_bindgen::generate!`:
+
+```rust title="src/lib.rs"
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::{
+    exports::wasi::http::incoming_handler::Guest,
+    wasi::{
+        http::types::{
+            Fields, IncomingBody, IncomingRequest, Method, OutgoingBody, OutgoingResponse,
+            ResponseOutparam,
+        },
+        keyvalue::store::open,
+    },
+};
+
+struct Component;
+
+impl Guest for Component {
+    fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
+        let (status, body) = match request.method() {
+            Method::Post => handle_post(request),
+            Method::Get => handle_get(request),
+            _ => (405u16, "Method Not Allowed\n".to_string()),
+        };
+
+        let response = OutgoingResponse::new(Fields::new());
+        response.set_status_code(status).unwrap();
+        let out_body = response.body().unwrap();
+        ResponseOutparam::set(response_out, Ok(response));
+        let stream = out_body.write().unwrap();
+        stream.blocking_write_and_flush(body.as_bytes()).unwrap();
+        drop(stream);
+        OutgoingBody::finish(out_body, None).unwrap();
+    }
+}
+
+bindings::export!(Component with_types_in bindings);
+```
+
+The `generate_all` option tells `wit-bindgen` to generate bindings for every interface in the world: imports, exports, and their transitive dependencies. The `wasi:keyvalue/store` interface lands at `bindings::wasi::keyvalue::store`.
+
+### Opening a bucket
+
+Every keyvalue operation goes through a `Bucket` resource returned by `store::open`:
+
+```rust
+const BUCKET: &str = "default";
+
+fn handle_post(request: IncomingRequest) -> (u16, String) {
+    let bucket = match open(BUCKET) {
+        Ok(b) => b,
+        Err(e) => return (500, format!("open bucket: {e:?}\n")),
+    };
+    // ... use the bucket
+}
+```
+
+The string passed to `open` is a logical bucket name. The wasmCloud runtime maps it to a physical store based on the host's `wasi:keyvalue` plugin configuration. Treat the bucket as a per-request resource and open it inside each handler rather than caching it at module scope.
+
+### Storing a value
+
+`bucket.set` takes a `&str` key and a `&[u8]` value:
+
+```rust
+#[derive(serde::Deserialize)]
+struct KvPayload {
+    key: String,
+    value: String,
+}
+
+fn handle_post(request: IncomingRequest) -> (u16, String) {
+    let body_bytes = match read_body(request) {
+        Ok(b) => b,
+        Err(e) => return (400, format!("read body: {e}\n")),
+    };
+
+    let payload: KvPayload = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(e) => return (400, format!("invalid JSON: {e}\n")),
+    };
+
+    let bucket = match open(BUCKET) {
+        Ok(b) => b,
+        Err(e) => return (500, format!("open bucket: {e:?}\n")),
+    };
+
+    match bucket.set(&payload.key, payload.value.as_bytes()) {
+        Ok(()) => (200, format!("Stored '{}'\n", payload.key)),
+        Err(e) => (500, format!("set: {e:?}\n")),
+    }
+}
+```
+
+### Reading a value
+
+`bucket.get` returns `Result<Option<Vec<u8>>, Error>`. `Ok(None)` means the key was not found:
+
+```rust
+fn handle_get(request: IncomingRequest) -> (u16, String) {
+    let path_and_query = request.path_with_query().unwrap_or_default();
+    let key = match parse_query_param(&path_and_query, "key") {
+        Some(k) => k,
+        None => return (400, "Missing required query parameter: key\n".to_string()),
+    };
+
+    let bucket = match open(BUCKET) {
+        Ok(b) => b,
+        Err(e) => return (500, format!("open bucket: {e:?}\n")),
+    };
+
+    match bucket.get(&key) {
+        Ok(Some(bytes)) => (200, format!("{}\n", String::from_utf8_lossy(&bytes))),
+        Ok(None) => (404, format!("Key '{key}' not found\n")),
+        Err(e) => (500, format!("get: {e:?}\n")),
+    }
+}
+```
+
+### Serialization: values are `list<u8>`
+
+`wasi:keyvalue/store` uses `list<u8>` (`Vec<u8>` in Rust) for values. To store structured data, serialize before `set` and deserialize after `get`:
+
+```rust
+let item_bytes = serde_json::to_vec(&item).map_err(|e| format!("serialize: {e}"))?;
+bucket.set(key, &item_bytes).map_err(|e| format!("set: {e:?}"))?;
+
+let bytes = bucket.get(key).map_err(|e| format!("get: {e:?}"))?;
+if let Some(bytes) = bytes {
+    let item: Item = serde_json::from_slice(&bytes).map_err(|e| format!("deserialize: {e}"))?;
+}
+```
+
+### Synchronous API
+
+All `wasi:keyvalue/store` calls (`open`, `get`, `set`, `delete`, `exists`, `list-keys`) are synchronous in WIT. The `wit-bindgen`-generated bindings expose them as plain functions, not `async fn`. Your handlers don't need to be async to use them.
+
+## Hybrid: `wstd` + `wit-bindgen` pattern
+
+If your component already uses `#[wstd::http_server]` and you want to add `wasi:keyvalue` on top, both can coexist. Declare only the new imports in WIT (let `wstd`'s macro provide the HTTP export) and use `wit-bindgen` for the import bindings:
+
+```wit title="wit/world.wit"
+package wasmcloud:my-component;
+
+// wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro.
+world my-component {
+  import wasi:keyvalue/store@0.2.0-draft;
+}
+```
+
+```rust title="src/lib.rs"
+wit_bindgen::generate!({
+    world: "my-component",
+    path: "wit",
+    generate_all,
+});
+
+use wasi::keyvalue::store::open;
+use wstd::http::{Body, Request, Response};
+
+#[wstd::http_server]
+async fn main(_req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
+    let bucket = open("default")
+        .map_err(|e| wstd::http::Error::msg(format!("open bucket: {e:?}")))?;
+    // ... use bucket
+    Ok(Response::new(Body::from("ok\n")))
+}
+```
+
+```toml title="Cargo.toml"
+[dependencies]
+wstd = "0.6"
+wit-bindgen = "0.46"
+```
+
+This gives you `wstd`'s ergonomic HTTP handling and async support alongside the keyvalue interface. See [Adding custom WASI interfaces](./index.mdx#adding-custom-wasi-interfaces) in the language guide for the full pattern, including handling type conflicts when imports overlap with `wasi:io`.
+
+## Build and verify
+
+```shell
+wash dev
+```
+
+`wash dev` builds the component, starts an HTTP server on `http://localhost:8000`, and provisions the configured `wasi:keyvalue` backend automatically.
+
+```shell
+# Store a value
+curl -X POST http://localhost:8000 \
+  -H "Content-Type: application/json" \
+  -d '{"key":"mykey","value":"myvalue"}'
+
+# Retrieve it
+curl "http://localhost:8000?key=mykey"
+
+# Missing key returns 404
+curl "http://localhost:8000?key=missing"
+```
+
+To verify persistence with a non-default backend, pick a backend in `.wash/config.yaml` (filesystem, NATS, Redis), restart the component, and confirm previously stored keys are still readable.
+
+## Choosing a backend
+
+The `BUCKET` constant in `src/lib.rs` is just a logical name; the host runtime selects the actual storage backend based on `.wash/config.yaml`. The [`http-kv-service`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-kv-service) template's `.wash/config.yaml` documents the available backends:
+
+| Backend       | Required config key            | Example value                    |
+|---------------|--------------------------------|----------------------------------|
+| `in_memory`   | *(none, default in `wash dev`)* | —                                |
+| `filesystem`  | `wasi_keyvalue_path`           | `/tmp/keyvalue-store`            |
+| `nats`        | `wasi_keyvalue_nats_url`       | `nats://127.0.0.1:4222`          |
+| `redis`       | `wasi_keyvalue_redis_url`      | `redis://127.0.0.1:6379`         |
+
+The component code is unchanged across backends.
+
+## Summary: checklist for adding any WIT interface
+
+1. **Add `import` lines to `wit/world.wit`** for the interfaces you need.
+2. **Add `wit-bindgen` to `Cargo.toml`** if it isn't already a dependency.
+3. **Generate bindings** with `wit_bindgen::generate!({ generate_all })`. For interfaces that share types with `wasi:io` (like `wasi:blobstore`), use the `with` option to point shared types at `wasip2`'s definitions to avoid duplicates.
+4. **Use the generated functions** under `bindings::wasi::<package>::<interface>::*`.
+5. **Handle serialization** — most WIT interfaces use `list<u8>` (`Vec<u8>`) for binary data; use `serde_json` for structured data.
+6. **No new Rust dependencies needed** beyond `wit-bindgen` itself — WIT interfaces are provided by the runtime, not by crates.io packages.
+
+## API reference: `wasi:keyvalue/store` operations used
+
+| Operation | Signature | Description |
+|-----------|-----------|-------------|
+| `open(name)` | `fn(&str) -> Result<Bucket, Error>` | Open a named bucket |
+| `bucket.get(key)` | `fn(&str) -> Result<Option<Vec<u8>>, Error>` | Get a value by key, `None` if missing |
+| `bucket.set(key, value)` | `fn(&str, &[u8]) -> Result<(), Error>` | Set a key to a value |
+| `bucket.delete(key)` | `fn(&str) -> Result<(), Error>` | Delete a key |
+| `bucket.exists(key)` | `fn(&str) -> Result<bool, Error>` | Check if a key exists |
+| `bucket.list_keys(cursor)` | `fn(Option<String>) -> Result<KeyResponse, Error>` | List keys with pagination cursor |
+
+## Further reading
+
+- [Rust Language Guide](./index.mdx) — toolchain overview, HTTP patterns, framework integration, and library compatibility
+- [Configuration](./configuration.mdx) — read configuration values from ConfigMaps, Secrets, and inline environment variables
+- [Filesystem](./filesystem.mdx) — read and write files from preopened directories
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
@@ -33,9 +33,9 @@ wash new https://github.com/wasmCloud/wasmCloud.git \
 
 ## Step 1: Declare the WIT imports in `wit/world.wit`
 
-Every capability your component uses must be declared in its WIT world. Add an `import` line for `wasi:keyvalue/store`:
+Every capability your component uses must be declared in its WIT world. Open `wit/world.wit` and add an `import` line for `wasi:keyvalue/store`:
 
-```wit title="wit/world.wit" {4}
+```wit {4}
 package wasmcloud:http-kv-service;
 
 world http-kv-service {
@@ -51,9 +51,9 @@ When you run `wash dev` or `wash build`, the build pipeline calls `wash wit fetc
 
 ## Step 2: Add `wit-bindgen` to `Cargo.toml`
 
-`wstd` alone does not bring in `wit-bindgen`. Add it as a direct dependency:
+`wstd` alone does not bring in `wit-bindgen`. Add it as a direct dependency in `Cargo.toml`:
 
-```toml title="Cargo.toml"
+```toml
 [package]
 name = "http-kv-service"
 edition = "2024"
@@ -72,9 +72,9 @@ Note that this template-style `Cargo.toml` does not depend on `wstd` at all, sin
 
 ## Step 3: Generate bindings and use the interface
 
-Generate bindings for everything in the world (both the `wasi:keyvalue` import and the `wasi:http/incoming-handler` export) with `wit_bindgen::generate!`:
+In `src/lib.rs`, generate bindings for everything in the world (both the `wasi:keyvalue` import and the `wasi:http/incoming-handler` export) with `wit_bindgen::generate!`:
 
-```rust title="src/lib.rs"
+```rust
 mod bindings {
     wit_bindgen::generate!({
         generate_all,
@@ -215,9 +215,11 @@ All `wasi:keyvalue/store` calls (`open`, `get`, `set`, `delete`, `exists`, `list
 
 ## Hybrid: `wstd` + `wit-bindgen` pattern
 
-If your component already uses `#[wstd::http_server]` and you want to add `wasi:keyvalue` on top, both can coexist. Declare only the new imports in WIT (let `wstd`'s macro provide the HTTP export) and use `wit-bindgen` for the import bindings:
+If your component already uses `#[wstd::http_server]` and you want to add `wasi:keyvalue` on top, both can coexist. Declare only the new imports in WIT (let `wstd`'s macro provide the HTTP export) and use `wit-bindgen` for the import bindings.
 
-```wit title="wit/world.wit"
+In `wit/world.wit`:
+
+```wit
 package wasmcloud:my-component;
 
 // wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro.
@@ -226,7 +228,9 @@ world my-component {
 }
 ```
 
-```rust title="src/lib.rs"
+In `src/lib.rs`:
+
+```rust
 wit_bindgen::generate!({
     world: "my-component",
     path: "wit",
@@ -245,7 +249,9 @@ async fn main(_req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> 
 }
 ```
 
-```toml title="Cargo.toml"
+In `Cargo.toml`:
+
+```toml
 [dependencies]
 wstd = "0.6"
 wit-bindgen = "0.46"

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -1,0 +1,429 @@
+---
+title: 'Messaging'
+sidebar_position: 2
+---
+
+You can add messaging capabilities to a Rust component with the [`wasmcloud:messaging`](https://github.com/wasmCloud/wasmCloud/tree/main/wit/messaging.wit) interface.
+
+This guide walks through the wasmCloud [`http-api-with-distributed-workloads`](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-api-with-distributed-workloads) Rust template, which dispatches work from an HTTP API to a background component over a message broker. You can use it as a model for adding `wasmcloud:messaging` to your own components.
+
+## Overview
+
+Messaging typically spans **at least two components**. A component can import `consumer` to publish events without a handler in the same deployment; for example, the component might publish audit events that an external NATS subscriber consumes. A handler can also receive messages from multiple senders.
+
+The example template demonstrates a two-component request-reply pattern that may serve as a starting point. The template consists of:
+
+- **`http-api`** — An HTTP component that accepts a `POST /task` request and uses `wasmcloud:messaging/consumer` to dispatch a request message and await its reply.
+- **`task-leet`** — A headless component that exports `wasmcloud:messaging/handler` to receive messages, process them (in this case, leet-speak the payload), and publish a reply.
+
+![Messaging flow](../../../images/messaging-flow.svg)
+
+:::info[NATS in production]
+`wasmcloud:messaging` uses NATS as its production transport, built into the wasmCloud runtime. During development with `wash dev`, messaging is handled in-process and no NATS server is required. In production, the runtime connects to NATS automatically when the host starts with a NATS URL.
+:::
+
+The template is organized as a Cargo workspace with two crates and a shared `wit/world.wit`:
+
+```
+http-api-with-distributed-workloads/
+├── Cargo.toml          # workspace, declares both crates
+├── wit/
+│   └── world.wit       # shared WIT worlds for both crates
+├── http-api/
+│   ├── Cargo.toml
+│   └── src/lib.rs      # imports consumer, exports HTTP handler
+└── task-leet/
+    ├── Cargo.toml
+    └── src/lib.rs      # exports handler, imports consumer for replies
+```
+
+`wasmcloud:messaging` is **not** bundled into `wstd`. Both crates use `wit-bindgen` to generate bindings for the messaging interfaces. The `http-api` crate combines `wit-bindgen`-generated `consumer` bindings with `wstd`'s `#[http_server]` macro for the HTTP export. The `task-leet` crate uses `wit-bindgen` only.
+
+:::tip[Complete example]
+A full working example is available as a template:
+```shell
+wash new https://github.com/wasmCloud/wasmCloud.git \
+  --name http-api-with-distributed-workloads \
+  --subfolder templates/http-api-with-distributed-workloads
+```
+:::
+
+## Step 1: Declare the WIT worlds
+
+Both components share a single `wit/world.wit`. The HTTP API only sends messages, so it imports `consumer` only. The worker receives messages and replies, so it both imports `consumer` and exports `handler`:
+
+```wit title="wit/world.wit"
+package wasmcloud:template@0.1.0;
+
+// wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro,
+// so it does not appear explicitly in the http-api world.
+world http-api {
+  import wasmcloud:messaging/consumer@0.2.0;
+}
+
+world task {
+  import wasmcloud:messaging/consumer@0.2.0;
+  export wasmcloud:messaging/handler@0.2.0;
+}
+```
+
+### What these interfaces provide
+
+| Interface | Direction | Purpose |
+|---|---|---|
+| [`wasmcloud:messaging/consumer`](https://github.com/wasmCloud/wasmCloud/blob/main/wit/messaging.wit) | import | Send messages (`request`, `publish`) |
+| [`wasmcloud:messaging/handler`](https://github.com/wasmCloud/wasmCloud/blob/main/wit/messaging.wit) | export | Receive messages (`handle-message`) |
+
+The underlying message type used by both interfaces:
+
+```wit
+record broker-message {
+  subject: string,
+  body: list<u8>,       // Vec<u8> in Rust
+  reply-to: option<string>,
+}
+```
+
+### How dependency resolution works
+
+When you run `wash dev` or `wash build`, the build pipeline calls `wash wit fetch` as a setup step. `wasmcloud:messaging` is hosted at the `wasmcloud.com` package registry, distinct from the `wasi.dev` registry used for standard WASI interfaces. Both registries are resolved automatically; no extra configuration is required.
+
+## Step 2: Use `consumer::request` from the HTTP API
+
+The `http-api` crate combines `#[wstd::http_server]` for the HTTP export with `wit-bindgen`-generated bindings for the `wasmcloud:messaging/consumer` import. Generate bindings against the `http-api` world:
+
+```rust title="http-api/src/lib.rs"
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../wit",
+        world: "http-api",
+        generate_all,
+    });
+}
+
+use anyhow::Context as _;
+use bindings::wasmcloud::messaging::consumer;
+use serde::Deserialize;
+use wstd::{
+    http::{Body, Request, Response, StatusCode},
+    time::Duration,
+};
+
+#[derive(Deserialize)]
+struct TaskRequest {
+    worker: Option<String>,
+    payload: String,
+}
+
+#[wstd::http_server]
+async fn main(req: Request<Body>) -> anyhow::Result<Response<Body>> {
+    match req.uri().path() {
+        "/task" => create_task(req).await,
+        _ => Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body("Not found\n".into())
+            .map_err(Into::into),
+    }
+}
+
+async fn create_task(mut req: Request<Body>) -> anyhow::Result<Response<Body>> {
+    let task: TaskRequest = req
+        .body_mut()
+        .json()
+        .await
+        .context("failed to parse body")?;
+
+    let subject = format!("tasks.{}", task.worker.unwrap_or_else(|| "default".into()));
+    let body = task.payload.into_bytes();
+    let timeout_ms = Duration::from_secs(5).as_millis() as u32;
+
+    match consumer::request(&subject, &body, timeout_ms) {
+        Ok(reply) => Response::builder()
+            .status(StatusCode::OK)
+            .body(reply.body.into())
+            .map_err(Into::into),
+        Err(err) => Response::builder()
+            .status(StatusCode::BAD_GATEWAY)
+            .body(err.into())
+            .map_err(Into::into),
+    }
+}
+```
+
+`consumer::request(subject, body, timeout_ms)` implements the request-reply pattern. It publishes `body` to `subject`, blocks until a reply arrives (or until `timeout_ms` elapses), and returns the reply as a `BrokerMessage`. It is **synchronous** in WIT, even though we call it from an `async fn` here. There is no `await` to add.
+
+`consumer::request` returns `Result<BrokerMessage, String>`. On error (timeout, no subscriber, delivery failure), the `Err(String)` describes what went wrong.
+
+:::warning[Timeout behavior]
+If no component is subscribed to `subject` within `timeout_ms` milliseconds, `consumer::request` returns `Err`. During `wash dev`, the wasmCloud runtime routes calls in-process, so timeouts only occur if the handler itself errors or takes too long. In production, a missing NATS subscription or an unreachable server both surface as timeout errors.
+:::
+
+`http-api/Cargo.toml`:
+
+```toml title="http-api/Cargo.toml"
+[package]
+name = "http-api"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+wit-bindgen = "0.41"
+wstd = "0.6"
+```
+
+### Subject naming
+
+Subjects are arbitrary dot-separated strings following NATS subject conventions. The template uses `tasks.{worker}` so multiple worker types can each subscribe to their own sub-subject:
+
+```text
+tasks.task-worker   →  handled by the task-worker component
+tasks.summarizer    →  would be handled by a hypothetical summarizer component
+```
+
+In development with `wash dev`, all messages are routed in-process regardless of subject. Subjects only become meaningful in production where NATS subscription patterns control routing.
+
+## Step 3: Implement the handler in the worker
+
+The worker exports `wasmcloud:messaging/handler@0.2.0` and imports `consumer` so it can publish replies. Generate bindings against the `task` world:
+
+```rust title="task-leet/src/lib.rs"
+wit_bindgen::generate!({
+    path: "../wit",
+    world: "task",
+    with: {
+        "wasmcloud:messaging/types@0.2.0": generate,
+        "wasmcloud:messaging/consumer@0.2.0": generate,
+    },
+});
+
+use crate::wasmcloud::messaging::types::BrokerMessage;
+use wasmcloud::messaging::consumer;
+
+struct Component;
+export!(Component);
+
+impl exports::wasmcloud::messaging::handler::Guest for Component {
+    fn handle_message(msg: BrokerMessage) -> Result<(), String> {
+        let Some(subject) = msg.reply_to else {
+            return Err("missing reply_to".to_string());
+        };
+
+        let payload = String::from_utf8(msg.body.to_vec())
+            .map_err(|e| format!("failed to decode body: {e}"))?;
+
+        consumer::publish(&BrokerMessage {
+            subject,
+            body: to_leet_speak(&payload).into(),
+            reply_to: None,
+        })
+    }
+}
+
+fn to_leet_speak(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c.to_ascii_lowercase() {
+            'a' => '4',
+            'e' => '3',
+            'i' => '1',
+            'o' => '0',
+            's' => '5',
+            't' => '7',
+            'l' => '1',
+            _ => c,
+        })
+        .collect()
+}
+```
+
+`exports::wasmcloud::messaging::handler::Guest::handle_message` is the export shape `wit-bindgen` generates for `export wasmcloud:messaging/handler@0.2.0`. Implement it on a unit struct and call `export!` to register the implementation.
+
+`handle_message` returns `Result<(), String>`. Returning `Err` propagates back to the caller; if the sender called `consumer::request`, the `Err` surfaces there as the request's `Err` variant.
+
+`consumer::publish(&msg)` is fire-and-forget delivery. It returns `Result<(), String>`, but since the worker is the last hop in this template, the calling pattern is `?` to propagate any delivery failure.
+
+`task-leet/Cargo.toml`:
+
+```toml title="task-leet/Cargo.toml"
+[package]
+name = "task-leet"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "0.41"
+wstd = "0.6"
+```
+
+### Fire-and-forget handlers
+
+If a handler does not need to reply (one-way notification pattern), omit the `consumer::publish` call:
+
+```rust
+impl exports::wasmcloud::messaging::handler::Guest for Component {
+    fn handle_message(msg: BrokerMessage) -> Result<(), String> {
+        let event = serde_json::from_slice::<Event>(&msg.body)
+            .map_err(|e| format!("decode: {e}"))?;
+        process_event(event); // side effects only, no reply
+        Ok(())
+    }
+}
+```
+
+## Step 4: Configure multi-component development
+
+A multi-crate workspace has a root `Cargo.toml` that lists each crate as a workspace member, plus a root `.wash/config.yaml` that points `component_path` at the primary component (the HTTP API) and lists the additional component under `dev: components:`:
+
+```toml title="Cargo.toml (workspace root)"
+[workspace]
+resolver = "3"
+members = ["http-api", "task-leet"]
+
+[workspace.package]
+edition = "2024"
+
+[workspace.dependencies]
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+wit-bindgen = "0.41"
+wstd = "0.6"
+```
+
+```yaml title=".wash/config.yaml"
+build:
+  command: cargo build --target wasm32-wasip2 --release
+  component_path: target/wasm32-wasip2/release/http_api.wasm
+
+dev:
+  components:
+    - name: task-leet
+      file: target/wasm32-wasip2/release/task_leet.wasm
+```
+
+The `dev: components:` list tells `wash dev` to deploy the worker alongside the main component. `wash dev` automatically links both components through the wasmCloud runtime; no NATS server is required during development.
+
+## Build and verify
+
+```shell
+wash dev
+```
+
+`wash dev` builds both crates, starts an HTTP server on port 8000, and routes messaging calls between the components in-process.
+
+```shell
+# Send a task — the worker converts the payload to leet speak
+curl -s -X POST http://localhost:8000/task \
+  -H 'Content-Type: application/json' \
+  -d '{"worker": "task-leet", "payload": "Hello World"}'
+```
+
+```text
+H3110 W0r1d
+```
+
+A request without a payload returns `400`:
+
+```shell
+curl -s -X POST http://localhost:8000/task \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+## Production deployment
+
+Both components run on the same wasmCloud host. Start the host with a NATS URL; the runtime's built-in messaging plugin connects to NATS automatically. Deploy both components together with a `WorkloadDeployment` manifest:
+
+```yaml
+apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: http-api-with-distributed-workloads
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: your-domain.example.com
+        - namespace: wasmcloud
+          package: messaging
+          interfaces:
+            - consumer
+            - handler
+          config:
+            subscriptions: "tasks.>"
+      components:
+        - name: http-api
+          image: <registry>/http-api:latest
+        - name: task-leet
+          image: <registry>/task-leet:latest
+```
+
+Key points about the manifest:
+
+- **`hostInterfaces`** declares which built-in host capabilities the workload needs. No separate HTTP server or NATS component is listed; both are provided by the runtime.
+- **`interfaces: [consumer, handler]`** declares both the sending and receiving sides of the messaging interface. The runtime automatically wires subscriptions to the component that exports `handler` (the worker), not to the HTTP API which only imports `consumer`.
+- **`subscriptions`** is a comma-separated list of NATS subject patterns. `tasks.>` matches any subject starting with `tasks.`, covering any number of worker types.
+- **HTTP `host` config** is the Host header the runtime uses to route incoming HTTP requests to this workload. The actual listen address is set at host startup (`--http-addr`).
+
+:::info[Subject-based routing in production]
+Because NATS subscriptions are configured per-workload at deploy time, subject naming becomes a contract between sender and handler. The `tasks.{worker}` convention in this template means each worker type can be independently scaled and replaced without modifying the HTTP API. Deploy a new worker with its own subscription and the API keeps working unchanged.
+:::
+
+## Summary: checklist for adding `wasmcloud:messaging`
+
+**For a component that sends messages (consumer):**
+
+1. **Add `import wasmcloud:messaging/consumer@0.2.0` to its WIT world**.
+2. **Add `wit-bindgen` to `Cargo.toml`** and generate bindings with `wit_bindgen::generate!`.
+3. **Call `consumer::request(subject, body, timeout_ms)`** for request-reply; it returns `Result<BrokerMessage, String>`.
+4. **Call `consumer::publish(&msg)`** for fire-and-forget delivery; it returns `Result<(), String>`.
+
+**For a component that handles messages (handler):**
+
+1. **Add both `import wasmcloud:messaging/consumer@0.2.0` and `export wasmcloud:messaging/handler@0.2.0` to its WIT world**. The import is needed for `publish()` (replies); the export declares the handler.
+2. **Implement `exports::wasmcloud::messaging::handler::Guest::handle_message`** on a unit struct and call `export!`.
+3. **Use `msg.reply_to`** to find the reply subject for request-reply patterns; call `consumer::publish` to respond.
+4. **Return `Err(String)` to signal failure** — the value propagates back to the caller.
+
+**For multi-component development:**
+
+1. **Use a Cargo workspace** with each component as a workspace member.
+2. **Declare `dev: components:` in root `.wash/config.yaml`** with the path to each additional component's `.wasm` file.
+3. **`wash dev` routes messages in-process** — no NATS server required during development.
+4. **In production**, use a `WorkloadDeployment` manifest with a `wasmcloud:messaging` `hostInterface` entry. Include `handler` in the interfaces list and set `subscriptions` in the `config` block.
+
+## API reference: `wasmcloud:messaging` functions used
+
+| Function | Signature | Description |
+|---|---|---|
+| `consumer::request(subject, body, timeout_ms)` | `fn(&str, &[u8], u32) -> Result<BrokerMessage, String>` | Publish to `subject` and block until a reply arrives or `timeout_ms` elapses. |
+| `consumer::publish(msg)` | `fn(&BrokerMessage) -> Result<(), String>` | Fire-and-forget publish. |
+| `handler::Guest::handle_message(msg)` | `fn(BrokerMessage) -> Result<(), String>` | Called by the runtime for each delivered message. Return `Err` to signal failure. |
+
+**`BrokerMessage` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `subject` | `String` | The message subject (NATS topic) |
+| `body` | `Vec<u8>` | Raw message payload |
+| `reply_to` | `Option<String>` | Reply subject set automatically by `consumer::request` |
+
+## Further reading
+
+- [Rust Language Guide](./index.mdx) — toolchain overview, HTTP patterns, async runtime guidance, and crate compatibility
+- [Key-Value Storage](./key-value-storage.mdx) — persistent state for a single component
+- [Configuration](./configuration.mdx) — read configuration values from ConfigMaps, Secrets, and inline environment variables
+- [Language Support overview](../index.mdx) — summary of all supported languages and toolchains

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -178,6 +178,8 @@ wit-bindgen = "0.41"
 wstd = "0.6"
 ```
 
+Any `wit-bindgen` 0.4x release works. The template pins `0.41` because it is the version the rest of the wasmCloud Rust template fleet uses; newer 0.4x releases are interchangeable.
+
 ### Subject naming
 
 Subjects are arbitrary dot-separated strings following NATS subject conventions. The template uses `tasks.{worker}` so multiple worker types can each subscribe to their own sub-subject:
@@ -244,7 +246,7 @@ fn to_leet_speak(input: &str) -> String {
 
 `handle_message` returns `Result<(), String>`. Returning `Err` propagates back to the caller; if the sender called `consumer::request`, the `Err` surfaces there as the request's `Err` variant.
 
-`consumer::publish(&msg)` is fire-and-forget delivery. It returns `Result<(), String>`, but since the worker is the last hop in this template, the calling pattern is `?` to propagate any delivery failure.
+`consumer::publish(&msg)` is fire-and-forget delivery. It returns `Result<(), String>`. Because the worker is the last hop in this template, the snippet returns the call's `Result` directly as `handle_message`'s return value, propagating any delivery failure to the runtime.
 
 In `task-leet/Cargo.toml`:
 
@@ -279,7 +281,7 @@ impl exports::wasmcloud::messaging::handler::Guest for Component {
 
 ## Step 4: Configure multi-component development
 
-A multi-crate workspace has a root `Cargo.toml` that lists each crate as a workspace member, plus a root `.wash/config.yaml` that points `component_path` at the primary component (the HTTP API) and lists the additional component under `dev: components:`.
+A convenient layout uses a Cargo workspace with a root `Cargo.toml` that lists each crate as a workspace member, plus a root `.wash/config.yaml` that points `component_path` at the primary component (the HTTP API) and lists the additional component under `dev: components:`. A standalone two-crate layout works too; the workspace just makes the shared dependencies easier to manage.
 
 In the workspace root `Cargo.toml`:
 
@@ -321,8 +323,9 @@ wash dev
 
 `wash dev` builds both crates, starts an HTTP server on port 8000, and routes messaging calls between the components in-process.
 
+Send a task. The worker converts the payload to leet speak:
+
 ```shell
-# Send a task — the worker converts the payload to leet speak
 curl -s -X POST http://localhost:8000/task \
   -H 'Content-Type: application/json' \
   -d '{"worker": "task-leet", "payload": "Hello World"}'

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -50,9 +50,11 @@ wash new https://github.com/wasmCloud/wasmCloud.git \
 
 ## Step 1: Declare the WIT worlds
 
-Both components share a single `wit/world.wit`. The HTTP API only sends messages, so it imports `consumer` only. The worker receives messages and replies, so it both imports `consumer` and exports `handler`:
+Both components share a single `wit/world.wit`. The HTTP API only sends messages, so it imports `consumer` only. The worker receives messages and replies, so it both imports `consumer` and exports `handler`.
 
-```wit title="wit/world.wit"
+In `wit/world.wit`:
+
+```wit
 package wasmcloud:template@0.1.0;
 
 // wasi:http/incoming-handler is exported via wstd's #[http_server] proc macro,
@@ -90,9 +92,9 @@ When you run `wash dev` or `wash build`, the build pipeline calls `wash wit fetc
 
 ## Step 2: Use `consumer::request` from the HTTP API
 
-The `http-api` crate combines `#[wstd::http_server]` for the HTTP export with `wit-bindgen`-generated bindings for the `wasmcloud:messaging/consumer` import. Generate bindings against the `http-api` world:
+The `http-api` crate combines `#[wstd::http_server]` for the HTTP export with `wit-bindgen`-generated bindings for the `wasmcloud:messaging/consumer` import. In `http-api/src/lib.rs`, generate bindings against the `http-api` world:
 
-```rust title="http-api/src/lib.rs"
+```rust
 mod bindings {
     wit_bindgen::generate!({
         path: "../wit",
@@ -158,9 +160,9 @@ async fn create_task(mut req: Request<Body>) -> anyhow::Result<Response<Body>> {
 If no component is subscribed to `subject` within `timeout_ms` milliseconds, `consumer::request` returns `Err`. During `wash dev`, the wasmCloud runtime routes calls in-process, so timeouts only occur if the handler itself errors or takes too long. In production, a missing NATS subscription or an unreachable server both surface as timeout errors.
 :::
 
-`http-api/Cargo.toml`:
+In `http-api/Cargo.toml`:
 
-```toml title="http-api/Cargo.toml"
+```toml
 [package]
 name = "http-api"
 version = "0.1.0"
@@ -189,9 +191,9 @@ In development with `wash dev`, all messages are routed in-process regardless of
 
 ## Step 3: Implement the handler in the worker
 
-The worker exports `wasmcloud:messaging/handler@0.2.0` and imports `consumer` so it can publish replies. Generate bindings against the `task` world:
+The worker exports `wasmcloud:messaging/handler@0.2.0` and imports `consumer` so it can publish replies. In `task-leet/src/lib.rs`, generate bindings against the `task` world:
 
-```rust title="task-leet/src/lib.rs"
+```rust
 wit_bindgen::generate!({
     path: "../wit",
     world: "task",
@@ -244,9 +246,9 @@ fn to_leet_speak(input: &str) -> String {
 
 `consumer::publish(&msg)` is fire-and-forget delivery. It returns `Result<(), String>`, but since the worker is the last hop in this template, the calling pattern is `?` to propagate any delivery failure.
 
-`task-leet/Cargo.toml`:
+In `task-leet/Cargo.toml`:
 
-```toml title="task-leet/Cargo.toml"
+```toml
 [package]
 name = "task-leet"
 version = "0.1.0"
@@ -277,9 +279,11 @@ impl exports::wasmcloud::messaging::handler::Guest for Component {
 
 ## Step 4: Configure multi-component development
 
-A multi-crate workspace has a root `Cargo.toml` that lists each crate as a workspace member, plus a root `.wash/config.yaml` that points `component_path` at the primary component (the HTTP API) and lists the additional component under `dev: components:`:
+A multi-crate workspace has a root `Cargo.toml` that lists each crate as a workspace member, plus a root `.wash/config.yaml` that points `component_path` at the primary component (the HTTP API) and lists the additional component under `dev: components:`.
 
-```toml title="Cargo.toml (workspace root)"
+In the workspace root `Cargo.toml`:
+
+```toml
 [workspace]
 resolver = "3"
 members = ["http-api", "task-leet"]
@@ -294,7 +298,9 @@ wit-bindgen = "0.41"
 wstd = "0.6"
 ```
 
-```yaml title=".wash/config.yaml"
+In `.wash/config.yaml`:
+
+```yaml
 build:
   command: cargo build --target wasm32-wasip2 --release
   component_path: target/wasm32-wasip2/release/http_api.wasm

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -195,10 +195,7 @@ The worker exports `wasmcloud:messaging/handler@0.2.0` and imports `consumer` so
 wit_bindgen::generate!({
     path: "../wit",
     world: "task",
-    with: {
-        "wasmcloud:messaging/types@0.2.0": generate,
-        "wasmcloud:messaging/consumer@0.2.0": generate,
-    },
+    generate_all,
 });
 
 use crate::wasmcloud::messaging::types::BrokerMessage;

--- a/docs/wash/index.mdx
+++ b/docs/wash/index.mdx
@@ -26,7 +26,7 @@ This quick command tour requires the [Rust toolchain](https://www.rust-lang.org/
 Create a new component and navigate to the project directory:
 
    ```shell
-   wash new https://github.com/wasmCloud/wasmCloud.git --subfolder examples/http-hello-world --name hello
+   wash new https://github.com/wasmCloud/wasmCloud.git --subfolder templates/http-hello-world --name hello
    ```
    ```shell
    cd hello

--- a/sidebars.js
+++ b/sidebars.js
@@ -127,7 +127,17 @@ const sidebars = {
       label: 'Language Support',
       link: { type: 'doc', id: 'wash/developer-guide/language-support/index' },
       items: [
-        'wash/developer-guide/language-support/rust/index',
+        {
+          type: 'category',
+          label: 'Rust Language Guide',
+          link: { type: 'doc', id: 'wash/developer-guide/language-support/rust/index' },
+          items: [
+            'wash/developer-guide/language-support/rust/key-value-storage',
+            'wash/developer-guide/language-support/rust/messaging',
+            'wash/developer-guide/language-support/rust/filesystem',
+            'wash/developer-guide/language-support/rust/configuration',
+          ],
+        },
         {
           type: 'category',
           label: 'TypeScript Language Guide',


### PR DESCRIPTION
New interface walkthroughs under `language-support/rust/`:
- Key-Value Storage
- Messaging
- Filesystem
- Configuration

At the Rust Language Support index, adds a new "when to use wstd vs tokio" section

Depends on wasmCloud/wasmCloud#5084 landing for the path updates to point to a real subfolder.