### PR TITLE
docs(typescript): rename http-*-service-hono template references to http-*-handler-hono

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -24,10 +24,10 @@ All templates and examples on this page target wasmCloud v2 and require `wash` 2
 | [HTTP Hello World (Hono)](#http-hello-world-hono) | TypeScript | HTTP server using Hono |
 | [HTTP Hello World (Fetch API)](#http-hello-world-fetch-api) | TypeScript | HTTP server using the Fetch API |
 | [HTTP Client](#http-client) | TypeScript | Outgoing HTTP proxy |
-| [HTTP Service (Hono)](#http-service-hono) | TypeScript | Full REST API service |
-| [HTTP Service with Blob Storage (Hono)](#http-service-with-blob-storage-hono) | TypeScript | REST API + `wasi:blobstore` |
-| [HTTP Service with Filesystem (Hono)](#http-service-with-filesystem-hono) | TypeScript | REST API + `wasi:filesystem` |
-| [HTTP Service with Key-Value Storage (Hono)](#http-service-with-key-value-storage-hono) | TypeScript | REST API + `wasi:keyvalue` |
+| [HTTP Handler (Hono)](#http-handler-hono) | TypeScript | Full REST API handler |
+| [HTTP Handler with Blob Storage (Hono)](#http-handler-with-blob-storage-hono) | TypeScript | REST API + `wasi:blobstore` |
+| [HTTP Handler with Filesystem (Hono)](#http-handler-with-filesystem-hono) | TypeScript | REST API + `wasi:filesystem` |
+| [HTTP Handler with Key-Value Storage (Hono)](#http-handler-with-key-value-storage-hono) | TypeScript | REST API + `wasi:keyvalue` |
 | [HTTP API with Distributed Workloads](#http-api-with-distributed-workloads) | TypeScript | Two components coordinating via `wasmcloud:messaging` |
 | [TCP Echo Service](#tcp-echo-service) | TypeScript | HTTP component + TCP service workload |
 
@@ -107,56 +107,56 @@ Create from template:
 wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-client
 ```
 
-#### HTTP Service (Hono)
+#### HTTP Handler (Hono)
 
-A full-featured HTTP service component using Hono, demonstrating middleware patterns including CORS, request logging, response timing, and request ID tracking, with RESTful CRUD endpoints and error handling.
+A full-featured HTTP handler component using Hono, demonstrating middleware patterns including CORS, request logging, response timing, and request ID tracking, with RESTful CRUD endpoints and error handling.
 
-- **Source**: [`wasmCloud/typescript — templates/http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono)
+- **Source**: [`wasmCloud/typescript — templates/http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono)
 - **Interfaces**: Exports `wasi:http/incoming-handler@0.2.3`
 
 Create from template:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-service-hono
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-handler-hono
 ```
 
-#### HTTP Service with Blob Storage (Hono)
+#### HTTP Handler with Blob Storage (Hono)
 
-An HTTP service component using Hono, backed by `wasi:blobstore` for persistent file storage. Provides a complete REST API for blob CRUD operations.
+An HTTP handler component using Hono, backed by `wasi:blobstore` for persistent file storage. Provides a complete REST API for blob CRUD operations.
 
-- **Source**: [`wasmCloud/typescript — templates/http-blobstore-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-blobstore-service-hono)
+- **Source**: [`wasmCloud/typescript — templates/http-blobstore-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-blobstore-handler-hono)
 - **Interfaces**: Imports `wasi:blobstore/blobstore@0.2.0-draft`; exports `wasi:http/incoming-handler@0.2.6`
 
 Create from template:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-blobstore-service-hono
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-blobstore-handler-hono
 ```
 
-#### HTTP Service with Filesystem (Hono)
+#### HTTP Handler with Filesystem (Hono)
 
-An HTTP service component using Hono that serves files from a mounted directory via `wasi:filesystem`. Demonstrates reading from a preopened host directory inside a Wasm component.
+An HTTP handler component using Hono that serves files from a mounted directory via `wasi:filesystem`. Demonstrates reading from a preopened host directory inside a Wasm component.
 
-- **Source**: [`wasmCloud/typescript — templates/http-filesystem-service-hono`](https://github.com/wasmCloud/typescript/tree/main/templates/http-filesystem-service-hono)
+- **Source**: [`wasmCloud/typescript — templates/http-filesystem-handler-hono`](https://github.com/wasmCloud/typescript/tree/main/templates/http-filesystem-handler-hono)
 - **Interfaces**: Imports `wasi:filesystem/types@0.2.2`, `wasi:filesystem/preopens@0.2.2`; exports `wasi:http/incoming-handler@0.2.6`
 
 Create from template:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-filesystem-service-hono
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-filesystem-handler-hono
 ```
 
-#### HTTP Service with Key-Value Storage (Hono)
+#### HTTP Handler with Key-Value Storage (Hono)
 
-An HTTP service component using Hono, backed by `wasi:keyvalue` for persistent key-value storage. Demonstrates CRUD operations, atomic incrementation, and Hono middleware patterns. When run with `npm run dev`, a NATS-KV key-value provider is automatically configured.
+An HTTP handler component using Hono, backed by `wasi:keyvalue` for persistent key-value storage. Demonstrates CRUD operations, atomic incrementation, and Hono middleware patterns. When run with `npm run dev`, a NATS-KV key-value provider is automatically configured.
 
-- **Source**: [`wasmCloud/typescript — templates/http-kv-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-kv-service-hono)
+- **Source**: [`wasmCloud/typescript — templates/http-kv-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-kv-handler-hono)
 - **Interfaces**: Imports `wasi:keyvalue/store@0.2.0-draft`, `wasi:keyvalue/atomics@0.2.0-draft`; exports `wasi:http/incoming-handler@0.2.6`
 
 Create from template:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-kv-service-hono
+wash new https://github.com/wasmCloud/typescript.git --name my-project --subfolder templates/http-kv-handler-hono
 ```
 
 #### HTTP API with Distributed Workloads

--- a/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
@@ -9,7 +9,7 @@ This guide walks through replacing the in-memory mock data store in the wasmClou
 
 ## Overview
 
-The wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:blobstore`, which gives the component persistent object storage backed by a real blob store. 
+The wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace the in-memory map with `wasi:blobstore`, which gives the component persistent object storage backed by a real blob store. 
 
 :::info[]
 By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Blobstore NATS plugin](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:blobstore` with a different storage solution.

--- a/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
@@ -5,11 +5,11 @@ sidebar_position: 1
 
 You can add blob storage capabilities to a component with the [`wasi:blobstore`](https://github.com/WebAssembly/wasi-blobstore/) interface.
 
-This guide walks through replacing the in-memory mock data store in the wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template with the `wasi:blobstore` interface. You can use this guide as a model for implementing `wasi:blobstore` in your own components or adding any new WIT interface to an existing component.
+This guide walks through replacing the in-memory mock data store in the wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template with the `wasi:blobstore` interface. You can use this guide as a model for implementing `wasi:blobstore` in your own components or adding any new WIT interface to an existing component.
 
 ## Overview
 
-The wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:blobstore`, which gives the component persistent object storage backed by a real blob store. 
+The wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:blobstore`, which gives the component persistent object storage backed by a real blob store. 
 
 :::info[]
 By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Blobstore NATS plugin](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-runtime/src/plugin/wasi_blobstore/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:blobstore` with a different storage solution.
@@ -28,8 +28,8 @@ No changes are needed to `rolldown.config.mjs`, `tsconfig.json`, `package.json`,
 A full working example is available as a template:
 ```bash
 wash new https://github.com/wasmCloud/typescript.git \
-  --name http-blobstore-service-hono \
-  --subfolder templates/http-blobstore-service-hono \
+  --name http-blobstore-handler-hono \
+  --subfolder templates/http-blobstore-handler-hono \
  
 ```
 :::
@@ -41,7 +41,7 @@ Every capability your component uses must be declared in its WIT world. Open `wi
 ```wit {4}
 package wasmcloud:templates@0.1.0;
 
-world typescript-http-blobstore-service-hono {
+world typescript-http-blobstore-handler-hono {
   import wasi:blobstore/blobstore@0.2.0-draft;
 
   export wasi:http/incoming-handler@0.2.6;

--- a/docs/wash/developer-guide/language-support/typescript/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/configuration.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 You can read runtime configuration values in a TypeScript component with the [`wasi:cli/environment`](https://github.com/WebAssembly/wasi-cli) interface. Configuration values can be supplied from inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. All arrive through the same interface regardless of source.
 
-This guide walks through adding `wasi:cli/environment` to the wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template and shows how to provide values via a Kubernetes workload manifest.
+This guide walks through adding `wasi:cli/environment` to the wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template and shows how to provide values via a Kubernetes workload manifest.
 
 ## Overview
 
@@ -29,7 +29,7 @@ Every capability your component uses must be declared in its WIT world. Open `wi
 ```wit {4}
 package wasmcloud:templates@0.1.0;
 
-world typescript-http-service-hono {
+world typescript-http-handler-hono {
   import wasi:cli/environment@0.2.3;
 
   export wasi:http/incoming-handler@0.2.6;
@@ -277,7 +277,7 @@ This runs the full pipeline:
 Use `wash inspect` to confirm that your component correctly declares a `wasi:cli/environment` import:
 
 ```bash
-wash inspect dist/http_service_hono.wasm
+wash inspect dist/http_handler_hono.wasm
 ```
 
 You should see a line like:

--- a/docs/wash/developer-guide/language-support/typescript/index.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/index.mdx
@@ -207,7 +207,7 @@ self.addEventListener('fetch', (event) => {
 
 This approach gives you more control — for example, you can inject WASI configuration values into the Hono context or add custom middleware.
 
-The wasmCloud TypeScript examples repository includes a [full http-service example built with Hono](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono).
+The wasmCloud TypeScript examples repository includes a [full http-handler example built with Hono](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono).
 
 ## Project structure
 
@@ -347,10 +347,10 @@ Use `wash new` to scaffold a TypeScript component project:
 wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-hello-world-fetch
 ```
 
-For an HTTP service project with Hono:
+For an HTTP handler project with Hono:
 
 ```shell
-wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-service-hono
+wash new https://github.com/wasmCloud/typescript.git --subfolder templates/http-handler-hono
 ```
 
 TypeScript templates for wasmCloud v2.x use standard `npm` commands for development loops and builds.
@@ -396,7 +396,7 @@ The patterns in these guides (declaring WIT imports, importing interfaces agains
 ## Further reading
 
 - [Developer Guide](../../index.mdx?lang=typescript) — quickstart tutorial for creating, building, and running a TypeScript component
-- [wasmCloud TypeScript templates](https://github.com/wasmCloud/typescript/tree/main/templates) — project templates including http-client, http-service-hono, and more
+- [wasmCloud TypeScript templates](https://github.com/wasmCloud/typescript/tree/main/templates) — project templates including http-client, http-handler-hono, and more
 - [jco documentation](https://github.com/bytecodealliance/jco) — full reference for the JavaScript Component toolchain
 - [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS) — details on how JavaScript is compiled to Wasm components
 - [StarlingMonkey](https://github.com/bytecodealliance/StarlingMonkey) — the embedded JavaScript engine and its supported Web APIs

--- a/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
@@ -9,7 +9,7 @@ This guide walks through replacing the in-memory mock data store in the wasmClou
 
 ## Overview
 
-The wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:keyvalue`, which gives the component persistent storage backed by a real key-value store. 
+The wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/main/templates/http-handler-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:keyvalue`, which gives the component persistent storage backed by a real key-value store. 
 
 :::info[]
 By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Key-Value NATS plugin](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:keyvalue` with a different storage solution.

--- a/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
@@ -5,11 +5,11 @@ sidebar_position: 0
 
 You can add key-value capabilities to a component with the [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue/) interface.
 
-This guide walks through replacing the in-memory mock data store in the wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template with the `wasi:keyvalue` interface. You can use this guide as a model for implementing `wasi:keyvalue` in your own components or adding any new WIT interface to an existing component.
+This guide walks through replacing the in-memory mock data store in the wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template with the `wasi:keyvalue` interface. You can use this guide as a model for implementing `wasi:keyvalue` in your own components or adding any new WIT interface to an existing component.
 
 ## Overview
 
-The wasmCloud [`http-service-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-service-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:keyvalue`, which gives the component persistent storage backed by a real key-value store. 
+The wasmCloud [`http-handler-hono`](https://github.com/wasmCloud/typescript/tree/v2/templates/http-handler-hono) template includes an in-memory `Map<string, Item>` that acts as a simulated database. This means all data is lost whenever the component restarts. In this guide, we'll replace it with `wasi:keyvalue`, which gives the component persistent storage backed by a real key-value store. 
 
 :::info[]
 By default, a wasmCloud deployment uses NATS JetStream for storage via the built-in [WASI Key-Value NATS plugin](https://github.com/wasmCloud/wasmCloud/blob/main/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs). You can use [host plugins](../../../../runtime/index.mdx) to back `wasi:keyvalue` with a different storage solution.
@@ -26,8 +26,8 @@ No changes are needed to `rolldown.config.mjs`, `tsconfig.json`, `package.json`,
 A full working example is available as a template:
 ```bash
 wash new https://github.com/wasmCloud/typescript.git \
-  --name http-kv-service-hono \
-  --subfolder templates/http-kv-service-hono \
+  --name http-kv-handler-hono \
+  --subfolder templates/http-kv-handler-hono \
  
 ```
 :::
@@ -39,7 +39,7 @@ Every capability your component uses must be declared in its WIT world. Open `wi
 ```wit {4-5}
 package wasmcloud:templates@0.1.0;
 
-world typescript-http-service-hono {
+world typescript-http-handler-hono {
   import wasi:keyvalue/store@0.2.0-draft;
   import wasi:keyvalue/atomics@0.2.0-draft;
 
@@ -274,7 +274,7 @@ This runs the full pipeline:
 1. `wash wit fetch` -- downloads `wasi:keyvalue` WIT definitions into `wit/deps/`
 2. `jco types` -- generates TypeScript type definitions in `generated/types/`
 3. `rolldown` -- bundles TypeScript into `dist/component.js` (leaving `wasi:` imports external)
-4. `jco componentize` -- compiles `dist/component.js` into `dist/http_service_hono.wasm`
+4. `jco componentize` -- compiles `dist/component.js` into `dist/http_handler_hono.wasm`
 
 ### Run
 


### PR DESCRIPTION
The `service` suffix is likely to create confusion with wasmCloud's defined notion of a service. This PR updates documentation to track the TypeScript template renames in wasmCloud/typescript#632:

- `http-service-hono` → `http-handler-hono`
- `http-blobstore-service-hono` → `http-blobstore-handler-hono`
- `http-filesystem-service-hono` → `http-filesystem-handler-hono`
- `http-kv-service-hono` → `http-kv-handler-hono`
- `http-logging-service-hono` → `http-logging-handler-hono`

The TCP echo example keeps its `service` wording because it truly is a wasmCloud service.

Coordinated with:
- wasmCloud/typescript#632 (TypeScript template renames)
- wasmCloud/wasmCloud#5084 (Rust template renames)
- wasmCloud/wasmcloud.com#1137 (Rust docs renames)