### PR TITLE
fix(docs): bump documented version to 2.0.4 and use explicit namespace for installs

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,7 +22,7 @@ Install the parts of the [wasmCloud platform](./overview/index.mdx) that you nee
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -66,7 +66,7 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -108,7 +108,7 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-Verify that `wash` is properly installed and check your version for **`2.0.3`** with:
+Verify that `wash` is properly installed and check your version for **`2.0.4`** with:
 
 ```bash
 wash -V
@@ -138,14 +138,36 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
 Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml). The overlay disables the deprecated Runtime Gateway by default — HTTP traffic is routed by the operator via EndpointSlices tied to standard Kubernetes Services:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
+
+:::warning[Existing wasmCloud state in the cluster]
+If you've previously installed the wasmCloud operator (in any namespace), `helm install` may fail with:
+
+```text
+Error: INSTALLATION FAILED: ... ClusterRole "wasmcloud-runtime-operator-..." cannot be imported into the current release
+```
+
+Helm 3 does not re-import cluster-scoped resources owned by a previous release. If you no longer need the prior install, fully clean up its cluster-scoped resources:
+
+```shell
+helm uninstall wasmcloud --namespace <previous-namespace>
+kubectl delete clusterrole -l app.kubernetes.io/instance=wasmcloud
+kubectl delete clusterrolebinding -l app.kubernetes.io/instance=wasmcloud
+kubectl delete crd -l app.kubernetes.io/instance=wasmcloud
+```
+
+**Deleting the CRDs also deletes any existing `WorkloadDeployment`, `Host`, `Workload`, `WorkloadReplicaSet`, and `Artifact` resources in the cluster.** Make sure you have manifests checked in (or otherwise saved) for anything you want to recreate before running the CRD delete.
+
+After cleanup, re-run the install command above.
+:::
 
 Verify the deployment:
 
 ```shell
-kubectl get pods -l app.kubernetes.io/instance=wasmcloud -n default
+kubectl get pods -l app.kubernetes.io/instance=wasmcloud -n wasmcloud
 ```
 
 Once all pods are running, you're ready to deploy a Wasm workload.
@@ -181,7 +203,7 @@ kubectl delete service hello-world
 Uninstall wasmCloud:
 
 ```shell
-helm uninstall wasmcloud
+helm uninstall wasmcloud --namespace wasmcloud
 ```
 
 Delete the local Kubernetes environment:

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -105,7 +105,8 @@ Use Helm to install the wasmCloud operator from an OCI chart image:
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -115,7 +116,8 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the host HTTP port to 80, which the kind cluster config maps to host port 80 via a NodePort Service:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -123,7 +125,8 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
   <TabItem value="k3d" label="k3d">
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -131,7 +134,8 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
   <TabItem value="k3s" label="k3s">
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -149,7 +153,7 @@ You can find the full set of configurable values for the chart in [`wasmCloud/wa
 Verify the deployment:
 
 ```shell
-kubectl get pods -l app.kubernetes.io/instance=wasmcloud -n default
+kubectl get pods -l app.kubernetes.io/instance=wasmcloud -n wasmcloud
 ```
 
 Once all pods are running, you're ready to deploy a Wasm workload.

