### PR TITLE
feat: wasmcloud-version plugin

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,46 @@
+name: update-version
+
+# Triggered by release-tag.yml in wasmCloud/wasmCloud after a stable release is
+# published. Updates the single version constant and opens a PR for review.
+
+on:
+  repository_dispatch:
+    types: [wasmcloud-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Use bot PAT so the PR triggers CI workflows.
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
+
+      - name: Update version constant
+        env:
+          NEW_VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          sed -i \
+            "s/export const WASMCLOUD_VERSION = '[^']*';/export const WASMCLOUD_VERSION = '${NEW_VERSION}';/" \
+            src/wasmcloud-version.ts
+          grep WASMCLOUD_VERSION src/wasmcloud-version.ts
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d1b9cd0f26de2b553b # v7.0.8
+        with:
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
+          commit-message: "docs: update wasmCloud version to ${{ github.event.client_payload.version }}"
+          branch: "docs/update-version-${{ github.event.client_payload.version }}"
+          title: "docs: update wasmCloud version to ${{ github.event.client_payload.version }}"
+          body: |
+            Automated version bump from the wasmCloud release pipeline.
+
+            Updates `src/wasmcloud-version.ts` to `${{ github.event.client_payload.version }}`.
+            The remark plugin propagates the new value to all `{{WASMCLOUD_VERSION}}` placeholders
+            in code blocks across the docs at build time — no other files need editing.
+          labels: "automated,documentation"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -6,6 +6,12 @@ name: update-version
 on:
   repository_dispatch:
     types: [wasmcloud-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "wasmCloud version to set (e.g. 2.1.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,6 +20,8 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      NEW_VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -22,8 +30,6 @@ jobs:
           token: ${{ secrets.WASMCLOUD_BOT_PAT }}
 
       - name: Update version constant
-        env:
-          NEW_VERSION: ${{ github.event.client_payload.version }}
         run: |
           sed -i \
             "s/export const WASMCLOUD_VERSION = '[^']*';/export const WASMCLOUD_VERSION = '${NEW_VERSION}';/" \
@@ -34,13 +40,13 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d1b9cd0f26de2b553b # v7.0.8
         with:
           token: ${{ secrets.WASMCLOUD_BOT_PAT }}
-          commit-message: "docs: update wasmCloud version to ${{ github.event.client_payload.version }}"
-          branch: "docs/update-version-${{ github.event.client_payload.version }}"
-          title: "docs: update wasmCloud version to ${{ github.event.client_payload.version }}"
+          commit-message: "docs: update wasmCloud version to ${{ env.NEW_VERSION }}"
+          branch: "docs/update-version-${{ env.NEW_VERSION }}"
+          title: "docs: update wasmCloud version to ${{ env.NEW_VERSION }}"
           body: |
             Automated version bump from the wasmCloud release pipeline.
 
-            Updates `src/wasmcloud-version.ts` to `${{ github.event.client_payload.version }}`.
+            Updates `src/wasmcloud-version.ts` to `${{ env.NEW_VERSION }}`.
             The remark plugin propagates the new value to all `{{WASMCLOUD_VERSION}}` placeholders
             in code blocks across the docs at build time — no other files need editing.
           labels: "automated,documentation"

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -66,7 +66,11 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
+<div className="nested-tabs">
+<Tabs groupId="windows-method" queryString>
+  <TabItem value="script" label="Install script" default>
+
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`{{WASMCLOUD_VERSION}}`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -92,6 +96,21 @@ iwr -useb https://wasmcloud.com/ps1 -OutFile install.ps1; .\install.ps1 -NoModif
 </details>
 
   </TabItem>
+  <TabItem value="winget" label="winget">
+
+If you have [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) installed, you can install `wash` with:
+
+```powershell
+winget install wasmCloud.wash
+```
+
+winget updates your PATH automatically. Open a new terminal session to use `wash`.
+
+  </TabItem>
+</Tabs>
+</div>
+
+  </TabItem>
 
   <TabItem value="source" label="Source">
 
@@ -108,7 +127,7 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-Verify that `wash` is properly installed and check your version for **`2.0.4`** with:
+Verify that `wash` is properly installed and check your version for **`{{WASMCLOUD_VERSION}}`** with:
 
 ```bash
 wash -V
@@ -138,7 +157,7 @@ curl -fLO https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/
 Use Helm to install the wasmCloud operator from an OCI chart image, using the [values for local installation](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml). The overlay disables the deprecated Runtime Gateway by default — HTTP traffic is routed by the operator via EndpointSlices tied to standard Kubernetes Services:
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -9,9 +9,9 @@ import TabItem from '@theme/TabItem';
 
 # Kubernetes Operator
 
-### The wasmCloud operator makes it easy to run wasmCloud and WebAssembly workloads on Kubernetes. 
+### The wasmCloud operator makes it easy to run wasmCloud and WebAssembly workloads on Kubernetes.
 
-We use the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to run wasmCloud on Kubernetes, leveraging the orchestrator to schedule wasmCloud infrastructure and workloads. 
+We use the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to run wasmCloud on Kubernetes, leveraging the orchestrator to schedule wasmCloud infrastructure and workloads.
 
 By aligning to Kubernetes, teams can adopt WebAssembly (Wasm) progressively&mdash;and integrate wasmCloud with existing tooling for ingress, registries, CI/CD, and other areas of the cloud-native ecosystem.
 
@@ -33,7 +33,7 @@ The entire platform can be deployed with [Helm](https://helm.sh/docs) using the 
 
 For a detailed breakdown of each component's responsibilities and the request flow, see the [Operator Overview](./operator-manual/overview.mdx). For commonly-overridden chart values, see the [Helm Values Reference](./operator-manual/helm-values.mdx).
 
-## Get started with the wasmCloud operator 
+## Get started with the wasmCloud operator
 
 Installation requires the following tools:
 
@@ -109,7 +109,7 @@ Use Helm to install the wasmCloud operator from an OCI chart image:
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -120,7 +120,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures the host HTTP port to 80, which the kind cluster config maps to host port 80 via a NodePort Service:
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -129,7 +129,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
   <TabItem value="k3d" label="k3d">
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -138,7 +138,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
   <TabItem value="k3s" label="k3s">
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -148,7 +148,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
 
 Along with the wasmCloud operator, wasmCloud CRDs, and NATS, the Helm chart will deploy **three wasmCloud hosts** using the [`wasmcloud/wash`](https://github.com/wasmCloud/wasmCloud/pkgs/container/wash) container image.
 
-You can build your own hosts that provide extended capabilities via [host plugins](../glossary.mdx#host-plugin). 
+You can build your own hosts that provide extended capabilities via [host plugins](../glossary.mdx#host-plugin).
 
 :::note[]
 You can find the full set of configurable values for the chart in [`wasmCloud/wasmCloud/charts/runtime-operator`](https://github.com/wasmCloud/wasmCloud/blob/main/charts/runtime-operator/values.yaml).

--- a/docs/kubernetes-operator/operator-manual/cicd.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd.mdx
@@ -29,7 +29,7 @@ The [`setup-wash-action`](https://github.com/wasmCloud/setup-wash-action) instal
 ```yaml
 - uses: wasmCloud/setup-wash-action@main
   with:
-    wash-version: "v2.0.4"    # version to install (default: v2.0.4)
+    wash-version: "v{{WASMCLOUD_VERSION}}"    # version to install (default: latest)
 ```
 
 ### setup-wash-cargo-auditable

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -94,7 +94,7 @@ Defaults to the chart's `appVersion`. Override only when you need to pin to a sp
 ```yaml
 operator:
   image:
-    tag: "2.0.4"
+    tag: "{{WASMCLOUD_VERSION}}"
 ```
 
 The same pattern applies to `gateway.image.tag` and `runtime.image.tag`.

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -33,9 +33,9 @@ The K3s setup (`deploy/k3s` in the `wasmCloud/wasmCloud` repository) runs five c
 |---------|-------|-------------|
 | `kubernetes` | `rancher/k3s` | K3s Kubernetes control plane |
 | `nats` | `nats:2-alpine` | NATS with JetStream (messaging backbone and object storage) |
-| `operator` | `ghcr.io/wasmcloud/runtime-operator:2.0.4` | wasmCloud operator (watches CRDs, schedules workloads) |
-| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:2.0.4` | HTTP ingress — routes requests to workloads (port 80) |
-| `wash-host` | `ghcr.io/wasmcloud/wash:2.0.4` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
+| `operator` | `ghcr.io/wasmcloud/runtime-operator:{{WASMCLOUD_VERSION}}` | wasmCloud operator (watches CRDs, schedules workloads) |
+| `gateway` | `ghcr.io/wasmcloud/runtime-gateway:{{WASMCLOUD_VERSION}}` | HTTP ingress — routes requests to workloads (port 80) |
+| `wash-host` | `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` | A [washlet](../../runtime/washlet.mdx) — the cluster-connected runtime host |
 
 The `kubernetes` container automatically loads wasmCloud CRDs from the operator chart on first start, and writes a kubeconfig to `tmp/kubeconfig.yaml` for local use.
 
@@ -155,7 +155,7 @@ To scale out, add additional `wash-host` entries to `docker-compose.yml`:
 
 ```yaml
   wash-host-2:
-    image: ghcr.io/wasmcloud/wash:2.0.4
+    image: ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}
     command: host --scheduler-nats-url nats://nats:4222 --data-nats-url nats://nats:4222 --http-addr 0.0.0.0:8080 --host-group default --host-name wash-host-2
     depends_on:
       nats:

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -27,11 +27,11 @@ helm show values oci://ghcr.io/wasmcloud/charts/runtime-operator --version <vers
 ```
 :::
 
-For example, with version `2.0.4`, the images are:
+For example, with version `{{WASMCLOUD_VERSION}}`, the images are:
 
-- `ghcr.io/wasmcloud/runtime-operator:2.0.4`
-- `ghcr.io/wasmcloud/runtime-gateway:2.0.4`
-- `ghcr.io/wasmcloud/wash:2.0.4`
+- `ghcr.io/wasmcloud/runtime-operator:{{WASMCLOUD_VERSION}}`
+- `ghcr.io/wasmcloud/runtime-gateway:{{WASMCLOUD_VERSION}}`
+- `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}`
 - `docker.io/nats:2.11.3-alpine`
 
 If you disable the built-in NATS server (`--set nats.enabled=false`), you do not need to mirror the NATS image.
@@ -51,12 +51,12 @@ Create a `mirror.yaml` file listing the source and destination for each image. R
 ```yaml
 images:
   # wasmCloud runtime images
-  - source: ghcr.io/wasmcloud/runtime-operator:2.0.4
-    destination: myregistry/wasmcloud/runtime-operator:2.0.4
-  - source: ghcr.io/wasmcloud/runtime-gateway:2.0.4
-    destination: myregistry/wasmcloud/runtime-gateway:2.0.4
-  - source: ghcr.io/wasmcloud/wash:2.0.4
-    destination: myregistry/wasmcloud/wash:2.0.4
+  - source: ghcr.io/wasmcloud/runtime-operator:{{WASMCLOUD_VERSION}}
+    destination: myregistry/wasmcloud/runtime-operator:{{WASMCLOUD_VERSION}}
+  - source: ghcr.io/wasmcloud/runtime-gateway:{{WASMCLOUD_VERSION}}
+    destination: myregistry/wasmcloud/runtime-gateway:{{WASMCLOUD_VERSION}}
+  - source: ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}
+    destination: myregistry/wasmcloud/wash:{{WASMCLOUD_VERSION}}
 
   # Third-party images
   - source: docker.io/nats:2.11.3-alpine
@@ -100,8 +100,9 @@ The Helm chart provides a `global.image.registry` value that overrides the regis
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --version {{WASMCLOUD_VERSION}} \
+  --namespace wasmcloud \
+  --create-namespace \
   --set global.image.registry="myregistry"
 ```
 
@@ -123,8 +124,9 @@ Then install with the pull secret:
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --version {{WASMCLOUD_VERSION}} \
+  --namespace wasmcloud \
+  --create-namespace \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
 ```
@@ -135,8 +137,9 @@ If you need to mirror images to different registry paths, you can override each 
 
 ```shell
 helm install wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
-  --namespace wasmcloud --create-namespace \
+  --version {{WASMCLOUD_VERSION}} \
+  --namespace wasmcloud \
+  --create-namespace \
   --set operator.image.registry="myregistry" \
   --set gateway.image.registry="myregistry" \
   --set runtime.image.registry="myregistry" \
@@ -151,7 +154,7 @@ If your organization uses a GitOps workflow or requires manifests to be reviewed
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
+  --version {{WASMCLOUD_VERSION}} \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret"
@@ -163,7 +166,7 @@ Write the rendered manifests to a directory for review or to check into version 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
+  --version {{WASMCLOUD_VERSION}} \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   --set global.image.pullSecrets[0].name="my-registry-secret" \
@@ -182,7 +185,7 @@ After rendering, you can verify that all image references point to your private 
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
+  --version {{WASMCLOUD_VERSION}} \
   --namespace wasmcloud \
   --set global.image.registry="myregistry" \
   | grep "image:"
@@ -206,7 +209,7 @@ Then reference it with `-f`:
 
 ```shell
 helm template wasmcloud-runtime oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --version 2.0.4 \
+  --version {{WASMCLOUD_VERSION}} \
   --namespace wasmcloud \
   -f my-values.yaml
 ```

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -71,12 +71,12 @@ If you prefer working in a language that isn't listed here, let us know!
 </div>
 
   </TabItem>
-  
+
 </Tabs>
 
 ## Publish image
 
-Now we can publish a Wasm binary image to any OCI compliant registry that supports **OCI artifacts**. 
+Now we can publish a Wasm binary image to any OCI compliant registry that supports **OCI artifacts**.
 
 :::note[What is this image?]
 The wasmCloud ecosystem uses the [OCI image specification](https://github.com/opencontainers/image-spec) to package Wasm components&mdash;these images are not container images, but conform to OCI standards and may be stored on any OCI-compatible registry. You can learn more about wasmCloud packaging on the [**Packaging**](../overview/packaging.mdx) page.
@@ -240,7 +240,7 @@ The tutorial below routes HTTP traffic through a Kubernetes Service whose Endpoi
   <TabItem value="existing" label="Existing cluster" default>
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -251,7 +251,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
 The [`values.local.yaml`](https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml) file configures each host's HTTP listener on port 80. The kind cluster config maps container port 30950 to host port 80, so any NodePort Service on port 30950 will be reachable at `localhost`:
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -262,7 +262,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
 The k3d cluster was started with host port 80 mapped to NodePort 30950 on the server node. That NodePort matches the `nodePort: 30950` in the hello-world Service applied later in this tutorial, so requests to `localhost:80` reach the workload directly:
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```
@@ -273,7 +273,7 @@ helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-op
 k3s includes a built-in load balancer (Klipper) that binds `LoadBalancer` services to node ports:
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   --namespace wasmcloud --create-namespace \
   -f https://raw.githubusercontent.com/wasmCloud/wasmCloud/refs/heads/main/charts/runtime-operator/values.local.yaml
 ```

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -21,7 +21,7 @@ Components are compiled from your language of choice—Rust, TypeScript, Go, and
 
 ## Install `wash`
 
-First, we need to install the latest version of `wash` (**`2.0.4`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
+First, we need to install the latest version of `wash` (**`{{WASMCLOUD_VERSION}}`**). If you've already installed `wash`, skip ahead to [Choose your language](#choose-your-language).
 
 <Tabs groupId="os" queryString>
   <TabItem value="macoslinux" label="macOS and Linux" default>
@@ -30,7 +30,7 @@ First, we need to install the latest version of `wash` (**`2.0.4`**). If you've 
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`{{WASMCLOUD_VERSION}}`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash
@@ -74,7 +74,11 @@ Homebrew updates your PATH automatically. You're ready to use `wash` in any term
 
   <TabItem value="windows" label="Windows">
 
-In PowerShell, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
+<div className="nested-tabs">
+<Tabs groupId="windows-method" queryString>
+  <TabItem value="script" label="Install script" default>
+
+In PowerShell, run the installation script to download and install the latest version of `wash` (**`{{WASMCLOUD_VERSION}}`**):
 
 ```powershell
 iwr -useb https://wasmcloud.com/ps1 | iex
@@ -100,6 +104,21 @@ iwr -useb https://wasmcloud.com/ps1 -OutFile install.ps1; .\install.ps1 -NoModif
 </details>
 
   </TabItem>
+  <TabItem value="winget" label="winget">
+
+If you have [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) installed, you can install `wash` with:
+
+```powershell
+winget install wasmCloud.wash
+```
+
+winget updates your PATH automatically. Open a new terminal session to use `wash`.
+
+  </TabItem>
+</Tabs>
+</div>
+
+  </TabItem>
 
   <TabItem value="source" label="Source">
 
@@ -116,13 +135,13 @@ Pre-built binaries for macOS, Linux, and Windows are [available on GitHub](https
   </TabItem>
 </Tabs>
 
-In a new terminal, verify that `wash` is properly installed and check your version for **`2.0.4`** with:
+In a new terminal, verify that `wash` is properly installed and check your version for **`{{WASMCLOUD_VERSION}}`** with:
 
 ```bash
 wash -V
 ```
 
-If `wash` is installed correctly, you will see the version string printed, for example `wash 2.0.4`.
+If `wash` is installed correctly, you will see the version string printed, for example `wash {{WASMCLOUD_VERSION}}`.
 Run `wash --help` to see all available commands and short descriptions for each.
 
 ## Choose your language
@@ -412,7 +431,6 @@ INFO cargo build --target wasm32-wasip2 --color always completed in 0.14s
 INFO HTTP server listening addr=0.0.0.0:8000
 INFO development session started successfully
 INFO listening for HTTP requests address=http://0.0.0.0:8000
-INFO watching for file changes (press Ctrl+c to stop)...
 ```
 
 By default, the application will run on our local port 8000. In a new terminal tab, we can `curl` our application:
@@ -604,7 +622,21 @@ If you prefer working in a language that isn't listed here, let us know!
   </TabItem>
 </Tabs>
 
-Save the modified file. Your toolchain automatically builds and deploys the updated component.
+Save the modified file, then rebuild and redeploy the updated component:
+
+<Tabs groupId="lang" queryString>
+
+  <TabItem value="rust" label="Rust" default>
+
+In the terminal running `wash dev`, press <kbd>Ctrl+C</kbd> to stop the dev session, then run `wash dev` again to rebuild and redeploy with your changes.
+
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+
+The TypeScript template uses [`nodemon`](https://nodemon.io/) to watch your `src/` directory and automatically rebuild and redeploy on save. No restart needed.
+
+  </TabItem>
+</Tabs>
 
 In the terminal, `curl` the application again:
 

--- a/docs/recipes/tls-bring-your-own-certificates.mdx
+++ b/docs/recipes/tls-bring-your-own-certificates.mdx
@@ -3,7 +3,7 @@ title: 'TLS with Bring-Your-Own Certificates'
 description: 'Serve HTTPS from a wasmCloud host group using your own TLS certificates'
 ---
 
-This recipe shows how to configure a wasmCloud host group to serve HTTPS using TLS certificates you provide. 
+This recipe shows how to configure a wasmCloud host group to serve HTTPS using TLS certificates you provide.
 
 By the end, you will have a kind cluster running wasmCloud with a host group that terminates TLS using a certificate stored in a Kubernetes Secret.
 
@@ -106,8 +106,7 @@ Key fields:
 Install with Helm:
 
 ```shell
-helm install wasmcloud --version 2.0.4 oci://ghcr.io/wasmcloud/charts/runtime-operator \
-  --namespace wasmcloud --create-namespace \
+helm install wasmcloud --version {{WASMCLOUD_VERSION}} oci://ghcr.io/wasmcloud/charts/runtime-operator \
   -f values.yaml
 ```
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -18,6 +18,8 @@ import {
   transformerNotationFocus,
 } from '@shikijs/transformers';
 import rehypeNameToId from 'rehype-name-to-id';
+import { WASMCLOUD_VERSION } from './src/wasmcloud-version';
+import wasmCloudVersionPlugin from './src/remark/wasmcloud-version';
 
 const rehypeShikiPlugin = [
   rehypeShiki,
@@ -104,6 +106,7 @@ const config = (async (): Promise<Config> => {
           docs: {
             sidebarPath: require.resolve('./sidebars.js'),
             editUrl: 'https://github.com/wasmCloud/wasmcloud.com/edit/main/',
+            remarkPlugins: [[wasmCloudVersionPlugin, { version: WASMCLOUD_VERSION }]],
             beforeDefaultRehypePlugins: [rehypeShikiPlugin],
             rehypePlugins: [rehypeNameToId],
             lastVersion: 'current',

--- a/src/remark/wasmcloud-version.ts
+++ b/src/remark/wasmcloud-version.ts
@@ -1,0 +1,21 @@
+interface Options {
+  version: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function replaceInNode(node: any, version: string): void {
+  if (node.type === 'code' || node.type === 'inlineCode') {
+    node.value = (node.value as string).replaceAll('{{WASMCLOUD_VERSION}}', version);
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      replaceInNode(child, version);
+    }
+  }
+}
+
+export default function wasmCloudVersionPlugin(options: Options) {
+  return (tree: unknown) => {
+    replaceInNode(tree, options.version);
+  };
+}

--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,0 +1,1 @@
+export const WASMCLOUD_VERSION = '2.0.6';


### PR DESCRIPTION
Adds a plugin to reference as a constant for the wasmCloud version. I will add a trigger to our release workflow to make this automatic. 



Additionally docs the winget path for Windows.

