### PR TITLE
docs: add troubleshooting page, document 2.1 namespace-scoping fields, correct Host CRD shape

### DIFF
--- a/blog/2026-05-07-wasmcloud-2.1.0/index.mdx
+++ b/blog/2026-05-07-wasmcloud-2.1.0/index.mdx
@@ -19,7 +19,7 @@ The biggest change in 2.1.0 is the transition of the `Host` CRD from cluster sco
 
 Previously, every `Host` object lived at the cluster level, even though the underlying host pod runs in a specific Kubernetes namespace. That mismatch created two friction points: tenant isolation required careful labeling conventions in lieu of a hard API boundary, and granting access to see your team's hosts (for one example) meant issuing a `ClusterRole` binding. Neither of these were as idiomatic to Kubernetes as we wanted.
 
-Starting in 2.1.0, the `Host` CRD is namespace-scoped rather than cluster-scoped. The runtime-operator creates every `Host` object in its own namespace, and a new `Host.spec.environment` field records where the underlying host pod actually runs—populated automatically from the downward API for in-cluster hosts, or supplied via `--environment` for external ones. The default behavior allows shared hosts, so for your existing installs, wasmCloud schedules exactly as it does today; `kubectl get hosts -n <operator-namespace>` shows the full set of hosts you have permission to see.
+Starting in 2.1.0, the `Host` CRD is namespace-scoped rather than cluster-scoped. The runtime-operator creates every `Host` object in its own namespace, and a new `Host.environment` field records where the underlying host pod actually runs—populated automatically from the downward API for in-cluster hosts, or supplied via `--environment` for external ones. The default behavior allows shared hosts, so for your existing installs, wasmCloud schedules exactly as it does today; `kubectl get hosts -n <operator-namespace>` shows the full set of hosts you have permission to see.
 
 For multi-tenant operators, there is now a single switch to enforce isolation:
 

--- a/docs/kubernetes-operator/api-reference.md
+++ b/docs/kubernetes-operator/api-reference.md
@@ -132,6 +132,7 @@ _Appears in:_
 | `hostId` _string_ |  |  | Required: \{\} <br /> |
 | `hostname` _string_ |  |  | Optional: \{\} <br /> |
 | `httpPort` _integer_ |  |  | Optional: \{\} <br /> |
+| `environment` _string_ | Environment records where the host is running. For Kubernetes host<br />pods this is the pod's namespace; for out-of-cluster hosts it can be<br />any operator-defined identifier (e.g. a region or data center). |  | Optional: \{\} <br /> |
 
 
 #### HostInterface
@@ -578,6 +579,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `hostSelector` _object (keys:string, values:string)_ |  |  | Optional: \{\} <br /> |
 | `hostId` _string_ |  |  | Optional: \{\} <br /> |