--- a/docs/kubernetes-operator/operator-manual/cicd.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd.mdx
@@ -29,7 +29,7 @@ The [`setup-wash-action`](https://github.com/wasmCloud/setup-wash-action) instal
 ```yaml
 - uses: wasmCloud/setup-wash-action@main
   with:
-    wash-version: "v2.0.3"    # version to install (default: v2.0.3)
+    wash-version: "v2.0.4"    # version to install (default: v2.0.4)
 ```
 
 ### setup-wash-cargo-auditable

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -94,7 +94,7 @@ Defaults to the chart's `appVersion`. Override only when you need to pin to a sp
 ```yaml
 operator:
   image:
-    tag: "2.0.3"
+    tag: "2.0.4"
 ```
 
 The same pattern applies to `gateway.image.tag` and `runtime.image.tag`.

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -33,9 +33,9 @@ The K3s setup (`deploy/k3s` in the `wasmCloud/wasmCloud` repository) runs five c
 |---------|-------|-------------|
 | `kubernetes` | `rancher/k3s` | K3s Kubernetes control plane |
 | `nats` | `nats:2-alpine` | NATS with JetStream (messaging backbone and object storage) |
-| `operator` | `ghcr.io/wasmcloud/runtime-operator:canary` | wasmCloud operator (watches CRDs, schedules workloads) |
-| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:canary` | HTTP ingress — routes requests to workloads (port 80) |
-| `wash-host` | `ghcr.io/wasmcloud/wash:canary-v2` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
+| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.4` | wasmCloud operator (watches CRDs, schedules workloads) |
+| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.4` | HTTP ingress — routes requests to workloads (port 80) |
+| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.4` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
 
 The `kubernetes` container automatically loads wasmCloud CRDs from the operator chart on first start, and writes a kubeconfig to `tmp/kubeconfig.yaml` for local use.
 
@@ -155,7 +155,7 @@ To scale out, add additional `wash-host` entries to `docker-compose.yml`:
 
 ```yaml
   wash-host-2:
-    image: ghcr.io/wasmcloud/wash:canary-v2
+    image: ghcr.io/wasmcloud/wash:2.0.4
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host-2
     depends_on:
       nats:

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -33,9 +33,9 @@ The K3s setup (`deploy/k3s` in the `wasmCloud/wasmCloud` repository) runs five c
 |---------|-------|-------------|
 | `kubernetes` | `rancher/k3s` | K3s Kubernetes control plane |
 | `nats` | `nats:2-alpine` | NATS with JetStream (messaging backbone and object storage) |
-| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.4` | wasmCloud operator (watches CRDs, schedules workloads) |
-| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.4` | HTTP ingress — routes requests to workloads (port 80) |
-| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.4` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
+| `operator` | `ghcr.io/wasmcloud/runtime-operator:canary` | wasmCloud operator (watches CRDs, schedules workloads) |
+| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:canary` | HTTP ingress — routes requests to workloads (port 80) |
+| `wash-host` | `ghcr.io/wasmcloud/wash:canary-v2` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
 
 The `kubernetes` container automatically loads wasmCloud CRDs from the operator chart on first start, and writes a kubeconfig to `tmp/kubeconfig.yaml` for local use.
 
@@ -155,7 +155,7 @@ To scale out, add additional `wash-host` entries to `docker-compose.yml`:
 
 ```yaml
   wash-host-2:
-    image: ghcr.io/wasmcloud/wash:2.0.4
+    image: ghcr.io/wasmcloud/wash:canary-v2
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host-2
     depends_on:
       nats:

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -33,9 +33,9 @@ The K3s setup (`deploy/k3s` in the `wasmCloud/wasmCloud` repository) runs five c
 |---------|-------|-------------|
 | `kubernetes` | `rancher/k3s` | K3s Kubernetes control plane |
 | `nats` | `nats:2-alpine` | NATS with JetStream (messaging backbone and object storage) |
-| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.3` | wasmCloud operator (watches CRDs, schedules workloads) |
-| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.3` | HTTP ingress — routes requests to workloads (port 80) |
-| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.3` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
+| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.4` | wasmCloud operator (watches CRDs, schedules workloads) |
+| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.4` | HTTP ingress — routes requests to workloads (port 80) |
+| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.4` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
 
 The `kubernetes` container automatically loads wasmCloud CRDs from the operator chart on first start, and writes a kubeconfig to `tmp/kubeconfig.yaml` for local use.
 
@@ -155,7 +155,7 @@ To scale out, add additional `wash-host` entries to `docker-compose.yml`:
 
 ```yaml
   wash-host-2:
-    image: ghcr.io/wasmcloud/wash:2.0.3
+    image: ghcr.io/wasmcloud/wash:2.0.4
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host-2
     depends_on:
       nats:

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -152,7 +152,7 @@ If your organization uses a GitOps workflow or requires manifests to be reviewed
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
 ```
@@ -164,7 +164,7 @@ Write the rendered manifests to a directory for review or to check into version 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret" \
   --output-dir ./wasmcloud-manifests
@@ -183,7 +183,7 @@ After rendering, you can verify that all image references point to your private 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   | grep "image:"
 ```
@@ -207,7 +207,7 @@ Then reference it with `-f`:
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --namespace wasmcloud \
   -f my-values.yaml
 ```
 

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -27,11 +27,11 @@ helm show values oci://ghcr.io/wasmcloud/charts/runtime-operator --version <vers
 ```
 :::
 
-For example, with version `2.0.3`, the images are:
+For example, with version `2.0.4`, the images are:
 
-- `ghcr.io/wasmcloud/runtime-operator:2.0.3`
-- `ghcr.io/wasmcloud/runtime-gateway:2.0.3`
-- `ghcr.io/wasmcloud/wash:2.0.3`
+- `ghcr.io/wasmcloud/runtime-operator:2.0.4`
+- `ghcr.io/wasmcloud/runtime-gateway:2.0.4`
+- `ghcr.io/wasmcloud/wash:2.0.4`
 - `docker.io/nats:2.11.3-alpine`
 
 If you disable the built-in NATS server (`--set nats.enabled=false`), you do not need to mirror the NATS image.
@@ -51,12 +51,12 @@ Create a `mirror.yaml` file listing the source and destination for each image. R
 ```yaml
 images:
   # wasmCloud runtime images
-  - source: ghcr.io/wasmcloud/runtime-operator:2.0.3
-    destination: myregistry/wasmcloud/runtime-operator:2.0.3
-  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.3
-    destination: myregistry/wasmcloud/runtime-gateway:2.0.3
-  - source: ghcr.io/wasmcloud/wash:2.0.3
-    destination: myregistry/wasmcloud/wash:2.0.3
+  - source: ghcr.io/wasmcloud/runtime-operator:2.0.4
+    destination: myregistry/wasmcloud/runtime-operator:2.0.4
+  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.4
+    destination: myregistry/wasmcloud/runtime-gateway:2.0.4
+  - source: ghcr.io/wasmcloud/wash:2.0.4
+    destination: myregistry/wasmcloud/wash:2.0.4
 
   # Third-party images
   - source: docker.io/nats:2.11.3-alpine
@@ -100,9 +100,8 @@ The Helm chart provides a `global.image.registry` value that overrides the regis
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
-  --create-namespace \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   --set global.image.registry="myregistry"
 ```
 
@@ -124,9 +123,8 @@ Then install with the pull secret:
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
-  --create-namespace \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
 ```
@@ -137,9 +135,8 @@ If you need to mirror images to different registry paths, you can override each 
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
-  --create-namespace \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   --set operator.image.registry="myregistry" \
   --set gateway.image.registry="myregistry" \
   --set runtime.image.registry="myregistry" \
@@ -154,8 +151,8 @@ If your organization uses a GitOps workflow or requires manifests to be reviewed
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
 ```
@@ -166,8 +163,8 @@ Write the rendered manifests to a directory for review or to check into version 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret" \
   --output-dir ./wasmcloud-manifests
@@ -185,8 +182,8 @@ After rendering, you can verify that all image references point to your private 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   --set global.image.registry="myregistry" \
   | grep "image:"
 ```
@@ -209,8 +206,8 @@ Then reference it with `-f`:
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.3 \
-  --namespace wasmcloud \
+  --version 2.0.4 \
+  --namespace wasmcloud --create-namespace \
   -f my-values.yaml
 ```
 

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -236,7 +236,8 @@ The tutorial below routes HTTP traffic through a Kubernetes Service whose Endpoi
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -246,7 +247,8 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures each host's HTTP listener on port 80. The kind cluster config maps container port 30950 to host port 80, so any NodePort Service on port 30950 will be reachable at `localhost`:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -256,7 +258,8 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3d supports `LoadBalancer` services natively and we started the cluster with port 80 mapped to the load balancer:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -266,7 +269,8 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3s includes a built-in load balancer (Klipper) that binds `LoadBalancer` services to node ports:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
 
@@ -276,7 +280,7 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
 Wait for the deployment to be ready:
 
 ```shell
-kubectl rollout status deploy -l app.kubernetes.io/instance=wasmcloud -n default
+kubectl rollout status deploy -l app.kubernetes.io/instance=wasmcloud -n wasmcloud
 ```
 
 ## Deploy Wasm workload

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -21,7 +21,7 @@ Components are compiled from your language of choice—Rust, TypeScript, Go, and
 
 ## Install `wash`
 
-First, we need to install the latest version of `wash` (**`2.0.3`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
+First, we need to install the latest version of `wash` (**`2.0.4`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
 
 <Tabs groupId="os" queryString>
   <TabItem value="macoslinux" label="macOS and Linux" default>
@@ -30,7 +30,7 @@ First, we need to install the latest version of `wash` (**`2.0.3`**). If you've 
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -74,7 +74,7 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.3`**):
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -116,13 +116,13 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.3`** with:
+In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.4`** with:
 
 ```bash
 wash -V
 ```
 
