### PR TITLE
docs(recipes): add Plugin or Service? decision guide

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -26,7 +26,7 @@ For a comprehensive migration guide with architecture comparisons, diagrams, and
 
 In v1, capability providers were external processes that communicated over NATS. In v2, capabilities are provided through [host plugins](./overview/hosts/plugins.mdx) (recommended for shared, performance-critical capabilities), [service components](./overview/workloads/services.mdx) (for workload-specific long-running functionality), or containerized providers (for minimal-change migration of existing providers).
 
-For details and examples, see [Migrating capability providers](./migration.mdx#migrating-capability-providers).
+For details and examples, see [Migrating capability providers](./migration.mdx#migrating-capability-providers). For guidance on choosing between a plugin and a service, see [Plugin or Service?](./recipes/plugin-or-service.mdx).
 
 ### Is `wadm` still a part of wasmCloud v2?
 

--- a/docs/overview/hosts/plugins.mdx
+++ b/docs/overview/hosts/plugins.mdx
@@ -103,5 +103,6 @@ Custom plugins are useful when you need to:
 ## Keep reading
 
 - Learn more about the [wasmCloud runtime](../../runtime/index.mdx).
+- Choosing between a plugin and a service? See [Plugin or Service?](../../recipes/plugin-or-service.mdx).
 - See the [wash-runtime source code](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-runtime) for implementation details.
 - Watch a [discussion of host plugin implementation](https://www.youtube.com/live/3DlUjl8gQVs?si=MbTz4MohjYDmE8fI&t=731) from a wasmCloud community call.

--- a/docs/overview/workloads/services.mdx
+++ b/docs/overview/workloads/services.mdx
@@ -145,6 +145,7 @@ As wasmCloud v2 moves from WASI P2 to P3 and beyond, services make it possible t
 
 - [Continue to learn more about interfaces](../interfaces.mdx).
 - Learn more about services' role within a component&mdash;and how to decide when you should use components or services&mdash;in [Workloads](./index.mdx).
+- Choosing between a plugin and a service? See [Plugin or Service?](../../recipes/plugin-or-service.mdx).
 - Learn how to develop services in the [Wasm Shell Developer Guide](../../wash/developer-guide/create-services.mdx).
 
 

--- a/docs/recipes/images/plugin-or-service.svg
+++ b/docs/recipes/images/plugin-or-service.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 380" fill="none">
+  <style>
+    text { font-family: system-ui, -apple-system, sans-serif; }
+    .box { rx: 8; ry: 8; }
+    .label { font-size: 14px; fill: #1a1a2e; font-weight: 600; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .arrow { stroke: #9ca3af; stroke-width: 2; marker-end: url(#arrowhead); }
+    .branch { font-size: 11px; fill: #6b7280; font-style: italic; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#9ca3af"/>
+    </marker>
+  </defs>
+
+  <!-- Q1 -->
+  <rect class="box" x="180" y="20" width="300" height="60" fill="#f9fafb" stroke="#9ca3af" stroke-width="1.5"/>
+  <text class="label" x="330" y="44" text-anchor="middle">Does it need to listen on a TCP port</text>
+  <text class="label" x="330" y="62" text-anchor="middle">inside the workload?</text>
+
+  <!-- Q1 → Service (Yes, right) -->
+  <line class="arrow" x1="480" y1="50" x2="538" y2="50"/>
+  <text class="branch" x="488" y="44">Yes</text>
+  <rect class="box" x="540" y="20" width="120" height="60" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text class="label" x="600" y="56" text-anchor="middle">Service</text>
+
+  <!-- Q1 → Q2 (No, down) -->
+  <line class="arrow" x1="330" y1="80" x2="330" y2="108"/>
+  <text class="branch" x="338" y="98">No</text>
+
+  <!-- Q2 -->
+  <rect class="box" x="180" y="110" width="300" height="60" fill="#f9fafb" stroke="#9ca3af" stroke-width="1.5"/>
+  <text class="label" x="330" y="134" text-anchor="middle">Should many workloads on the host</text>
+  <text class="label" x="330" y="152" text-anchor="middle">share this capability in-process?</text>
+
+  <!-- Q2 → Plugin (Yes, right) -->
+  <line class="arrow" x1="480" y1="140" x2="538" y2="140"/>
+  <text class="branch" x="488" y="134">Yes</text>
+  <rect class="box" x="540" y="110" width="120" height="60" fill="#fff7ed" stroke="#f97316" stroke-width="1.5"/>
+  <text class="label" x="600" y="146" text-anchor="middle">Plugin</text>
+
+  <!-- Q2 → Q3 (No, down) -->
+  <line class="arrow" x1="330" y1="170" x2="330" y2="198"/>
+  <text class="branch" x="338" y="188">No</text>
+
+  <!-- Q3 -->
+  <rect class="box" x="180" y="200" width="300" height="60" fill="#f9fafb" stroke="#9ca3af" stroke-width="1.5"/>
+  <text class="label" x="330" y="224" text-anchor="middle">Is it part of the application,</text>
+  <text class="label" x="330" y="242" text-anchor="middle">or part of the platform?</text>
+
+  <!-- Q3 → Service (Application, down-left) -->
+  <line class="arrow" x1="250" y1="260" x2="250" y2="298"/>
+  <text class="branch" x="258" y="282">Application</text>
+
+  <!-- Q3 → Plugin (Platform, down-right) -->
+  <line class="arrow" x1="410" y1="260" x2="410" y2="298"/>
+  <text class="branch" x="418" y="282">Platform</text>
+
+  <rect class="box" x="190" y="300" width="120" height="60" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text class="label" x="250" y="336" text-anchor="middle">Service</text>
+
+  <rect class="box" x="350" y="300" width="120" height="60" fill="#fff7ed" stroke="#f97316" stroke-width="1.5"/>
+  <text class="label" x="410" y="336" text-anchor="middle">Plugin</text>
+</svg>

--- a/docs/recipes/index.mdx
+++ b/docs/recipes/index.mdx
@@ -12,6 +12,7 @@ Recipes assume familiarity with the [Quickstart](../quickstart/index.mdx), the [
 
 | Recipe | Description |
 |---|---|
+| [Plugin or Service?](./plugin-or-service.mdx) | Decide whether to extend a wasmCloud host with a plugin or ship a service inside the workload |
 | [TLS with Bring-Your-Own Certificates](./tls-bring-your-own-certificates.mdx) | Serve HTTPS from a wasmCloud host group using your own TLS certificates |
 | [Expose a Workload via Kubernetes Service](./expose-workload-via-kubernetes-service.mdx) | Route cluster traffic to a workload through a Kubernetes Service and EndpointSlice |
 | [Inject Configuration from ConfigMaps and Secrets](./inject-configuration-from-configmaps-and-secrets.mdx) | Provide runtime configuration to a component from inline values, ConfigMaps, and Secrets |

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -1,0 +1,72 @@
+---
+title: 'Plugin or Service?'
+description: 'Decide whether to extend a wasmCloud host with a plugin or ship a wasmCloud service alongside your workload'
+---
+
+This recipe gives you a framework for choosing between two ways of providing capabilities to a wasmCloud application: extending the host with a [plugin](../overview/hosts/plugins.mdx), or shipping a [service](../overview/workloads/services.mdx) inside the workload. The two are not interchangeable&mdash;each has hard constraints that rule it out in some situations, and softer trade-offs in the rest.
+
+## What each one is
+
+A **host plugin** is a Rust implementation of the `HostPlugin` trait, compiled into the host binary. At workload bind time, the runtime adds the plugin's WIT imports directly to the wasmtime linker for each component or service in the workload, so calls from guest code dispatch in-process. `wash-runtime` ships built-in plugins for `wasi:keyvalue`, `wasi:blobstore`, `wasi:config`, `wasi:logging`, `wasi:otel`, `wasmcloud:messaging`, and more. See the [Plugins overview](../overview/hosts/plugins.mdx).
+
+A **wasmCloud service** is a Wasm component that runs for the lifetime of a workload, deployed as part of a [`WorkloadDeployment`](../kubernetes-operator/crds.mdx#workloaddeployment). Unlike regular components, services receive the `wasi:sockets` TCP bind permission, can listen on loopback and unspecified addresses, and are automatically restarted if they crash. A service exports either `wasi:cli/run` or exactly one WIT interface so the runtime has an unambiguous entry point. See the [Services overview](../overview/workloads/services.mdx).
+
+## Plugin and service comparison
+
+| | Plugin | Service |
+|---|---|---|
+| **Form** | Rust trait impl linked into the host binary | Wasm component shipped with the workload |
+| **Author language** | Rust | Any language that targets `wasm32-wasip2` |
+| **Decision point** | Host build time | Workload deploy time |
+| **Scope** | All workloads on the host | One workload |
+| **Execution** | In-process (added to the Wasmtime linker) | Separate Wasm instance |
+| **Shared state across workloads** | Yes&mdash;e.g. one connection pool or cache | No&mdash;sandboxed per workload |
+| **TCP listen()** | No | Yes, on loopback and unspecified addresses |
+| **Auto-restart on crash** | N/A | Yes |
+| **Declared by workload as** | `host_interfaces: [...]` | `service: { ... }` |
+| **Operator-facing toggle** | Cargo features on the host crate | Manifest field on the workload |
+
+## Decision tree
+
+![Decision tree for choosing a plugin or a service](./images/plugin-or-service.svg)
+
+The first two questions are hard filters: needing to listen on a TCP port rules plugins out, and needing in-process sharing across workloads rules services out. The third question is a tiebreaker that maps the choice to where the code should live in your deploy: with the platform (plugin) or with the application (service).
+
+## When to choose a plugin
+
+Pick a plugin when:
+
+- The capability is **infrastructure**&mdash;storage, telemetry, secrets, messaging, a custom database driver&mdash;and should behave the same across every workload running on the host.
+- You want **one resource** (a connection pool, a shared cache, a hardware handle) serving many workloads at once. Built-in plugins like `InMemoryKeyValue` do exactly this, keyed by workload ID for isolation.
+- The capability needs to be **available to components in any language**, not just Rust. Plugins expose a WIT interface, so guests written in Rust, TypeScript, Go, or any other Wasm-targeting language consume them identically.
+- You **control the host build** and can roll a new host image to ship the change.
+
+## When to choose a service
+
+Pick a service when:
+
+- The work is **specific to one application** and shouldn't bleed across deployments&mdash;a per-tenant connection, a request batcher, an in-memory cache that only one workload uses.
+- You need to **listen on a TCP port** inside the workload, whether as a real protocol server or as a way to bridge component invocations into a streaming connection.
+- The behavior ships **with the application artifact**, not with the platform. Updating it means redeploying the workload, not rebuilding the host.
+- The implementation **isn't Rust**, or the team writing it doesn't own the host binary.
+
+## Best-practice examples
+
+**Per-app configuration from Kubernetes ConfigMaps and Secrets** → **Plugin.**
+The built-in `wasi:config` plugin reads runtime configuration uniformly for every workload on the host. This is platform-level concern, language-agnostic, and benefits from a single code path. See the [config-injection recipe](./inject-configuration-from-configmaps-and-secrets.mdx).
+
+**Cron-driven invocation of components in the same workload** → **Service.**
+A long-running loop that periodically calls a component interface is application logic, lives with the workload, and benefits from automatic restart. See the canonical [`cron-service` example](https://github.com/wasmCloud/wasmCloud/tree/main/examples/cron-service).
+
+**Connecting to a proprietary database with no WASI binding** → **Plugin.**
+If multiple workloads should share one driver and one connection pool, build a custom plugin against the `HostPlugin` trait. Components stay portable&mdash;they import a WIT interface, not a Rust SDK. See [Creating Host Plugins](../runtime/creating-host-plugins.mdx).
+
+**A TCP protocol adapter that translates between an external system and your components** → **Service.**
+Listening on a TCP port inside the workload is a hard requirement here. A service can bind to `127.0.0.1`, accept incoming connections, and call into companion components over WIT. Plugins cannot listen on ports.
+
+## Keep reading
+
+- [Plugins overview](../overview/hosts/plugins.mdx)&mdash;built-in plugins and the registration API.
+- [Services overview](../overview/workloads/services.mdx)&mdash;the service model, TCP isolation, and export requirements.
+- [Creating Host Plugins](../runtime/creating-host-plugins.mdx)&mdash;the `HostPlugin` trait reference for plugin authors.
+- [Creating Services](../wash/developer-guide/create-services.mdx)&mdash;the developer-guide walkthrough for service authors.

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -49,7 +49,7 @@ Pick a plugin when:
 - The capability is **infrastructure**&mdash;storage, telemetry, secrets, messaging, a custom database driver&mdash;and should behave the same across every workload running on the host.
 - You want **one resource** (a connection pool, a shared cache, a hardware handle) serving many workloads at once. Built-in plugins like `InMemoryKeyValue` do exactly this, keyed by workload ID for isolation.
 - The capability needs to be **available to components in any language**, not just Rust. Plugins expose a WIT interface, so guests written in Rust, TypeScript, Go, or any other Wasm-targeting language consume them identically.
-- You **control the host build** and can roll a new host image to ship the change.
+- You **control the host build** and can roll a new host image to ship any required changes.
 
 ## When to choose a service
 

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -13,7 +13,11 @@ More concretely, when workloads are bound, the runtime adds the plugin's WIT imp
 
 For example, `wash-runtime` ships with built-in host plugins for interfaces like `wasi:keyvalue`, `wasi:blobstore`, `wasi:config`, `wasi:logging`, `wasi:otel`, `wasmcloud:messaging`, and more. See the [Plugins overview](../overview/hosts/plugins.mdx).
 
-A **wasmCloud service** is a Wasm component that runs for the lifetime of a workload, deployed as part of a [`WorkloadDeployment`](../kubernetes-operator/crds.mdx#workloaddeployment). Unlike regular components, services receive the `wasi:sockets` TCP bind permission, can listen on loopback and unspecified addresses, and are automatically restarted if they crash. A service exports either `wasi:cli/run` or exactly one WIT interface so the runtime has an unambiguous entry point. See the [Services overview](../overview/workloads/services.mdx).
+A **wasmCloud service** is a Wasm component that runs for the lifetime of a workload, deployed as part of a [`WorkloadDeployment`](../kubernetes-operator/crds.mdx#workloaddeployment). 
+
+Unlike other components in a `WorkloadDeployment`, services receive the `wasi:sockets` TCP bind permission, can listen on loopback and unspecified addresses to interact with other components in the workload, and are automatically restarted if they crash. 
+
+A service exports either `wasi:cli/run` or exactly one WIT interface so the runtime has an unambiguous entry point. See the [Services overview](../overview/workloads/services.mdx).
 
 ## Plugin and service comparison
 

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -5,7 +5,7 @@ description: 'Decide whether to extend a wasmCloud host with a plugin or ship a 
 
 This recipe gives you a framework for choosing between two ways of providing capabilities to a wasmCloud application: extending the host with a [plugin](../overview/hosts/plugins.mdx), or shipping a [service](../overview/workloads/services.mdx) inside the workload. The two are not interchangeable&mdash;each has hard constraints that rule it out in some situations, and softer trade-offs in the rest.
 
-## What each one is
+## A quick introduction to plugins and services
 
 A **host plugin** is a Rust implementation of the `HostPlugin` trait, compiled into the host binary. A host plugin is native Rust code that is available to and executed by components via calling into the host.
 

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -7,7 +7,11 @@ This recipe gives you a framework for choosing between two ways of providing cap
 
 ## What each one is
 
-A **host plugin** is a Rust implementation of the `HostPlugin` trait, compiled into the host binary. At workload bind time, the runtime adds the plugin's WIT imports directly to the wasmtime linker for each component or service in the workload, so calls from guest code dispatch in-process. `wash-runtime` ships built-in plugins for `wasi:keyvalue`, `wasi:blobstore`, `wasi:config`, `wasi:logging`, `wasi:otel`, `wasmcloud:messaging`, and more. See the [Plugins overview](../overview/hosts/plugins.mdx).
+A **host plugin** is a Rust implementation of the `HostPlugin` trait, compiled into the host binary. A host plugin is native Rust code that is available to and executed by components via calling into the host.
+
+More concretely, when workloads are bound, the runtime adds the plugin's WIT imports directly to the wasmtime linker for each component or service in the workload, so calls from guest code dispatch in-process. 
+
+For example, `wash-runtime` ships with built-in host plugins for interfaces like `wasi:keyvalue`, `wasi:blobstore`, `wasi:config`, `wasi:logging`, `wasi:otel`, `wasmcloud:messaging`, and more. See the [Plugins overview](../overview/hosts/plugins.mdx).
 
 A **wasmCloud service** is a Wasm component that runs for the lifetime of a workload, deployed as part of a [`WorkloadDeployment`](../kubernetes-operator/crds.mdx#workloaddeployment). Unlike regular components, services receive the `wasi:sockets` TCP bind permission, can listen on loopback and unspecified addresses, and are automatically restarted if they crash. A service exports either `wasi:cli/run` or exactly one WIT interface so the runtime has an unambiguous entry point. See the [Services overview](../overview/workloads/services.mdx).
 

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -38,7 +38,9 @@ A service exports either `wasi:cli/run` or exactly one WIT interface so the runt
 
 ![Decision tree for choosing a plugin or a service](./images/plugin-or-service.svg)
 
-The first two questions are hard filters: needing to listen on a TCP port rules plugins out, and needing in-process sharing across workloads rules services out. The third question is a tiebreaker that maps the choice to where the code should live in your deploy: with the platform (plugin) or with the application (service).
+The first two questions are hard filters: needing to listen on a TCP port rules plugins out, and needing in-process sharing across workloads rules services out. 
+
+The third question is a tiebreaker that maps the choice to where the code should live in your deploy: with the platform (plugin) or with the application (service).
 
 ## When to choose a plugin
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -160,6 +160,7 @@ const sidebars = {
       label: 'Recipes',
       link: { type: 'doc', id: 'recipes/index' },
       items: [
+        'recipes/plugin-or-service',
         'recipes/tls-bring-your-own-certificates',
         'recipes/expose-workload-via-kubernetes-service',
         'recipes/inject-configuration-from-configmaps-and-secrets',


### PR DESCRIPTION
Adds a new recipe at `/docs/recipes/plugin-or-service` with a capability comparison, an SVG decision tree, and worked examples, plus cross-links from the plugin and service overviews and the FAQ.

Closes wasmCloud/wasmCloud#5055