### PR TITLE
fix(quickstart): map host port 80 to NodePort 30950 on k3d so curl localhost works

### DIFF
--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -67,12 +67,14 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
   </TabItem>
   <TabItem value="k3d" label="k3d">
 
-[k3d](https://k3d.io/) runs a lightweight [k3s](https://k3s.io/) cluster inside Docker. It starts quickly and supports `LoadBalancer` services natively.
+[k3d](https://k3d.io/) runs a lightweight [k3s](https://k3s.io/) cluster inside Docker.
 
 **Requirements:** [Docker](https://docs.docker.com/get-started/get-docker/) · [k3d](https://k3d.io/#installation)
 
+The `--port` flag maps host port 80 to NodePort 30950 on the server node. The hello-world manifest exposes the workload as a `NodePort` Service on port 30950, so this maps the Wasm component directly to `localhost:80` without going through k3d's bundled Traefik LoadBalancer:
+
 ```shell
-k3d cluster create wasmcloud --port "80:80@loadbalancer"
+k3d cluster create wasmcloud --port "80:30950@server:0"
 ```
 
   </TabItem>

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -77,6 +77,8 @@ The `--port` flag maps host port 80 to NodePort 30950 on the server node. The he
 k3d cluster create wasmcloud --port "80:30950@server:0"
 ```
 
+If you'd prefer the `LoadBalancer` pattern more typical of k8s production deployments, see the [Expose a Workload via Kubernetes Service](../recipes/expose-workload-via-kubernetes-service.mdx#exposing-the-service-externally) recipe.
+
   </TabItem>
   <TabItem value="k3s" label="k3s">
 

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -192,7 +192,7 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
   </TabItem>
   <TabItem value="k3d" label="k3d">
 
-[k3d](https://k3d.io/) runs a lightweight [k3s](https://k3s.io/) cluster inside Docker. It starts quickly and supports `LoadBalancer` services natively.
+[k3d](https://k3d.io/) runs a lightweight [k3s](https://k3s.io/) cluster inside Docker.
 
 **Requirements:** [Docker](https://docs.docker.com/get-started/get-docker/) · [k3d](https://k3d.io/#installation)
 
@@ -200,8 +200,10 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
 On Linux, Docker may require `sudo` unless you've completed the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to run Docker as a non-root user.
 :::
 
+The `--port` flag maps host port 80 to NodePort 30950 on the server node. The hello-world manifest used later in this tutorial exposes the workload as a `NodePort` Service on port 30950, so this maps the Wasm component directly to `localhost:80` without going through k3d's bundled Traefik LoadBalancer:
+
 ```shell
-k3d cluster create wasmcloud --port "80:80@loadbalancer"
+k3d cluster create wasmcloud --port "80:30950@server:0"
 ```
 
   </TabItem>
@@ -253,7 +255,7 @@ helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-op
   </TabItem>
   <TabItem value="k3d" label="k3d">
 
-k3d supports `LoadBalancer` services natively and we started the cluster with port 80 mapped to the load balancer:
+The k3d cluster was started with host port 80 mapped to NodePort 30950 on the server node. That NodePort matches the `nodePort: 30950` in the hello-world Service applied later in this tutorial, so requests to `localhost:80` reach the workload directly:
 
 ```shell
 helm install wasmcloud --version 2.0.3 oci://ghcr.io/wasmcloud/charts/runtime-operator \

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -206,6 +206,8 @@ The `--port` flag maps host port 80 to NodePort 30950 on the server node. The he
 k3d cluster create wasmcloud --port "80:30950@server:0"
 ```
 
+If you'd prefer the `LoadBalancer` pattern more typical of k8s production deployments, see the [Expose a Workload via Kubernetes Service](../recipes/expose-workload-via-kubernetes-service.mdx#exposing-the-service-externally) recipe.
+
   </TabItem>
   <TabItem value="k3s" label="k3s">
 


### PR DESCRIPTION
The k3d quickstart instructed users to create the cluster with `--port "80:80@loadbalancer"`, which connects host port 80 to k3d's bundled Traefik LoadBalancer. The `hello-world` manifest applied later uses Service `type: NodePort` on port 30950, which Traefik does not route. That means `helm install` succeeds, `kubectl apply` succeeds, the workload reports `READY: True`, but `curl localhost` returns `404 page not found` from Traefik.

This contradicts the kind tab's mechanism (`containerPort: 30950 -> hostPort: 80`), which works because kind's port mapping bypasses the bundled load balancer and lands traffic directly on the NodePort.

This PR changes the k3d cluster create command to `--port "80:30950@server:0"`, which maps host port 80 directly to NodePort 30950 on the server node, matching how kind handles the same mapping. No Ingress or LoadBalancer Service required.