-If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.3`.
+If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.4`.
 Run `wash --help` to see all available commands and short descriptions for each.
 
 ## Choose your language

--- a/docs/recipes/tls-bring-your-own-certificates.mdx
+++ b/docs/recipes/tls-bring-your-own-certificates.mdx
@@ -106,14 +106,15 @@ Key fields:
 Install with Helm:
 
 ```shell
-helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+  --namespace wasmcloud --create-namespace \
   -f values.yaml
 ```
 
 Wait for the pods to start:
 
 ```shell
-kubectl rollout status deploy -l app.kubernetes.io/instance=wasmcloud -n default
+kubectl rollout status deploy -l app.kubernetes.io/instance=wasmcloud -n wasmcloud
 ```
 
 ## Step 4: Expose the host group with a NodePort Service

--- a/docs/recipes/tls-bring-your-own-certificates.mdx
+++ b/docs/recipes/tls-bring-your-own-certificates.mdx
@@ -273,7 +273,7 @@ When `generate.enabled` is `true` and `secretName` is empty, the chart creates a
 ```shell
 kubectl delete workloaddeployment hello-world
 kubectl delete svc wasmcloud-https
-helm uninstall wasmcloud
+helm uninstall wasmcloud --namespace wasmcloud
 kind delete cluster
 ```
 


### PR DESCRIPTION
Addresses a reported quickstart failure where `helm install` returns:

```
Error: INSTALLATION FAILED: ClusterRole "wasmcloud-runtime-operator-..." cannot be imported into the current release: invalid ownership metadata
```

Reproduced locally. The root cause is that we were running `helm install wasmcloud --version 2.0.3 ...` with no `--namespace` flag, so helm targeted the active namespace. If a user has prior wasmCloud cluster state from a previous install in any other namespace, helm refused to re-import the cluster-scoped resources (ClusterRoles, ClusterRoleBindings, CRDs) and the install failed. Bumping to 2.0.4 doesn't fix this because the failure happens during admission of cluster-scoped resources before chart contents matter.

This PR resolves the issue with a couple changes:

- Bumps every active `--version 2.0.3` install command and `:2.0.3` image tag to `2.0.4` across docs
- Adds `--namespace wasmcloud --create-namespace` to every `helm install` command in the active install instructions, plus matching `-n wasmcloud` on the verify / rollout / uninstall snippets
- Add a troubleshooting callout on the installation page with the cleanup sequence for the prior-install conflict