+| `environment` _string_ | Environment, if set, scopes scheduling to Hosts whose Environment<br />matches this value, regardless of the Workload's own namespace.<br />The value is matched against Host.Environment — typically a<br />Kubernetes namespace for in-cluster host pods, or any<br />operator-defined identifier for out-of-cluster hosts (e.g. a<br />region or data center). Only honored when the operator is started<br />with allowSharedHosts=true, or when Environment equals the<br />Workload's namespace. |  | Optional: \{\} <br /> |
 | `components` _[WorkloadComponent](#workloadcomponent) array_ |  |  | Optional: \{\} <br /> |
 | `hostInterfaces` _[HostInterface](#hostinterface) array_ |  |  | Optional: \{\} <br /> |
 | `service` _[WorkloadService](#workloadservice)_ |  |  | Optional: \{\} <br /> |

--- a/docs/kubernetes-operator/crds.mdx
+++ b/docs/kubernetes-operator/crds.mdx
@@ -55,11 +55,12 @@ metadata:
   namespace: default
   labels:
     hostgroup: default
-spec:
-  hostId: NABCDEFGHIJKLMNOPQRSTUVWXYZ234567
-  hostname: host-sample.default
-  httpPort: 4000
+hostId: NABCDEFGHIJKLMNOPQRSTUVWXYZ234567
+hostname: host-sample.default
+httpPort: 4000
 ```
+
+Unlike most Kubernetes resources, the `Host` CRD does not use a `spec` wrapper — fields like `hostId`, `hostname`, `httpPort`, and `environment` are set at the resource root. See the [Host API reference](./api-reference.md#host) for the full field list.
 
 ## Workload
 
@@ -88,7 +89,7 @@ spec:
           config:
             LOG_LEVEL: info
         allowedHosts:
-          - https://api.example.com
+          - api.example.com
   hostInterfaces:
     - namespace: wasi
       package: http
@@ -208,7 +209,7 @@ The `poolSize`, `maxInvocations`, and `allowedHosts` fields on a component contr
 
 - **`poolSize`**: Sets the maximum number of concurrent instances of this component that the host will pre-allocate in its execution pool. Higher values increase throughput under load; lower values reduce memory consumption. If omitted, the host uses its default pool size.
 - **`maxInvocations`**: Limits the number of in-flight invocations allowed for this component at any one time. Requests that exceed this limit are queued or rejected, providing back-pressure to protect host resources.
-- **`allowedHosts`**: A list of hostnames or URLs this component is permitted to make outbound HTTP calls to. Calls to addresses not on this list are blocked, enforcing a least-privilege network policy for the component. See [Workload Security](./workload-security.mdx#restricting-outbound-http-with-allowedhosts) for details and usage guidance.
+- **`allowedHosts`**: A list of hostnames this component is permitted to make outbound HTTP calls to (e.g., `api.example.com`, `*.s3.amazonaws.com`). Entries are matched case-insensitively against the request's host — no scheme, no path. When the list is non-empty, calls to hosts not on the list are blocked, enforcing a least-privilege network policy for the component. An empty list (or omitted field) allows all outbound HTTP. See [Workload Security](./workload-security.mdx#restricting-outbound-http-with-allowedhosts) for details and usage guidance.
 
 ## WorkloadReplicaSet
 

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -87,6 +87,37 @@ operator:
 
 When `watchNamespaces` is populated, the chart generates namespace-scoped `Role` and `RoleBinding` resources for each listed namespace (instead of a single `ClusterRole`).
 
+### `operator.hostNamespaces`
+
+Introduced in 2.1. List of namespaces where host pods run. The operator's pod informer cache and per-namespace pod RBAC cover this set so the host-pod controller can manage finalizers on host pods. Leave empty when host pods only run in the operator's own namespace (the chart's default).
+
+```yaml
+operator:
+  hostNamespaces:
+    - team-a
+    - team-b
+```
+
+When you set `runtime.hostGroups[].namespace` to deploy host pods outside the operator's namespace, also include those namespaces here — otherwise the operator can't observe or finalize the host pods running there.
+
+### `operator.allowSharedHosts`
+
+Introduced in 2.1. Default: `true`. Controls whether `WorkloadDeployment`s can schedule onto hosts whose `Host.environment` differs from the workload's own namespace, via `spec.template.spec.environment`.
+
+```yaml
+operator:
+  allowSharedHosts: false
+```
+
+The default (`true`) preserves the existing behavior where workloads with no `environment` set may schedule onto any matching host regardless of which tenant namespace the host runs in. This is permissive: in a multi-tenant cluster where each tenant has its own namespace and host pods, a workload in `team-a` can target hosts in `team-b` simply by setting `spec.template.spec.environment: team-b`.
+
+Set to `false` when namespace boundaries are part of your tenant isolation model. With `allowSharedHosts: false`:
+
+- Scheduling is locked to the workload's own namespace.
+- Any cross-namespace `environment` value is rejected with a `CrossEnvironmentSchedulingDenied` Warning Event and a `HostSelection=False` condition on the Workload.
+
+See [Troubleshooting: Workload stays unscheduled with `allowSharedHosts: false`](../../troubleshooting.mdx#workload-stays-unscheduled-with-allowsharedhosts-false) for the symptom and resolution patterns.
+
 ### `operator.image.tag`
 
 Defaults to the chart's `appVersion`. Override only when you need to pin to a specific operator build that differs from the chart release:
@@ -140,6 +171,20 @@ runtime:
 ```
 
 `WorkloadDeployment` manifests target a group via `spec.template.spec.hostSelector.hostgroup`.
+
+### `runtime.hostGroups[].namespace`
+
+Introduced in 2.1. Namespace to deploy this host group's `Deployment`, `Service`, generated TLS Secret, and `ServiceAccount` into. Empty (default) deploys to the chart release's namespace.
+
+```yaml
+runtime:
+  hostGroups:
+    - name: team-a
+      namespace: team-a
+      replicas: 2
+```
+
+When you override this, ensure the namespace exists and is included in [`operator.hostNamespaces`](#operatorhostnamespaces) so the operator has the pod RBAC and informer cache access it needs to manage host pod lifecycle there. Each host's `Host.environment` will reflect the namespace where its pod runs, which is what `allowSharedHosts: false` matches against for namespace-scoped scheduling.
 
 ### `runtime.hostGroups[].http.port`
 

--- a/docs/kubernetes-operator/workload-security.mdx
+++ b/docs/kubernetes-operator/workload-security.mdx
@@ -26,7 +26,7 @@ Use `wash inspect <component.wasm>` to see exactly which interfaces a component 
 
 ## Restricting outbound HTTP with `allowedHosts`
 
-When a component has the `wasi:http/outgoing-handler` interface bound, it can make outbound HTTP requests. Use `allowedHosts` to restrict which URLs it may call:
+When a component has the `wasi:http/outgoing-handler` interface bound, it can make outbound HTTP requests. Use `allowedHosts` to restrict which hosts it may call:
 
 ```yaml
 components:
@@ -34,11 +34,14 @@ components:
     image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
     localResources:
       allowedHosts:
-        - https://api.example.com
-        - https://storage.googleapis.com
+        - api.example.com
+        - storage.googleapis.com
+        - "*.s3.amazonaws.com"
 ```
 
-Any request to a URL not on the list is blocked by the host before it leaves the process. This is enforced at the wasmCloud level, independently of any Kubernetes NetworkPolicy.
+Entries are matched case-insensitively against the request's host (no scheme, no path). A leading wildcard like `*.example.com` matches any subdomain but not the bare `example.com` — list both if you need both. When `allowedHosts` is non-empty, any outbound HTTP request whose host doesn't match an entry is blocked by the host before it leaves the process. This is enforced at the wasmCloud level, independently of any Kubernetes NetworkPolicy.
+
+If `allowedHosts` is empty or the field is omitted, all outbound HTTP requests are allowed — the allowlist only takes effect when at least one entry is present.
 
 :::note
 `allowedHosts` controls outbound HTTP calls made via `wasi:http/outgoing-handler`. It does not restrict network access that may be available through other host interfaces that are explicitly bound to the component.

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -42,6 +42,10 @@ The runtime provides WASI interface support through three distinct mechanisms:
 
 Hosts can be extended with additional custom plugins at build-time.
 
+:::info[Declaring plugins in Kubernetes]
+On Kubernetes, host plugins are *available* on the host but must be *declared per workload* under `spec.hostInterfaces` (in a `Workload`) or `spec.template.spec.hostInterfaces` (in a `WorkloadDeployment`). The runtime links interfaces declaratively from the workload spec; an undeclared import surfaces as a linker error at startup. See [Host Interfaces](../kubernetes-operator/crds.mdx#host-interfaces) for the field reference and [Troubleshooting](../troubleshooting.mdx#missing-host-interface-implementation-in-the-linker) for the specific error.
+:::
+
 ## Usage
 
 ```rust

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,0 +1,236 @@
+---
+title: "Troubleshooting"
+sidebar_position: 12
+description: "Common errors and their fixes when running wasmCloud workloads on Kubernetes."
+---
+
+This page collects common errors you may encounter when running wasmCloud workloads and the resolutions for each. Entries include the literal error message, the underlying cause, and the fix.
+
+If you hit an error that isn't listed here, please open an issue on [github.com/wasmCloud/wasmCloud](https://github.com/wasmCloud/wasmCloud/issues) or ask in the [wasmCloud Slack](https://slack.wasmcloud.com/) so we can document it.
+
+## Workload deployment
+
+### Missing host interface implementation in the linker
+
+You see an error similar to the following when a `WorkloadDeployment` fails to start:
+
+```
+component imports instance `wasi:config/store@0.2.0-rc.1`, but a matching implementation was not found in the linker
+```
+
+**Cause:** A wasmCloud host advertises the set of [host plugins](./overview/hosts/plugins.mdx) it provides (for example, `wasi:keyvalue`, `wasi:blobstore`, `wasi:config`, `wasi:logging`, `wasmcloud:messaging`), but a workload must declare *which* of those interfaces its components import. The runtime resolves and links interfaces declaratively from the workload spec; if the import isn't declared, the linker has no matching implementation to wire in and the component fails to instantiate.
+
+**Fix:** Add the missing interface under `spec.hostInterfaces` (in a `Workload`) or `spec.template.spec.hostInterfaces` (in a `WorkloadDeployment`). For the error above, the relevant entry is:
+
+```yaml
+hostInterfaces:
+  - namespace: wasi
+    package: config
+    version: "0.2.0-rc.1"
+    interfaces:
+      - store
+    config:
+      example.greeting: "hello from wasi:config"
+      example.environment: "dev"
+```
+
+Each entry requires `namespace`, `package`, and `interfaces`; `version` and `config` are optional. The same pattern applies to other host plugins:
+
+```yaml
+hostInterfaces:
+  - namespace: wasi
+    package: keyvalue
+    interfaces: [store, atomics, batch]
+    config:
+      backend: nats
+      bucket: my-bucket
+  - namespace: wasi
+    package: blobstore
+    interfaces: [blobstore]
+  - namespace: wasmcloud
+    package: messaging
+    interfaces: [consumer, producer]
+```
+
+**See also:** [Host Interfaces](./kubernetes-operator/crds.mdx#host-interfaces) for the full field reference (including the `name` field for multi-backend binding) and the [`HostInterface` API reference](./kubernetes-operator/api-reference.md#hostinterface). If you're hitting this error in `wash dev` rather than on Kubernetes, see [Debugging Components: Unknown import errors](./wash/developer-guide/debugging-components.mdx#unknown-import-errors).
+
+### Outbound HTTP call from a component is blocked
+
+A component that imports `wasi:http/outgoing-handler` and is bound to the corresponding host interface still cannot reach an external URL — the call fails or returns an error to the component, even though the network path appears clear.
+
+**Cause:** The host enforces a per-component allowlist of outbound destinations via `localResources.allowedHosts`. When the list is non-empty, any outbound HTTP request whose host doesn't match an entry is blocked at the wasmCloud layer before the request leaves the process — independently of any Kubernetes `NetworkPolicy`. If `allowedHosts` is set but does not include the host the component is trying to reach, the call is rejected.
+
+**Fix:** Add the host to `allowedHosts` for the component:
+
+```yaml
+components:
+  - name: http-component
+    image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+    localResources:
+      allowedHosts:
+        - api.example.com
+        - storage.googleapis.com
+        - "*.s3.amazonaws.com"
+```
+
+Entries are matched against the request's host (no scheme, no path) using case-insensitive comparison. A leading wildcard like `*.example.com` matches any subdomain but **not** the bare `example.com` — list both if you need both.
+
+If `allowedHosts` is empty (or the field is omitted), **all outbound HTTP requests are allowed** — the allowlist only takes effect when at least one entry is present.
+
+**See also:** [Workload Security — Restricting outbound HTTP with `allowedHosts`](./kubernetes-operator/workload-security.mdx#restricting-outbound-http-with-allowedhosts). If outbound HTTP is blocked at the cluster level rather than the wasmCloud level, see the same page for [NetworkPolicy](./kubernetes-operator/workload-security.mdx#kubernetes-networkpolicy-for-host-pods) guidance.
+
+### Workload image fails to pull from a private registry
+
+A `WorkloadDeployment` never reaches its desired replica count, and either the underlying `Artifact` fails to resolve or the host records a registry authentication error when fetching the component image. The pull URL points to a private registry (private GHCR, ECR, ACR, a self-hosted registry, etc.).
+
+**Cause:** wasmCloud references component images by registry URL. When the image is private, the resource that references it needs registry credentials in the form of a Kubernetes [`docker-registry` Secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-from-private-registry/), pointed to via the `imagePullSecret` field. If the field is omitted, or the Secret doesn't grant pull access to the image, the pull fails.
+
+**Fix:**
+
+1. Create a `docker-registry` Secret in the workload's namespace:
+
+   ```shell
+   kubectl create secret docker-registry ghcr-secret \
+     --namespace default \
+     --docker-server=ghcr.io \
+     --docker-username=<github-username> \
+     --docker-password=<github-pat-with-read-packages>
+   ```
+
+2. Reference the Secret from the resource that fetches the image. On an `Artifact` (recommended for automatic rollout on new image versions):
+
+   ```yaml
+   apiVersion: runtime.wasmcloud.dev/v1alpha1
+   kind: Artifact
+   metadata:
+     name: my-component
+     namespace: default
+   spec:
+     image: ghcr.io/my-org/my-component:0.1.0
+     imagePullSecret:
+       name: ghcr-secret
+   ```
+
+   Or directly on a `WorkloadComponent` (or `WorkloadService`) when not using an Artifact:
+
+   ```yaml
+   components:
+     - name: my-component
+       image: ghcr.io/my-org/my-component:0.1.0
+       imagePullSecret:
+         name: ghcr-secret
+   ```
+
+3. The Secret must live in the **same namespace** as the resource that references it.
+
+**See also:** [`ArtifactSpec`](./kubernetes-operator/api-reference.md#artifactspec) and the [CRDs guide](./kubernetes-operator/crds.mdx#artifact). For mirroring the wasmCloud chart's own images to a private registry (air-gapped installs), see [Private Registries and Air-Gapped Deployments](./kubernetes-operator/operator-manual/private-registries.mdx).
+
+## Scheduling
+
+### Workload stays unscheduled — no host matches `hostSelector`
+
+A `WorkloadDeployment` reports zero ready replicas indefinitely. The image pulls cleanly, there are no runtime errors, and `kubectl describe workloaddeployment` shows the workload as pending without recent placement events — the operator has simply found no host to put it on.
+
+**Cause:** `hostSelector` is a label selector matched against `Host` metadata labels. If no `Host` object carries labels matching the selector, the workload has nowhere to land. The most common cause is a typo or mismatch between the workload's selector (commonly `hostgroup: default`) and the labels on the host pool defined in Helm values (`runtime.hostGroups[]`).
+
+**Fix:** Compare the selector to your host labels.
+
+```shell
+# List host labels across namespaces
+kubectl get hosts -A --show-labels
+
+# Inspect the selector on the workload
+kubectl get workloaddeployment <name> -n <namespace> \
+  -o jsonpath='{.spec.template.spec.hostSelector}'
+```
+
+Either update the workload's selector to match an existing host group:
+
+```yaml
+spec:
+  template:
+    spec:
+      hostSelector:
+        hostgroup: my-team
+```
+
+…or add a matching host group in Helm values. The host group's `name` becomes the value of the `hostgroup` label on `Host` resources it produces:
+
+```yaml
+runtime:
+  hostGroups:
+    - name: my-team
+      replicas: 3
+```
+
+If a host group exists but the workload still doesn't schedule, also check `allowSharedHosts` — see the next entry.
+
+**See also:** [`runtime.hostGroups`](./kubernetes-operator/operator-manual/helm-values.mdx#runtimehostgroups) for host group configuration, [`WorkloadSpec`](./kubernetes-operator/api-reference.md#workloadspec) for the selector field.
+
+### Workload stays unscheduled with `allowSharedHosts: false`
+
+After enabling `operator.allowSharedHosts: false`, workloads that previously scheduled successfully now stay unscheduled, even though `hostSelector` still matches host labels in another namespace.
+
+**Cause:** As of [wasmCloud 2.1](/blog/wasmcloud-2-1-0-release/), `allowSharedHosts: false` enforces namespace-level scheduling isolation. A workload is only placed onto hosts whose `Host.environment` matches the workload's own namespace (or a value explicitly set via `WorkloadDeployment.spec.template.spec.environment`). Hosts in other namespaces are skipped regardless of label matches. This is the intended security boundary, but it can surprise teams who relied on cross-namespace host sharing before the upgrade.
+
+**Fix:** Choose the model that matches your isolation requirements.
+
+- **Run a host pool in the workload's namespace.** Add a host group to Helm values that the operator creates in the workload's namespace:
+
+  ```yaml
+  runtime:
+    hostGroups:
+      - name: team-a
+        namespace: team-a
+        replicas: 2
+  ```
+
+- **Opt in to a specific shared namespace** by setting `environment` on the WorkloadDeployment, pointing to a namespace where a host pool is intentionally shared:
+
+  ```yaml
+  spec:
+    template:
+      spec:
+        environment: shared-infra
+        hostSelector:
+          hostgroup: shared
+  ```
+
+  Cross-namespace placement requires that sharing is allowed for the target — if `allowSharedHosts: false` is set globally, the workload's namespace must match the host's `environment` for placement to succeed.
+
+- **Re-enable host sharing** if your isolation requirements allow it, returning to a cluster-wide host pool model:
+
+  ```yaml
+  operator:
+    allowSharedHosts: true
+  ```
+
+**See also:** [wasmCloud 2.1.0 release notes](/blog/wasmcloud-2-1-0-release/) for the full namespace-scoped scheduling model.
+
+## Hosts and namespaces
+
+### `Host` objects don't appear in the expected namespace
+
+After upgrading to wasmCloud 2.1, `kubectl get hosts` in your workload's namespace returns no results, or `Host` objects you expected to find are missing.
+
+**Cause:** As of [wasmCloud 2.1](/blog/wasmcloud-2-1-0-release/), the `Host` CRD is **namespace-scoped** rather than cluster-scoped. The runtime-operator creates every `Host` object in its own namespace — not in the namespace where the underlying host pod actually runs. Each `Host` records the pod's location in the new `Host.environment` field (a top-level field on the `Host` resource, not nested under `spec`), populated automatically from the downward API for in-cluster hosts (or supplied via `--environment` for external ones).
+
+**Fix:** Look in the operator's namespace, or list across all namespaces:
+
+```shell
+# List every host you have permission to see
+kubectl get hosts -A
+
+# List hosts in the operator's namespace
+kubectl get hosts -n <operator-namespace>
+```
+
+The `ENVIRONMENT` column in the default `kubectl get hosts` output shows each host's environment. To filter by environment, use a jsonpath query against the top-level `environment` field:
+
+```shell
+kubectl get hosts -A -o jsonpath='{range .items[?(@.environment=="team-a")]}{.metadata.name}{"\n"}{end}'
+```
+
+If you were relying on `ClusterRole` bindings to grant host visibility, note that user-facing host roles in 2.1 are generated as namespaced `Role`s. A namespace admin can now grant host visibility within their own namespace without cluster-admin involvement.
+
+**See also:** [Migration to v2](./migration.mdx) for upgrade notes, and the [Host API reference](./kubernetes-operator/api-reference.md#host).

--- a/docs/wash/developer-guide/debugging-components.mdx
+++ b/docs/wash/developer-guide/debugging-components.mdx
@@ -168,6 +168,8 @@ component imports instance `wasi:http/types@0.2.0`, but a matching implementatio
 - If you're using a draft or experimental interface (like `wasi:keyvalue` or `wasi:config`), ensure your runtime is configured to provide it.
 - Use `wash inspect` to verify which interfaces your component imports, then check your runtime's documentation for supported interfaces.
 
+If you're seeing this error when deploying a workload to Kubernetes rather than in `wash dev`, the fix is different — see [Troubleshooting: Missing host interface implementation in the linker](../../troubleshooting.mdx#missing-host-interface-implementation-in-the-linker).
+
 ### Threading errors
 
 **Symptom:**

--- a/sidebars.js
+++ b/sidebars.js
@@ -173,6 +173,7 @@ const sidebars = {
     },
     'glossary',
     'faq',
+    'troubleshooting',
     'migration',
 
     {


### PR DESCRIPTION
- Adds a new top-level Troubleshooting page covering common Kubernetes deployment errors (linker misses, blocked outbound HTTP, image pulls, scheduling stalls, host visibility) and cross-links it with the existing Debugging Components guide. 

- Fills gaps for 2.1's namespace-scoping fields (`Host.environment`, `WorkloadSpec.environment`, `operator.allowSharedHosts`, `operator.hostNamespaces`, `runtime.hostGroups[].namespace`) in the API reference and Helm values pages. 

- Corrects a few inaccuracies: the Host CRD has no `spec` wrapper, and `allowedHosts` is matched against bare hostnames with wildcard support (an empty list allows all).