### PR TITLE
fix(seo): fix page titles, meta descriptions, OG tags, and heading st…

### DIFF
--- a/blog/2022-05-23-deploying-wasmcloud-actors-from-github-packages/index.mdx
+++ b/blog/2022-05-23-deploying-wasmcloud-actors-from-github-packages/index.mdx
@@ -3,7 +3,7 @@ title: 'Deploying wasmCloud Actors from GitHub Packages'
 image: './images/github-packages.png'
 date: "2022-05-23"
 authors: [brooksmtownsend]
-description: 'Simplifying the deployment experience for WebAssembly modules.'
+description: 'Use GitHub Packages (GHCR) as an OCI registry to host and deploy wasmCloud actors, simplifying the WebAssembly module deployment workflow.'
 categories: ['webassembly', 'wasmcloud', 'developer experience']
 slug: deploying-wasmcloud-actors-from-github-packages
 ---

--- a/blog/2022-05-25-wasmcloud-capabilities-are-managed-algebraic-effects-for-webassembly-functions/index.mdx
+++ b/blog/2022-05-25-wasmcloud-capabilities-are-managed-algebraic-effects-for-webassembly-functions/index.mdx
@@ -3,7 +3,7 @@ title: 'Capabilities as Algebraic Effects for Wasm'
 image: './images/algebra.jpg'
 date: "2022-05-25"
 authors: [autodidaddict]
-description: 'wasmCloud Capabilities are a managed, distributed implementation of algebraic effects'
+description: 'How wasmCloud capabilities provide a managed, distributed implementation of algebraic effects for WebAssembly functions in cloud-native apps.'
 categories: ['webassembly', 'wasmcloud']
 slug: wasmcloud-capabilities-are-managed-algebraic-effects-for-webassembly-functions
 ---

--- a/blog/2022-06-01-example-creating-webassembly-actor-in-go-with-tinygo/index.mdx
+++ b/blog/2022-06-01-example-creating-webassembly-actor-in-go-with-tinygo/index.mdx
@@ -3,7 +3,7 @@ title: 'Portable Components with TinyGo and wasmCloud'
 image: './images/tinygo-logo.png'
 date: "2022-06-01"
 authors: [autodidaddict]
-description: 'A walkthrough of creating a TinyGo wasmCloud actor'
+description: 'A step-by-step walkthrough of creating a portable WebAssembly actor in Go using TinyGo and the wasmCloud platform to ship Wasm components.'
 categories: ['tinygo', 'webassembly', 'wasmcloud', 'go', 'example']
 slug: example-creating-webassembly-actor-in-go-with-tinygo
 ---

--- a/blog/2022-06-16-webassembly-components-and-wasmcloud-actors-a-glimpse-of-the-future/index.mdx
+++ b/blog/2022-06-16-webassembly-components-and-wasmcloud-actors-a-glimpse-of-the-future/index.mdx
@@ -3,7 +3,7 @@ title: 'Wasm Components and wasmCloud Actors'
 image: './images/wasm.png'
 date: "2022-06-16"
 authors: [thomastaylor312]
-description: 'Using the Component Model with wasmCloud Actors'
+description: 'A glimpse of the future: pairing the Wasm component model with wasmCloud actors to build portable, language-agnostic WebAssembly applications.'
 categories: ['wasm', 'webassembly', 'components']
 slug: webassembly-components-and-wasmcloud-actors-a-glimpse-of-the-future
 ---

--- a/blog/2022-06-25-wasmcloud-third-anniversary/index.mdx
+++ b/blog/2022-06-25-wasmcloud-third-anniversary/index.mdx
@@ -3,7 +3,7 @@ title: "Reflections on Three Years of wasmCloud"
 image: "./images/waxosuit.png"
 date: "2022-06-25"
 authors: [autodidaddict]
-description: "Reflections on Three Years of wasmCloud"
+description: "Reflections on three years of wasmCloud: from a WebAssembly book and the waxosuit prototype to a CNCF project for cloud-native Wasm applications."
 categories: ["wasm", "webassembly"]
 slug: wasmcloud-third-anniversary
 ---

--- a/blog/2022-09-19-road-to-ubiquity/index.mdx
+++ b/blog/2022-09-19-road-to-ubiquity/index.mdx
@@ -3,7 +3,7 @@ title: 'WebAssembly and the Road to Ubiquity'
 image: './images/ij_map_sample.jpeg'
 date: "2022-09-19"
 authors: [autodidaddict]
-description: "A brief look down WebAssembly's road to ubiquity"
+description: "A look at WebAssembly's road to ubiquity: how Wasm tooling, components, and platforms like wasmCloud will make Wasm a 'boring' production choice."
 categories: ['webassembly', 'wasmcloud', 'ubiquity', 'wasi', 'component model']
 slug: road-to-ubiquity
 ---

--- a/blog/2022-10-04-balancing-nfr-coupling/index.mdx
+++ b/blog/2022-10-04-balancing-nfr-coupling/index.mdx
@@ -3,7 +3,7 @@ title: 'Using Capabilities to Decouple Non-Functional Requirements'
 image: './images/train_coupling.jpg'
 date: "2022-10-04"
 authors: [autodidaddict]
-description: 'A look at the motivation and design behind loosely coupling services for actors'
+description: 'The motivation and design behind decoupling non-functional requirements from business logic using wasmCloud capabilities and WebAssembly actors.'
 categories: ['webassembly', 'wasmcloud', 'nfr', 'capabilities', 'design']
 slug: balancing-nfr-coupling
 ---

--- a/blog/2022-10-18-globally-distributed-webassembly-applications-with-wasmcloud-and-nats/index.mdx
+++ b/blog/2022-10-18-globally-distributed-webassembly-applications-with-wasmcloud-and-nats/index.mdx
@@ -3,7 +3,7 @@ title: 'Globally Distributed Wasm Apps with NATS'
 image: './images/ngs-global.png'
 date: "2022-10-18"
 authors: [brooksmtownsend]
-description: 'Taking a wasmCloud lattice from local to globally distributed with NATS and NGS'
+description: 'Take a wasmCloud lattice from local to globally distributed using NATS and NGS to run WebAssembly applications across any cloud, edge, or device.'
 categories: ['webassembly', 'wasmcloud', 'nats', 'distributed', 'lattice']
 slug: globally-distributed-webassembly-applications-with-wasmcloud-and-nats
 ---

--- a/blog/2022-11-17-better-together-building-efficient-microservices-in-kubernetes-with-webassembly/index.mdx
+++ b/blog/2022-11-17-better-together-building-efficient-microservices-in-kubernetes-with-webassembly/index.mdx
@@ -3,7 +3,7 @@ title: 'Better Together: Wasm Microservices on K8s'
 image: './images/header.png'
 date: "2022-11-17"
 authors: [seanisom, colinmurphy]
-description: 'Bringing two major CNCF projects together—wasmCloud and Kubernetes—promises greater agility and major efficiencies'
+description: 'How Adobe pairs two major CNCF projects, wasmCloud and Kubernetes, to run efficient WebAssembly microservices with better agility and density.'
 categories: ['webassembly', 'wasmcloud', 'kubernetes', 'Cloud Native', 'CNCF']
 slug: better-together-building-efficient-microservices-in-kubernetes-with-webassembly
 ---

--- a/blog/2023-02-22-zero-trust-security/index.mdx
+++ b/blog/2023-02-22-zero-trust-security/index.mdx
@@ -3,7 +3,7 @@ title: 'Zero Trust Computing with Wasm and wasmCloud'
 image: './images/zero-trust-b_w.jpg'
 date: "2023-02-22"
 authors: [autodidaddict]
-description: 'A look at how WebAssembly supports zero trust computing from the bottom to the top of the stack'
+description: 'How WebAssembly and wasmCloud support zero trust computing from the module up through the runtime, capabilities, and the distributed lattice.'
 categories: ['webassembly', 'wasmcloud', 'distsys', 'zerotrust', 'security']
 slug: zero-trust-security
 ---

--- a/blog/2023-03-30-all-the-clouds-a-stage-webassembly-actor/index.mdx
+++ b/blog/2023-03-30-all-the-clouds-a-stage-webassembly-actor/index.mdx
@@ -3,7 +3,7 @@ title: "All the Cloud's a Stage for Wasm Actors"
 image: './images/child_actor.jpg'
 date: "2023-03-30"
 authors: [autodidaddict]
-description: 'An overview on the actor model with a focus on WebAssembly'
+description: 'An overview of the actor model with a focus on WebAssembly and how wasmCloud spawns and supervises Wasm actors without manual supervision trees.'
 slug: all-the-clouds-a-stage-webassembly-actor
 ---
 

--- a/blog/2023-05-20-host-there-and-back-again/index.mdx
+++ b/blog/2023-05-20-host-there-and-back-again/index.mdx
@@ -4,7 +4,7 @@ title: 'The Host; Or There and Back Again'
 image: './images/there-and-back-again.jpg'
 date: "2023-05-20"
 authors: [autodidaddict]
-description: 'Reflecting on the evolution of the wasmCloud runtime host'
+description: 'Reflecting on the evolution of the wasmCloud runtime host, from the early Rust prototype through Elixir/OTP and back to Rust with libwasmcloud.'
 ---
 
 ![map - zoom in for easter eggs](./images/there-and-back-again.jpg)

--- a/blog/2023-06-07-wasmtime-a-standardized-runtime-for-wasmcloud/index.mdx
+++ b/blog/2023-06-07-wasmtime-a-standardized-runtime-for-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ title: "Wasmtime: A Standardized Runtime for wasmCloud"
 image: "./images/header-bridge.png"
 date: "2023-06-07"
 authors: [brooksmtownsend]
-description: "An overview of our decision to transition to Wasmtime to underpin wasmCloud"
+description: "Why wasmCloud is adopting Wasmtime as its standardized WebAssembly runtime, embracing the component model and the Bytecode Alliance ecosystem."
 ---
 
 ![lego bridge](./images/header-bridge.png)

--- a/blog/2023-06-13-objects-instances-state-distributed-systems/index.mdx
+++ b/blog/2023-06-13-objects-instances-state-distributed-systems/index.mdx
@@ -4,7 +4,7 @@ title: 'Objects, Instances, and State in Distributed Systems'
 image: './images/dist-star-system.jpg'
 date: "2023-06-13"
 authors: [autodidaddict]
-description: 'Comparing Object Oriented and Functional Models in Distributed Systems'
+description: 'Comparing object-oriented and functional models in distributed systems, and what each approach means for state, scaling, and WebAssembly actors.'
 ---
 
 ![map - zoom in for easter eggs](./images/dist-star-system.jpg)

--- a/blog/2023-06-27-webassembly-patterns-command-reactor-library/index.mdx
+++ b/blog/2023-06-27-webassembly-patterns-command-reactor-library/index.mdx
@@ -3,7 +3,7 @@ title: 'Wasm Patterns: Command, Reactor, Library'
 image: './images/interaction_patterns.jpg'
 date: "2023-06-27"
 authors: [autodidaddict]
-description: Exploring WebAssembly Interaction Patterns - Command, Reactor, and Library"
+description: 'Exploring the three main WebAssembly interaction patterns — Command, Reactor, and Library — and when to choose each for your Wasm components.'
 categories: ['webassembly', 'components', 'patterns']
 slug: webassembly-patterns-command-reactor-library
 ---

--- a/blog/2023-10-05-hacktoberfest-is-here/index.mdx
+++ b/blog/2023-10-05-hacktoberfest-is-here/index.mdx
@@ -3,7 +3,7 @@ title: "Hacktoberfest is Here! \U0001F383"
 image: './images/Hacktoberfest-10.png'
 date: "2023-10-05"
 authors: [brooksmtownsend]
-description: 'Come join us for Hacktoberfest and contribute to open source this spooky season!'
+description: 'Join wasmCloud for Hacktoberfest and contribute to open source WebAssembly projects like wash, wadm, and the wasmCloud host this spooky season.'
 categories: ['webassembly', 'wasmcloud', 'Hacktoberfest', 'Cloud Native']
 slug: hacktoberfest-is-here
 ---

--- a/blog/2023-11-21-experimental-support-for-gophers-in-wasmCloud/index.mdx
+++ b/blog/2023-11-21-experimental-support-for-gophers-in-wasmCloud/index.mdx
@@ -3,7 +3,7 @@ title: "Experimental Support for Gophers in wasmCloud"
 image: "./blobby-versus-globby.jpg"
 date: "2023-11-21"
 authors: [brooksmtownsend]
-description: "wasmCloud now comes with experimental component support for Go"
+description: "wasmCloud adds experimental Go support via TinyGo, letting Gophers build standards-based WebAssembly components for cloud-native applications."
 categories: ["Golang", "wasmcloud"]
 slug: experimental-support-for-gophers-in-wasmCloud
 ---

--- a/blog/2023-12-06-wasmcloud-a-retrospective/index.mdx
+++ b/blog/2023-12-06-wasmcloud-a-retrospective/index.mdx
@@ -3,7 +3,7 @@ title: 'Road to 1.0: wasmCloud Q3/Q4 Retrospective'
 image: './images/wasmcloud-a-retro.png'
 date: "2023-12-06"
 authors: [brooksmtownsend]
-description: 'As we near the launch of wasmCloud 1.0 we take a look back at the progress wasmCloud has made in the last few months.'
+description: 'As wasmCloud nears its 1.0 launch, a retrospective on Q3/Q4 progress: WASI Preview 2, the Wasm component model, and the move back to Rust.'
 categories: ['webassembly', 'wasmcloud', 'Cloud Native', 'CNCF']
 slug: wasmcloud-a-retrospective
 ---

--- a/blog/2023-12-13-wasmcloud-a-refreshed-roadmap/index.mdx
+++ b/blog/2023-12-13-wasmcloud-a-refreshed-roadmap/index.mdx
@@ -3,7 +3,7 @@ title: 'Road to 1.0: wasmCloud, a Refreshed Roadmap'
 image: './images/2024q1roadmap.png'
 date: "2023-12-13"
 authors: [brooksmtownsend]
-description: "As we near the release of wasmCloud 1.0, we take a look at the refreshed roadmap and the steps we'll take to get to 1.0"
+description: "A refreshed Q1 2024 roadmap as wasmCloud nears 1.0: standards-led WebAssembly components, vendor-less developer experience, and cloud-native tooling."
 categories: ['webassembly', 'wasmcloud', 'Cloud Native', 'CNCF']
 slug: wasmcloud-a-refreshed-roadmap
 ---

--- a/blog/2024-01-09-bringing-wasm-to-telecoms-with-cncf-wasmcloud/index.mdx
+++ b/blog/2024-01-09-bringing-wasm-to-telecoms-with-cncf-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ title: 'Bringing WebAssembly to Telecoms with CNCF wasmCloud'
 image: './images/cncf-wasmcloud-in-telecoms.jpg'
 date: "2024-01-09"
 authors: [thomastaylor312]
-description: 'How WebAssembly helps CSPs look beyond Kubernetes for faster, greener, and more secure software deployment'
+description: 'A TM Forum Catalyst Project with Orange, Vodafone, and others shows how WebAssembly and wasmCloud help telecoms look beyond Kubernetes to the edge.'
 ---
 
 ![wasmcloud in telecoms](./images/cncf-wasmcloud-in-telecoms.jpg)

--- a/blog/2024-02-21-wasmcloud-0.82-wasi-p2-is-here/index.mdx
+++ b/blog/2024-02-21-wasmcloud-0.82-wasi-p2-is-here/index.mdx
@@ -3,7 +3,7 @@ title: "wasmCloud 0.82: WASI 0.2, OTEL logging, and more"
 date: "2024-02-21"
 authors: [ericgregory]
 image: "./082.png"
-description: "wasmCloud 0.82 brings full WASI 0.2 support, OpenTelemetry logging, and key improvements on the road to wasmCloud 1.0."
+description: "wasmCloud 0.82 brings full WASI 0.2 support, OpenTelemetry logging, and key WebAssembly component improvements on the road to wasmCloud 1.0."
 tags: ['wasmCloud', 'WASI', 'OpenTelemetry', 'WebAssembly', 'Wasm']
 slug: wasmcloud-0.82-wasi-p2-is-here
 ---

--- a/blog/2024-03-14-wasmio-kubeconeu-preview/index.mdx
+++ b/blog/2024-03-14-wasmio-kubeconeu-preview/index.mdx
@@ -3,7 +3,7 @@ title: WASM I/O and KubeCon EU 2024 Preview
 image: './images/wasmio-kubeconeu-post-header.jpg'
 date: "2024-03-14"
 authors: [liamrandall]
-description: All roads lead to Europe; find out what we have planned at WASM I/O and KubeCon EU!
+description: 'All roads lead to Europe: preview wasmCloud and Cosmonic sessions at WASM I/O Barcelona and KubeCon + CloudNativeCon EU 2024 in Paris.'
 tags: ['Cosmonic', 'wasmCloud', 'Cloud Native', 'WebAssembly', 'Wasm']
 slug: wasmio-kubeconeu-preview
 ---

--- a/blog/2024-03-19-wasmcloud-1-brings-components-to-enterprise/index.mdx
+++ b/blog/2024-03-19-wasmcloud-1-brings-components-to-enterprise/index.mdx
@@ -3,7 +3,7 @@ title: 'wasmCloud 1.0 Brings Components to Enterprise'
 image: './images/wasmcloud-1.png'
 date: "2024-03-19"
 authors: [brooksmtownsend]
-description: 'wasmCloud 1.0 brings WASI 0.2 and the Wasm Component Model to production environments'
+description: 'wasmCloud 1.0 brings WASI 0.2 and the Wasm component model to production, with wRPC for distributed components and wash build for any language.'
 categories: ['webassembly', 'wasmcloud', 'Cloud Native', 'CNCF']
 slug: wasmcloud-1-brings-components-to-enterprise
 ---

--- a/blog/2024-03-19-wasmcloud-1.0-vendor-neutral-apps/index.mdx
+++ b/blog/2024-03-19-wasmcloud-1.0-vendor-neutral-apps/index.mdx
@@ -3,7 +3,7 @@ title: "Vendor-neutral apps with wasmCloud 1.0 and WASI 0.2"
 date: "2024-03-19"
 authors: [ericgregory]
 image: "./wC-1.0-feature-vendor-neutral.png"
-description: "How wasmCloud 1.0 enables you to write apps once and run anywhere with WASI 0.2."
+description: "How wasmCloud 1.0 and WASI 0.2 let you write WebAssembly applications once and run them anywhere — across cloud, edge, and Kubernetes."
 tags: ['wasmCloud', 'WASI', 'WebAssembly', 'Wasm']
 slug: wasmcloud-1.0-vendor-neutral-apps
 ---

--- a/blog/2024-03-20-otel-observable/index.mdx
+++ b/blog/2024-03-20-otel-observable/index.mdx
@@ -3,7 +3,7 @@ title: 'Complete OpenTelemetry Observability with wasmCloud'
 date: "2024-03-20"
 authors: [ericgregory]
 image: './wC-1.0-feature-otel.png'
-description: 'wasmCloud 1.0 supports traces, logs, and metrics using the industry-standard OpenTelemetry (OTEL) specification.'
+description: 'wasmCloud 1.0 supports traces, logs, and metrics using OpenTelemetry (OTEL), giving Wasm applications full cloud-native observability out of the box.'
 tags: ['wasmCloud', 'WASI', 'WebAssembly', 'Wasm']
 slug: otel-observable
 ---

--- a/blog/2024-04-10-wasm-day-summary-blog/index.mdx
+++ b/blog/2024-04-10-wasm-day-summary-blog/index.mdx
@@ -3,7 +3,7 @@ title: "Highlights and Insights from Wasm Day EU, 2024"
 date: "2024-04-10"
 authors: [brooksmtownsend]
 image: "./wasm-day-show-blog-header.png"
-description: "A handy summary of all this year's Cloud Native Wasm Day EU sessions."
+description: "Highlights and insights from Cloud Native Wasm Day EU 2024: components as Wasm's Docker moment, wasmCloud production stories, and standards momentum."
 tags: ['wasmCloud', 'WASI', 'WebAssembly', 'Wasm', 'cloud native']
 slug: wasm-day-summary-blog
 ---

--- a/blog/2024-04-16-wasmcloud-operator-is-here/index.mdx
+++ b/blog/2024-04-16-wasmcloud-operator-is-here/index.mdx
@@ -3,7 +3,7 @@ title: 'wasmCloud Operator: Cosmonic Brings Wasm Components to K8s'
 image: './images/wasmcloud-operator-kubernetes.jpg'
 date: "2024-04-16"
 authors: [brooksmtownsend]
-description: 'OSSNA: Cosmonic releases wasmCloud-operator to Bring Community Wasm to K8s'
+description: 'Cosmonic contributes the wasmCloud Operator to CNCF, bringing WebAssembly components to Kubernetes with familiar Kubernetes deployment patterns.'
 categories: ['webassembly', 'wasmcloud', 'Cloud Native', 'CNCF', engineering, cloud native]
 slug: wasmcloud-operator-is-here
 ---

--- a/blog/2024-04-18-wasmcloud-1.0-webassembly-apps-production-any-cloud-any-edge/index.mdx
+++ b/blog/2024-04-18-wasmcloud-1.0-webassembly-apps-production-any-cloud-any-edge/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'wasmCloud 1.0: Production Wasm on Any Cloud'
-description: 'Distributed computing with WebAssembly components, ready for production workloads.'
+description: 'wasmCloud 1.0 is here: distributed computing with WebAssembly components, ready for production workloads on any cloud, any edge, any Kubernetes.'
 authors: [brooksmtownsend]
 image: './images/wasmcloud-1.0-release.jpeg'
 date: "2024-04-18"

--- a/blog/2024-05-28-community-update-wasmcloud-incubation-process/index.mdx
+++ b/blog/2024-05-28-community-update-wasmcloud-incubation-process/index.mdx
@@ -4,7 +4,7 @@ title: 'Community Update: wasmCloud Incubation Process'
 image: './images/wasmcloud_large_social.png'
 date: "2024-05-28"
 authors: [thomastaylor312]
-description: "An update on wasmCloud's Incubation Process"
+description: "An update on wasmCloud's journey through the CNCF incubation process, and how the new streamlined CNCF TOC template is shaping the project's path."
 ---
 
 ![wasmcloud incubation process](./images/wasmcloud_large_social.png)

--- a/blog/2024-06-18-taking-a-wasm-component-from-idea-to-server-to-browser-to-plugin/index.mdx
+++ b/blog/2024-06-18-taking-a-wasm-component-from-idea-to-server-to-browser-to-plugin/index.mdx
@@ -4,7 +4,7 @@ title: 'A Wasm Component: Server to Browser to Plugin'
 image: './images/wit2wadm-header.jpg'
 date: "2024-06-18"
 authors: [brooksmtownsend]
-description: 'How WebAssembly components help engineers reuse the same code in new contexts, regardless of language'
+description: 'How the wit2wadm project took a single WebAssembly component from server to browser to wash plugin, reusing the same code across every context.'
 ---
 
 ![Taking a Wasm component from idea, to server, to browser, to plugin ](./images/wit2wadm-header.jpg)

--- a/blog/2024-06-27-tm-forum-webassembly-canvas-project-in-phase-2/index.mdx
+++ b/blog/2024-06-27-tm-forum-webassembly-canvas-project-in-phase-2/index.mdx
@@ -4,7 +4,7 @@ title: 'Telecoms: TM Forum Webassembly Canvas Project in Phase 2'
 image: './images/tmforum-oda-map-header.jpg'
 date: "2024-06-27"
 authors: [liamrandall]
-description: 'WebAssembly adoption in the Telecoms sector is heating up! TM Forum WebAssembly Canvas Catalyst reaches Phase 2'
+description: 'WebAssembly adoption in telecoms heats up: the TM Forum WebAssembly Canvas Catalyst reaches Phase 2, exploring wasmCloud alongside Kubernetes for ODA.'
 ---
 
 ![tmforum-oda-map-header.jpg](./images/tmforum-oda-map-header.jpg)

--- a/blog/2024-07-02-compile-go-directly-to-webassembly-components-with-tinygo-and-wasi-p2/index.mdx
+++ b/blog/2024-07-02-compile-go-directly-to-webassembly-components-with-tinygo-and-wasi-p2/index.mdx
@@ -3,7 +3,7 @@ title: "Compile Go to Wasm Components with TinyGo and WASI P2"
 authors: [ericgregory]
 image: './images/compile-go-directly-to-webassembly-components-with-tinygo-and-wasip2.png'
 date: "2024-07-02"
-description: 'TinyGo now supports WASI P2, letting developers write idiomatic Go and compile directly to portable WebAssembly components.'
+description: 'TinyGo now supports WASI P2, letting developers write idiomatic Go and compile directly to portable WebAssembly components that run anywhere.'
 categories: ['webassembly', 'wasmcloud', 'go', 'golang', 'wasi', 'components']
 slug: compile-go-directly-to-webassembly-components-with-tinygo-and-wasi-p2
 ---

--- a/blog/2024-07-08-how-webassembly-components-extend-the-frontiers-of-kubernetes-to-multi-cloud-edge-and-beyond/index.mdx
+++ b/blog/2024-07-08-how-webassembly-components-extend-the-frontiers-of-kubernetes-to-multi-cloud-edge-and-beyond/index.mdx
@@ -4,7 +4,7 @@ title: 'Wasm Components Extend K8s to Multi-Cloud and Edge'
 image: './images/next-wave-header.jpg'
 date: "2024-07-08"
 authors: [thomastaylor312]
-description: 'How WebAssembly components are unlocking new ways to extend the value of existing Kubernetes investments'
+description: 'How WebAssembly components and wasmCloud extend the frontiers of Kubernetes into multi-cloud, multi-cluster, and edge environments without disruption.'
 ---
 
 WebAssembly (Wasm) components are here and [already unlocking new computing patterns](https://www.youtube.com/watch?v=wttN69wciSM). Meanwhile, CNCF's [**wasmCloud**](https://wasmcloud.com/) offers Wasm-native orchestration for distributed components&mdash;in essence, a Kubernetes for WebAssembly.

--- a/blog/2024-07-11-webassembly-components-the-next-wave-of-cloud-native-computing/index.mdx
+++ b/blog/2024-07-11-webassembly-components-the-next-wave-of-cloud-native-computing/index.mdx
@@ -4,7 +4,7 @@ title: 'Wasm Components: The Next Wave of Cloud Native'
 image: './images/next-wave-header.jpg'
 date: "2024-07-11"
 authors: [liamrandall, ricochet]
-description: 'How WebAssembly components represent a paradigm shift in application development and deployment'
+description: 'Why WebAssembly components represent the next paradigm shift in cloud-native application development and deployment, after containers and Kubernetes.'
 ---
 
 ![next wave of compute](./images/next-wave-header.jpg)

--- a/blog/2024-07-16-how-to-virtualize-webassembly-components-with-wasi-virt/index.mdx
+++ b/blog/2024-07-16-how-to-virtualize-webassembly-components-with-wasi-virt/index.mdx
@@ -3,7 +3,7 @@ title: "How to virtualize WebAssembly components with WASI Virt"
 image: './images/how-to-wasi-virt.png'
 date: "2024-07-16"
 authors: [ericgregory]
-description: 'How WebAssembly component virtualization works, when you might want to use WASI Virt, and how to get started'
+description: 'How WebAssembly component virtualization works with WASI Virt: when to use it, how composability enables it, and a hands-on walkthrough to get started.'
 slug: how-to-virtualize-webassembly-components-with-wasi-virt
 ---
 

--- a/blog/2024-07-30-how-to-run-webassembly-components-on-kubernetes-with-wasmcloud/index.mdx
+++ b/blog/2024-07-30-how-to-run-webassembly-components-on-kubernetes-with-wasmcloud/index.mdx
@@ -3,7 +3,7 @@ title: "Run Wasm Components on Kubernetes with wasmCloud"
 image: './images/webassembly-components-on-kubernetes.png'
 date: "2024-07-30"
 authors: [ericgregory]
-description: 'Learn how to get started running WebAssembly components on Kubernetes in about five minutes.'
+description: 'A five-minute tutorial: run WebAssembly components on Kubernetes with the wasmCloud operator and extend your cluster to multi-cloud and edge workloads.'
 slug: how-to-run-webassembly-components-on-kubernetes-with-wasmcloud
 ---
 

--- a/blog/2024-08-06-wasmcloud-1.1-brings-secrets-support-and-more-enhancements-for-enterprises/index.mdx
+++ b/blog/2024-08-06-wasmcloud-1.1-brings-secrets-support-and-more-enhancements-for-enterprises/index.mdx
@@ -3,7 +3,7 @@ title: 'wasmCloud 1.1: Secrets Support and More Enterprise Features'
 image: './images/wasmcloud-1-1.png'
 authors: [brooksmtownsend]
 date: "2024-08-06"
-description: 'Learn about the new features in wasmCloud 1.1, including secrets support.'
+description: 'wasmCloud 1.1 lands enterprise-grade features: pluggable secrets support, Postgres and Couchbase capabilities, and first-class Go provider tooling.'
 slug: wasmcloud-1.1-brings-secrets-support-and-more-enhancements-for-enterprises
 ---
 

--- a/blog/2024-08-07-introducing-secrets-how-wasmcloud-solves-for-secrets-in-distributed-environments/index.mdx
+++ b/blog/2024-08-07-introducing-secrets-how-wasmcloud-solves-for-secrets-in-distributed-environments/index.mdx
@@ -4,7 +4,7 @@ authors: [brooksmtownsend]
 slug: secure-pluggable-webassembly-secrets-with-vault-k8s-secrets
 image: './images/secure-pluggable-wasm-secrets.png'
 date: "2024-08-13"
-description: ""
+description: "How wasmCloud 1.1 solves secrets in distributed environments with a pluggable, zero-trust API that works with HashiCorp Vault, Kubernetes, and NATS KV."
 ---
 
 ![Introducing secrets](./images/secure-pluggable-wasm-secrets.png)

--- a/blog/2024-08-19-join-us-for-wasmcloud-innovation-day/index.mdx
+++ b/blog/2024-08-19-join-us-for-wasmcloud-innovation-day/index.mdx
@@ -4,7 +4,7 @@ authors: [cazjt]
 image: './images/innovation-day.jpg'
 slug: 2024-08-19-join-us-for-wasmcloud-innovation-day
 date: "2024-08-19"
-description: "Join us for the first wasmCloud Innovation Day on September 18 for a day of demos and learning"
+description: "Join the first wasmCloud Innovation Day on September 18 for a day of WebAssembly demos, real-world component case studies, and hands-on workshops."
 ---
 
 ![wasmCloud Innovation Day](./images/innovation-day.jpg)

--- a/blog/2024-08-22-wasmcloud-on-the-factory-floor/index.mdx
+++ b/blog/2024-08-22-wasmcloud-on-the-factory-floor/index.mdx
@@ -4,7 +4,7 @@ authors: [cazjt]
 image: './images/mm-quote.jpg'
 slug: 2024-08-23-wasmcloud-on-the-factory-floor
 date: "2024-08-23"
-description: "How MachineMetrics uses WebAssembly and wasmCloud for processing high velocity machine data"
+description: "How MachineMetrics uses WebAssembly and wasmCloud at the edge to process high-velocity machine data on factory floors with efficient Wasm components."
 ---
 
 ![wasmCloud on the factory floor](./images/mm-quote.jpg)

--- a/blog/2024-08-27-wasmcloud-1.2-improved-streams-automatic-config-updates/index.mdx
+++ b/blog/2024-08-27-wasmcloud-1.2-improved-streams-automatic-config-updates/index.mdx
@@ -4,7 +4,7 @@ authors: [brooksmtownsend]
 image: './images/wasmcloud-1.2.png'
 slug: 2024-08-27-wasmcloud-1.2-improved-streams-automatic-config-updates
 date: "2024-08-27"
-description: "Check out the enhancements in wasmCloud 1.2"
+description: "wasmCloud 1.2 brings improved wasi:blobstore streaming, automatic configuration updates for providers, and other quality-of-life enhancements."
 ---
 
 ![wasmcloud 1.2](./images/wasmcloud-1.2.png)

--- a/blog/2024-09-05-build-wasm-components-dotnet-wasmcloud/index.mdx
+++ b/blog/2024-09-05-build-wasm-components-dotnet-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 image: './images/build-wasm-components-dotnet-wasmcloud.webp'
 slug: 2024-09-05-build-wasm-components-dotnet-wasmcloud
 date: "2024-09-05"
-description: "Learn how to compile .NET/C# code to a WebAssembly component and run it on wasmCloud"
+description: "Learn how to compile idiomatic .NET and C# code into a portable WebAssembly component using componentize-dotnet, then run it on wasmCloud."
 ---
 
 ![Build native WebAssembly components with .NET and C# and deploy on wasmCloud](./images/build-wasm-components-dotnet-wasmcloud.webp)

--- a/blog/2024-09-17-wasmcloud-postgres-capability-brings-pluggable-databases/index.mdx
+++ b/blog/2024-09-17-wasmcloud-postgres-capability-brings-pluggable-databases/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 image: './images/wasmcloud-postgres-capability.webp'
 slug: 2024-09-17-wasmcloud-postgres-capability-brings-pluggable-databases
 date: "2024-09-17"
-description: "Learn how to get started with the Postgres capability in wasmCloud."
+description: "Get started with the wasmCloud Postgres capability: a pluggable, language-agnostic database provider for WebAssembly components and cloud-native apps."
 ---
 
 ![The wasmCloud Postgres capability brings pluggable PostgreSQL access for your apps](./images/wasmcloud-postgres-capability.webp)

--- a/blog/2024-09-24-wasmcloud-innovation-day-2024-in-review/index.mdx
+++ b/blog/2024-09-24-wasmcloud-innovation-day-2024-in-review/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 image: './images/wcid-header.webp'
 slug: 2024-09-24-wasmcloud-innovation-day-2024-in-review
 date: "2024-09-24"
-description: "Check out the exciting demos and learning sessions at wasmCloud Innovation Day."
+description: "A recap of wasmCloud Innovation Day 2024: keynotes from Bailey Hayes, secrets demos, production use cases, and the future of WebAssembly components."
 ---
 
 ![wasmCloud Innovation Day 2024 in review](./images/wcid-header.webp)

--- a/blog/2024-10-30-wasmcloud-at-kubecon-na-2024/index.mdx
+++ b/blog/2024-10-30-wasmcloud-at-kubecon-na-2024/index.mdx
@@ -4,7 +4,7 @@ authors: [cazjt]
 image: './images/KubeCon-CloudNativeCon-24.png'
 slug: 2024-10-30-wasmcloud-at-kubecon-na-2024
 date: "2024-10-30"
-description: "Join us at WasmCon and KubeCon NA 2024"
+description: "wasmCloud's guide to WasmCon and KubeCon + CloudNativeCon NA 2024 in Salt Lake City: talks from American Express, Adobe, Akamai, and the wasmCloud booth."
 toc_max_heading_level: 2
 ---
 

--- a/blog/2024-11-07-update-to-wit-package-management-in-wasmcloud/index.mdx
+++ b/blog/2024-11-07-update-to-wit-package-management-in-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 image: './images/update-to-wit-package-management.webp'
 slug: 2024-11-08-update-to-wit-package-management-in-wasmcloud
 date: "2024-11-08"
-description: "How WIT package management in wasmCloud is evolving"
+description: "How WIT package management in wasmCloud is evolving: wash v0.36 deprecates wit-deps in favor of the OCI-native wkg from Wasm Package Tools."
 ---
 
 ![TK](./images/update-to-wit-package-management.webp)

--- a/blog/2024-11-07-wasmcloud-spurs-wasm-adoption-with-major-devex-improvements/index.mdx
+++ b/blog/2024-11-07-wasmcloud-spurs-wasm-adoption-with-major-devex-improvements/index.mdx
@@ -4,7 +4,7 @@ authors: [cazjt]
 image: './images/wasmcloud-spurs.webp'
 slug: 2024-11-07-wasmcloud-spurs-wasm-adoption-with-major-devex-improvements
 date: "2024-11-07"
-description: "wasmCloud is making Wasm adoption easier than ever with major improvements to developer experience."
+description: "wasmCloud is making Wasm adoption easier than ever with wash dev, hot reload, and major developer experience improvements for WebAssembly components."
 ---
 
 ![wasmCloud spurs Wasm adoption with major DevEx improvements](./images/wasmcloud-spurs.webp)

--- a/blog/2024-11-13-join-us-for-contribfest/index.mdx
+++ b/blog/2024-11-13-join-us-for-contribfest/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 image: './images/contribfest-2024.webp'
 slug: 2024-11-13-join-us-for-contribfest
 date: "2024-11-13"
-description: "Learn about Contribfest, good first issues for new wasmCloud contributors, and how you can get involved."
+description: "Join wasmCloud at KubeCon NA 2024 for Contribfest: pair with maintainers on good first issues and start contributing to the WebAssembly platform."
 ---
 
 ![Header remixes original photo at https://commons.wikimedia.org/wiki/File:Saltlakecity_winter2009.jpg](./images/contribfest-2024.webp)

--- a/blog/2024-11-14-secure-your-wasmcloud-supply-chain-with-sboms/index.mdx
+++ b/blog/2024-11-14-secure-your-wasmcloud-supply-chain-with-sboms/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 slug: 2024-11-14-secure-your-wasmcloud-supply-chain-with-sboms
 image: './images/wasmcloud-sboms.webp'
 date: "2024-11-19"
-description: "In this blog, we'll explore how to generate SBOMs for wasmCloud projects using common open source tools syft and grype."
+description: "How to secure your wasmCloud supply chain by generating Software Bills of Materials (SBOMs) for WebAssembly projects with open source syft and grype."
 
 ---
 

--- a/blog/2024-11-26-starting-your-webassembly-developer-loop-with-wash-dev/index.mdx
+++ b/blog/2024-11-26-starting-your-webassembly-developer-loop-with-wash-dev/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 slug: 2024-11-26-starting-your-webassembly-developer-loop-with-wash-dev
 image: './images/wash-dev.webp'
 date: "2024-11-26"
-description: "In this blog, we'll explain how you can use `wash dev` to start developing WebAssembly components in minutes."
+description: "How to use wash dev to start a hot-reloading WebAssembly developer loop in minutes, with plug-and-play wasmCloud capabilities and zero boilerplate."
 ---
 
 ![Starting your WebAssembly developer loop with wash dev](./images/wash-dev.webp)

--- a/blog/2024-12-12-the-pitfalls-of-modern-platform-engineering/index.mdx
+++ b/blog/2024-12-12-the-pitfalls-of-modern-platform-engineering/index.mdx
@@ -4,7 +4,7 @@ authors: [ricochet, cazjt]
 slug: 2024-12-12-the-pitfalls-of-modern-platform-engineering
 image: './images/pitfalls-of-modern-platform-engineering.webp'
 date: "2024-12-12"
-description: "How WebAssembly and wasmCloud help platform teams tackle the costs and complexities of building applications at scale."
+description: "Bailey Hayes on how WebAssembly components and wasmCloud help platform engineering teams tackle the costs and complexities of building apps at scale."
 ---
 
 ![The Pitfalls of Modern Platform Engineering](./images/pitfalls-of-modern-platform-engineering.webp)

--- a/blog/2024-12-17-wasmclouds-fresh-approach-to-secrets/index.mdx
+++ b/blog/2024-12-17-wasmclouds-fresh-approach-to-secrets/index.mdx
@@ -4,7 +4,7 @@ authors: [brooksmtownsend, cazjt]
 slug: 2024-12-17-wasmclouds-fresh-approach-to-secrets
 image: './images/wasmclouds-fresh-approach-to-secrets.webp'
 date: "2024-12-17"
-description: "How wasmCloud's pluggable secrets architecture solves common challenges in cloud native secret management for developers."
+description: "How wasmCloud's pluggable, just-in-time secrets architecture solves common challenges in cloud-native secret management across distributed environments."
 ---
 
 ![wasmCloud's fresh approach to secrets](./images/wasmclouds-fresh-approach-to-secrets.webp)

--- a/blog/2024-12-20-the-evolution-of-golang-in-wasmcloud/index.mdx
+++ b/blog/2024-12-20-the-evolution-of-golang-in-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ authors: [lxfontes, cazjt]
 slug: 2024-12-20-the-evolution-of-golang-in-wasmcloud
 image: './images/evolution.webp'
 date: "2024-12-20"
-description: "How wasmCloud SDKs for Go components and providers make it easier than ever to build wasmCloud applications with Go."
+description: "How the wasmCloud Go component and provider SDKs, plus the new wadge testing framework, make building WebAssembly applications in Go easier than ever."
 ---
 
 ![The Go gopher was designed by Renee French and is licensed under the Creative Commons 3.0 Attributions license](./images/evolution.webp)

--- a/blog/2025-01-09-wasmcloud-operator-bringing-the-benefits-of-wasm-to-kubernetes/index.mdx
+++ b/blog/2025-01-09-wasmcloud-operator-bringing-the-benefits-of-wasm-to-kubernetes/index.mdx
@@ -4,7 +4,7 @@ authors: [lxfontes, cazjt]
 slug: 2025-01-09-wasmcloud-operator-bringing-the-benefits-of-wasm-to-kubernetes
 image: './images/wasmcloud-operator.webp'
 date: "2025-01-09"
-description: "wasmCloud maintainer Lucas Fontes discusses how the wasmCloud operator helps bring the benefits of Wasm to Kubernetes."
+description: "wasmCloud maintainer Lucas Fontes discusses how the wasmCloud operator brings WebAssembly components to Kubernetes and extends clusters to the edge."
 ---
 
 ![wasmcloud-operator](./images/wasmcloud-operator.webp)

--- a/blog/2025-01-21-wash-dev-a-rapid-developer-loop-for-webassembly-components/index.mdx
+++ b/blog/2025-01-21-wash-dev-a-rapid-developer-loop-for-webassembly-components/index.mdx
@@ -4,7 +4,7 @@ authors: [vados-cosmonic, cazjt]
 slug: 2025-01-21-wash-dev-wasmclouds-rapid-developer-loop-for-webassembly-projects
 image: './images/wash-dev-header.webp'
 date: "2025-01-21"
-description: "Victor Adossi demonstrates wash dev, the rapid developer loop for building and iterating on wasmCloud Wasm components."
+description: "Victor Adossi demonstrates wash dev, the rapid hot-reload developer loop for building, iterating on, and deploying wasmCloud WebAssembly components."
 ---
 
 ![wash-dev](./images/wash-dev-header.webp)

--- a/blog/2025-02-03-compiling-c-to-webassembly-with-wasmcloud/index.mdx
+++ b/blog/2025-02-03-compiling-c-to-webassembly-with-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ authors: [colinmurphy, cazjt]
 slug: 2025-02-03-compiling-c-to-webassembly-with-wasmcloud
 image: './images/Adobe-innovation-day-header.jpeg'
 date: "2025-02-03"
-description: "Adobe's Colin Murphy demonstrates compiling C and C++ to WebAssembly components and running them on wasmCloud."
+description: "Adobe's Colin Murphy demonstrates compiling C and C++ to portable WebAssembly components and running them on wasmCloud for edge PDF text extraction."
 ---
 
 ![Adobe presentation at Innovation Day](./images/Adobe-innovation-day-header.jpeg)

--- a/blog/2025-02-18-introducing-the-wasmcloud-benchmark-chart/index.mdx
+++ b/blog/2025-02-18-introducing-the-wasmcloud-benchmark-chart/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory]
 slug: 2025-02-18-introducing-the-wasmcloud-benchmark-chart
 image: './images/benchmark-header.webp'
 date: "2025-02-18"
-description: "Learn about the Helm chart for benchmarking wasmCloud."
+description: "A new wasmCloud benchmark Helm chart for Kubernetes bundles Grafana, k6, and OpenTelemetry tooling to measure performance of your WebAssembly workloads."
 ---
 
 ![Introducing the wasmCloud benchmark chart](./images/benchmark-header.webp)

--- a/blog/2025-03-04-why-were-adopting-spiffe-for-webassembly-workload-identity/index.mdx
+++ b/blog/2025-03-04-why-were-adopting-spiffe-for-webassembly-workload-identity/index.mdx
@@ -4,7 +4,7 @@ authors: [joonas, ericgregory]
 slug: 2025-03-04-why-were-adopting-spiffe-for-webassembly-workload-identity
 image: './images/spiffe-wasmcloud-header.webp'
 date: "2025-03-04"
-description: "Why wasmCloud is adopting SPIFFE as the standard for WebAssembly workload identity across on-prem, edge, and cloud."
+description: "Why wasmCloud is adopting SPIFFE and SPIRE as the universal standard for WebAssembly workload identity across on-prem, edge, and cloud environments."
 ---
 
 import BedaTweet from './images/spiffe-beda-twitter.png';

--- a/blog/2025-04-01-wasmcloud-at-kubecon-eu-2025/index.mdx
+++ b/blog/2025-04-01-wasmcloud-at-kubecon-eu-2025/index.mdx
@@ -4,7 +4,7 @@ authors: [cazjt]
 slug: 2025-04-01-wasmcloud-at-kubecon-cloudnativecon-europe-2025
 image: './images/KubeCon-EU-Header.jpg'
 date: "2025-04-01"
-description: "Join the wasmCloud community at KubeCon + CloudNativeCon Europe 2025."
+description: "Find wasmCloud at KubeCon + CloudNativeCon Europe 2025 in London: project booth, maintainer talks, and sessions on WebAssembly, components, and SPIFFE."
 ---
 
 ![KubeCon + CloudNativeCon Europe 2025](./images/KubeCon-EU-Header.jpg)

--- a/blog/2025-05-01-platform-harness/index.mdx
+++ b/blog/2025-05-01-platform-harness/index.mdx
@@ -4,7 +4,7 @@ authors: [ericgregory, ricochet]
 slug: 2025-05-13-platform-engineering-with-webassembly-and-the-platform-harness-pattern
 image: './images/platform-harness-header.webp'
 date: "2025-05-13"
-description: "."
+description: "How the 'platform harness' pattern with WebAssembly components and wasmCloud unlocks new approaches to platform engineering beyond containers and sidecars."
 ---
 
 ![Platform engineering with WebAssembly and the platform harness pattern](./images/platform-harness-header.webp)

--- a/blog/2025-05-21-one-year-of-wasmcloud-1.0/index.mdx
+++ b/blog/2025-05-21-one-year-of-wasmcloud-1.0/index.mdx
@@ -4,7 +4,7 @@ authors: [brooksmtownsend]
 slug: 2025-05-21-one-year-of-wasmcloud-1.0
 image: './images/one-year-blog-header.webp'
 date: "2025-05-21"
-description: "Celebrating one year of wasmCloud 1.0."
+description: "Celebrating one year of wasmCloud 1.0: reflecting on WASI 0.2 adoption, community growth, and the path toward WASI 0.3 and a more pluggable host."
 ---
 
 ![One year of wasmCloud 1.0](./images/one-year-blog-header.webp)

--- a/blog/2025-07-01-charting-the-next-steps-for-wasmcloud/index.mdx
+++ b/blog/2025-07-01-charting-the-next-steps-for-wasmcloud/index.mdx
@@ -4,7 +4,7 @@ authors: [brooksmtownsend]
 slug: charting-the-next-steps-for-wasmcloud
 image: './images/blog-header.webp'
 date: "2025-07-03"
-description: "Looking back and looking forward to chart the next steps for wasmCloud." 
+description: "Looking back and looking forward to chart the next steps for wasmCloud: what works post-1.0, what to retire, and where the WebAssembly platform is headed." 
 ---
 
 ![Charting the next steps for wasmCloud](./images/blog-header.webp)

--- a/blog/2025-07-15-q3-2025-roadmap-recap/index.md
+++ b/blog/2025-07-15-q3-2025-roadmap-recap/index.md
@@ -4,7 +4,7 @@ authors: [ericgregory]
 slug: 2025-07-15-q3-2025-roadmap-recap
 image: './images/q3-2025-roadmap-recap.webp'
 date: "2025-07-15"
-description: "Recapping the major initiatives that emerged from the Q3 2025 roadmap planning meeting."
+description: "Recapping wasmCloud's Q3 2025 roadmap: a slimmer host, rethinking capability providers as wRPC servers, and a cleaner WebAssembly developer experience."
 ---
 
 ![Q3 2025 Roadmap Recap](./images/q3-2025-roadmap-recap.webp)

--- a/blog/2025-08-22-wash-plugin/index.mdx
+++ b/blog/2025-08-22-wash-plugin/index.mdx
@@ -4,7 +4,7 @@ authors: [brooksmtownsend]
 slug: introducing-wash-wasm-powered-plugin-system
 image: './images/plugin-header.webp'
 date: "2025-08-27"
-description: "Why a Wasm-driven plugin model is so powerful for CLIs" 
+description: "Why a Wasm-driven plugin model is so powerful for CLIs, and how the next-generation wash CLI uses WebAssembly components for portable, sandboxed extensions." 
 ---
 
 ![Introducing the wash CLI's new Wasm-powered plugin system](./images/plugin-header.webp)

--- a/blog/2025-08-26-setup-wash/index.mdx
+++ b/blog/2025-08-26-setup-wash/index.mdx
@@ -4,7 +4,7 @@ authors: [ricochet]
 slug: 2025-08-20-github-action-for-wasm-development-setup-wash
 image: './images/setup-wash-header.webp'
 date: "2025-08-20"
-description: "Comparing approaches to authoring, maintaining, and publishing GitHub Actions."
+description: "Introducing setup-wash, a GitHub Action for installing the Wasm Shell CLI, plus lessons learned comparing TypeScript, container, and composite Actions."
 ---
 
 ![Header](./images/setup-wash-header.webp)

--- a/blog/2025-11-04-wasmcloud-at-kubecon-cloudnativecon-2025/index.mdx
+++ b/blog/2025-11-04-wasmcloud-at-kubecon-cloudnativecon-2025/index.mdx
@@ -2,7 +2,7 @@
 title: "wasmCloud at KubeCon + CloudNativeCon NA 2025"
 authors: [ericgregory]
 date: '2025-11-05'
-description: 'Meet the wasmCloud team at KubeCon + CloudNativeCon NA 2025 in Atlanta!'
+description: 'Meet wasmCloud at KubeCon + CloudNativeCon NA 2025 in Atlanta: project booth, maintainer talks on service meshes, WASI WebGPU, GitOps, and more.'
 slug: wasmcloud-at-kubecon-cloudnativecon-na-2025
 image: './images/wasmcloud-kubecon-na-2025-header.webp'
 ---

--- a/blog/2025-11-10-wasmcon-na-25-liveblog/index.mdx
+++ b/blog/2025-11-10-wasmcon-na-25-liveblog/index.mdx
@@ -2,7 +2,7 @@
 title: "WasmCon NA 2025 Liveblog"
 authors: [ericgregory] 
 date: '2025-11-10'
-description: 'Meet the wasmCloud team at KubeCon + CloudNativeCon NA 2025 in Atlanta!'
+description: 'Live coverage of WasmCon at KubeCon NA 2025 in Atlanta: WASI P3, the Component Model, language support, and the future of WebAssembly in production.'
 slug: wasmcon-na-25-liveblog
 image: './images/wasmcon-header.webp'
 ---

--- a/blog/2026-03-12-wasmcloud-at-kubecon-eu-2026/index.mdx
+++ b/blog/2026-03-12-wasmcloud-at-kubecon-eu-2026/index.mdx
@@ -2,7 +2,7 @@
 title: "wasmCloud at KubeCon + CloudNativeCon EU 2026"
 authors: [ericgregory]
 date: '2026-03-12'
-description: 'Meet the wasmCloud team at KubeCon + CloudNativeCon EU 2026 in Amsterdam!'
+description: 'Meet wasmCloud at KubeCon + CloudNativeCon EU 2026 in Amsterdam: visit the project booth, attend WasmCon, and see what is new in wasmCloud v2.'
 slug: wasmcloud-at-kubecon-cloudnativecon-eu-2026
 image: './images/kubecon-eu-2026-header.png'
 ---

--- a/blog/2026-05-07-wasmcloud-2.1.0/index.mdx
+++ b/blog/2026-05-07-wasmcloud-2.1.0/index.mdx
@@ -2,7 +2,7 @@
 title: "wasmCloud 2.1.0: Namespaced hosts, native routing"
 authors: [ericgregory]
 date: '2026-05-07'
-description: 'wasmCloud 2.1.0 brings namespace-scoped Host CRDs, Kubernetes-native Service routing, plugin support in services, the first HTTP microbenchmarks, and a preview of WASI P3.'
+description: 'wasmCloud 2.1.0 brings namespace-scoped Host CRDs, Kubernetes-native Service routing, plugin support in services, HTTP benchmarks, and a WASI P3 preview.'
 slug: wasmcloud-2-1-0-release
 image: './images/2.1-blog-header.png'
 ---

--- a/community/2022-11-01-welcome-community.mdx
+++ b/community/2022-11-01-welcome-community.mdx
@@ -1,6 +1,7 @@
 ---
 slug: welcome-community
 title: Welcome to the wasmCloud Community!
+description: 'Welcome to the wasmCloud community: weekly Wednesday meetings, contributing guide, and links to Slack, mailing list, and GitHub for the WebAssembly project.'
 authors: [brooksmtownsend]
 tags: [community]
 showTitle: true

--- a/community/2022-11-02-community-meeting.mdx
+++ b/community/2022-11-02-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-11-02
+description: 'wasmCloud community call kicking off these notes with memory optimizations in the host, choosing a home for community meeting notes, and KubeCon presence plans.'
 date: 2022-11-02
 ---
 

--- a/community/2022-11-09-community-meeting.mdx
+++ b/community/2022-11-09-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-11-09
+description: 'wasmCloud community call covering the new Docusaurus docs site, wash down shutdown command, project-template GitHub Actions, and monorepo workflows.'
 date: 2022-11-09
 ---
 

--- a/community/2022-11-16-community-meeting.mdx
+++ b/community/2022-11-16-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-11-16
+description: 'wasmCloud community call on wash up multi-host support, .NET WebAssembly status, wash-lib refactor, and migrating capability providers from Smithy to WIT.'
 date: 2022-11-16
 ---
 

--- a/community/2022-11-23-community-meeting.mdx
+++ b/community/2022-11-23-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-11-23
+description: 'wasmCloud community call featuring wash up multi-host demos, a Kafka messaging capability provider, repo reorganization, and the wasmtime engine migration.'
 date: 2022-11-23
 ---
 

--- a/community/2022-11-29-community-meeting.mdx
+++ b/community/2022-11-29-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-11-29
+description: 'wasmCloud community call covering the OTP supervision tree refactor for the host runtime and the wash-lib refactor toward a reusable WebAssembly CLI.'
 date: 2022-11-29
 ---
 

--- a/community/2022-12-07-community-meeting.mdx
+++ b/community/2022-12-07-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-12-07
+description: 'wasmCloud community call featuring a full-stack KVCounter demo, revisiting wasmCloud manifests, linting and Credo cleanup, and component model .world support.'
 date: 2022-12-07
 ---
 

--- a/community/2022-12-13-community-meeting.mdx
+++ b/community/2022-12-13-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-12-13
+description: 'wasmCloud community call with a surprise demo from Jordan, discussion of durable key-value lattice cache, wash binary packaging, and wasi-cloud updates.'
 date: 2022-12-13
 ---
 

--- a/community/2022-12-28-community-meeting.mdx
+++ b/community/2022-12-28-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2022-12-28
+description: 'Short holiday wasmCloud community call sketching 2023 New Year resolutions for the WebAssembly platform via an Excalidraw whiteboard of high-level goals.'
 date: 2022-12-28
 ---
 

--- a/community/2023-01-04-community-meeting.mdx
+++ b/community/2023-01-04-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-01-04
+description: 'wasmCloud community call welcoming 2023 with the official wash 0.14.0 release, package manager and distribution survey, and wasmCloud sensor interface plans.'
 date: 2023-01-04
 ---
 

--- a/community/2023-01-11-community-meeting.mdx
+++ b/community/2023-01-11-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-01-11
+description: 'wasmCloud community call featuring a wazero Go host runtime demo, wash 0.14.0 walkthrough, the 0.60.0-rc.1 release candidate, and wasmCloud security overview.'
 date: 2023-01-11
 ---
 

--- a/community/2023-01-18-community-meeting.mdx
+++ b/community/2023-01-18-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-01-18
+description: 'wasmCloud community call covering meeting streaming plans, a wash demo to start actors from a local file, and the wascap 0.9.2 upgrade with breaking changes.'
 date: 2023-01-18
 ---
 

--- a/community/2023-01-25-community-meeting.mdx
+++ b/community/2023-01-25-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-01-25
+description: 'wasmCloud community call with a distributed demo across GCP, laptop, and Raspberry Pi, roadmap walkthrough, and discussion on actor nomenclature.'
 date: 2023-01-25
 ---
 

--- a/community/2023-02-01-community-meeting.mdx
+++ b/community/2023-02-01-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-02-01
+description: 'wasmCloud community call featuring testing actors with Dagger, the Little Blobby Tables demo, C4 model docs, the 0.60 host update, and Wasm I/O event news.'
 date: 2023-02-01
 ---
 

--- a/community/2023-02-08-community-meeting.mdx
+++ b/community/2023-02-08-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-02-08
+description: 'wasmCloud community call featuring the wasm-air ADSP flight-tracking demo, wash 0.14.1 yanked plus 0.15.0 plans, roadmap feedback, and actor model discussion.'
 date: 2023-02-08
 ---
 

--- a/community/2023-02-15-community-meeting.mdx
+++ b/community/2023-02-15-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-02-15
+description: 'wasmCloud community call featuring a devcontainers demo for wash and wasmcloud-otp plus an overview of KubeCon EU, Wasm I/O, and Cloud Native Wasm Day talks.'
 date: 2023-02-15
 ---
 

--- a/community/2023-02-22-community-meeting.mdx
+++ b/community/2023-02-22-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-02-22
+description: 'wasmCloud community call tidying wadm for production, debating GitHub Projects for roadmap tracking, and announcing a Cosmonic DevPost hackathon.'
 date: 2023-02-22
 ---
 

--- a/community/2023-03-01-community-meeting.mdx
+++ b/community/2023-03-01-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-03-01
+description: 'wasmCloud community call with cargo nextest integration tests in wash, washboard error handling improvements, and continued wadm RFC discussion.'
 date: 2023-03-01
 ---
 

--- a/community/2023-03-08-community-meeting.mdx
+++ b/community/2023-03-08-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-03-08
+description: 'wasmCloud community call featuring a Rust wadm implementation handling lattice events, GitHub Projects for the OSS roadmap, and an initial Rust wasmCloud host.'
 date: 2023-03-08
 ---
 

--- a/community/2023-03-15-community-meeting.mdx
+++ b/community/2023-03-15-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-03-15
+description: 'wasmCloud community call covering link definitions and names, WASI component model progress, GitHub Projects usage, SCALE 20x recap, and hackathon updates.'
 date: 2023-03-15
 ---
 

--- a/community/2023-03-22-community-meeting.mdx
+++ b/community/2023-03-22-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-03-22
+description: 'Light wasmCloud community call while maintainers travel to Wasm I/O, focused on the v0.62.0 release candidate and the new libwasmcloud NIF for the host runtime.'
 date: 2023-03-22
 ---
 

--- a/community/2023-03-29-community-meeting.mdx
+++ b/community/2023-03-29-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-03-29
+description: 'wasmCloud community call demoing KVCounter with Wasm components, exploring component model impact on actors and providers, plus Concordance event sourcing.'
 date: 2023-03-29
 ---
 

--- a/community/2023-04-05-community-meeting.mdx
+++ b/community/2023-04-05-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-04-05
+description: 'wasmCloud community call featuring a Concordance event sourcing replay demo, a wadm State of the Union, and v0.62.0 release notes with component support status.'
 date: 2023-04-05
 ---
 

--- a/community/2023-04-12-community-meeting.mdx
+++ b/community/2023-04-12-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-04-12
+description: 'wasmCloud community call with a wadm progress report on the Rust rewrite plus discussion of Go''s official wasip1 merge and what it means for WebAssembly actors.'
 date: 2023-04-12
 ---
 

--- a/community/2023-04-12-community-meeting.mdx
+++ b/community/2023-04-12-community-meeting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Community Meeting - 2023-04-12
-description: 'wasmCloud community call with a wadm progress report on the Rust rewrite plus discussion of Go''s official wasip1 merge and what it means for WebAssembly actors.'
+description: 'wasmCloud community call with a wadm Rust rewrite progress report and discussion of Go''s official wasip1 merge for WebAssembly actors.'
 date: 2023-04-12
 ---
 

--- a/community/2023-04-26-community-meeting.mdx
+++ b/community/2023-04-26-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-04-26
+description: 'wasmCloud community call demoing wadm with the OAM declarative format, debating numbergen cryptography for components, and recapping KubeCon EU and Wasm Day.'
 date: 2023-04-26
 ---
 

--- a/community/2023-05-03-community-meeting.mdx
+++ b/community/2023-05-03-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-05-03
+description: 'wasmCloud community call with the SigScale rating actor demo, wadm 0.4 release update, DevPost hackathon winners, and the wash CLI restructure RFC.'
 date: 2023-05-03
 ---
 

--- a/community/2023-05-10-community-meeting.mdx
+++ b/community/2023-05-10-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-05-10
+description: 'wasmCloud community call demoing burrito static wasmCloud host releases, discussing runtime-defined built-in capability providers, and the CNCF Incubating path.'
 date: 2023-05-10
 ---
 

--- a/community/2023-05-17-community-meeting.mdx
+++ b/community/2023-05-17-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-05-17
+description: 'wasmCloud community call with a wash burrito demo on v0.63.0 and RFCs to remove the washboard from the host, focus features on Rust, and add a stale-issue bot.'
 date: 2023-05-17
 ---
 

--- a/community/2023-05-24-community-meeting.mdx
+++ b/community/2023-05-24-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-05-24
+description: 'wasmCloud community call covering wadm release prep, an RFC for WIT-based interfaces, and component model progress in Wasmtime and the WASI preview 2 adapter.'
 date: 2023-05-24
 ---
 

--- a/community/2023-05-31-community-meeting.mdx
+++ b/community/2023-05-31-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-05-31
+description: 'wasmCloud community call on the wash command structure RFC, wadm release readiness, and a three-pronged RFC to overhaul lattice link configuration handling.'
 date: 2023-05-31
 ---
 

--- a/community/2023-06-07-community-meeting.mdx
+++ b/community/2023-06-07-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-06-07
+description: 'wasmCloud community call featuring a wash spy distributed debugging demo, the wadm 0.4 release, wash 0.18.0 changes, and CNCF Incubating status application.'
 date: 2023-06-07
 ---
 

--- a/community/2023-06-14-community-meeting.mdx
+++ b/community/2023-06-14-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-06-14
+description: 'wasmCloud community call demoing wash capture, wash dev, the wash 0.18 release, and a discussion of the wash development loop for WebAssembly applications.'
 date: 2023-06-14
 ---
 

--- a/community/2023-06-21-community-meeting.mdx
+++ b/community/2023-06-21-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-06-21
+description: 'wasmCloud community call featuring Azure webhooks for auto-updating OCI URLs, a WebAssembly component interop demo, and continued discussion on secrets in apps.'
 date: 2023-06-21
 ---
 

--- a/community/2023-06-28-community-meeting.mdx
+++ b/community/2023-06-28-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-06-28
+description: 'wasmCloud community call demoing a system information provider for host metrics and a deep discussion on link names, configuration, and capability isolation.'
 date: 2023-06-28
 ---
 

--- a/community/2023-07-05-community-meeting.mdx
+++ b/community/2023-07-05-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-07-05
+description: 'wasmCloud community call demoing wash ui, the detached washboard backed by wadm state, and a discussion of actor lifecycles, streams, and stateful actors.'
 date: 2023-07-05
 ---
 

--- a/community/2023-07-12-community-meeting.mdx
+++ b/community/2023-07-12-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-07-12
+description: 'wasmCloud community call covering WIT-ified providers starting with Golang and a deep dive into WIT, WASI Preview 2, and the WebAssembly component model.'
 date: 2023-07-12
 ---
 

--- a/community/2023-07-19-community-meeting.mdx
+++ b/community/2023-07-19-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-07-19
+description: 'wasmCloud community call updating wit-ified providers with msgpack and wasifills, plus a discussion of how RFCs and ADRs are managed across the wasmCloud org.'
 date: 2023-07-19
 ---
 

--- a/community/2023-07-26-community-meeting.mdx
+++ b/community/2023-07-26-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-07-26
+description: 'wasmCloud community call demoing a WIT-based NATS messaging provider, the path from Smithy to wit interfaces, and wadm 0.5.0 multi-tenant fixes.'
 date: 2023-07-26
 ---
 

--- a/community/2023-08-02-community-meeting.mdx
+++ b/community/2023-08-02-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-08-02
+description: 'wasmCloud community call with a Rust WIT provider SDK demo and codegen update, plus a discussion on the wasmCloud roadmap and WebAssembly standards alignment.'
 date: 2023-08-02
 ---
 

--- a/community/2023-08-09-community-meeting.mdx
+++ b/community/2023-08-09-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-08-09
+description: 'wasmCloud community call featuring a wadm 0.5 manifest upgrade and status demo on petclinic plus a roadmap update on the Rust host and WIT-ification.'
 date: 2023-08-09
 ---
 

--- a/community/2023-08-16-community-meeting.mdx
+++ b/community/2023-08-16-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-08-16
+description: 'wasmCloud community call demoing the wadm actor daemonscaler and Concordance event sourcing codegen, plus a roadmap update ahead of WasmCon in Bellevue.'
 date: 2023-08-16
 ---
 

--- a/community/2023-08-23-community-meeting.mdx
+++ b/community/2023-08-23-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-08-23
+description: 'wasmCloud community call demoing wadm 0.5.0 manifest validation, prepping the wadm release and wash 0.20.0, and a roadmap update on Rust host OTP parity.'
 date: 2023-08-23
 ---
 

--- a/community/2023-08-30-community-meeting.mdx
+++ b/community/2023-08-30-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-08-30
+description: 'wasmCloud community call on the Rust host hitting OTP feature parity, the v0.78.0 initial Rust host release plan, and a roadmap look before WasmCon and BACon.'
 date: 2023-08-30
 ---
 

--- a/community/2023-09-13-community-meeting.mdx
+++ b/community/2023-09-13-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-09-13
+description: 'wasmCloud community call demoing Rust and TinyGo WebAssembly components built with wit-bindgen and no wasmCloud SDK, plus a check-in on the witify milestone.'
 date: 2023-09-13
 ---
 

--- a/community/2023-09-20-community-meeting.mdx
+++ b/community/2023-09-20-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-09-20
+description: 'wasmCloud community call featuring a live DTW23 5G telecom demo on wasmCloud, NATS microservices integration, metrics RFC, and the wasmCloud 0.78.0 release.'
 date: 2023-09-20
 ---
 

--- a/community/2023-09-27-community-meeting.mdx
+++ b/community/2023-09-27-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-09-27
+description: 'wasmCloud community call demoing WASI-fill generation, discussing long-running processes and RPC timeouts, plus metrics and component autoscaling RFCs.'
 date: 2023-09-27
 ---
 

--- a/community/2023-10-04-community-meeting.mdx
+++ b/community/2023-10-04-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-10-04
+description: 'wasmCloud community call on dynamically generated Wasifills, versions in wasmCloud documentation, and Hacktoberfest issue picks for new contributors.'
 date: 2023-10-04
 ---
 

--- a/community/2023-10-11-community-meeting.mdx
+++ b/community/2023-10-11-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-10-11
+description: 'wasmCloud community call demoing actor autoscaling with scale-to-zero, the Trail of Bits security audit, and documentation improvements for the project.'
 date: 2023-10-11
 ---
 

--- a/community/2023-10-18-community-meeting.mdx
+++ b/community/2023-10-18-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-10-18
+description: 'wasmCloud community call covering wash build for wasm32-wasi-preview2 components, the wasmCloud security audit results, monorepo plans, and WASI-virt updates.'
 date: 2023-10-18
 ---
 

--- a/community/2023-10-25-community-meeting.mdx
+++ b/community/2023-10-25-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-10-25
+description: 'wasmCloud community call featuring the TinyGo Globby demo using WASI contracts, the wasmcloud/wasmcloud monorepo move, and the CNCF Incubation application.'
 date: 2023-10-25
 ---
 

--- a/community/2023-11-01-community-meeting.mdx
+++ b/community/2023-11-01-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-11-01
+description: 'wasmCloud community call with a wadm 0.8 showcase, documentation overhaul plans, Wasmtime 14 update, monorepo progress, and a round of community shoutouts.'
 date: 2023-11-01
 ---
 

--- a/community/2023-11-07-community-meeting.mdx
+++ b/community/2023-11-07-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-11-07
+description: 'wasmCloud community call streaming live from KubeCon CloudNativeCon NA 2023 in Chicago with a Cloud Native Wasm Day recap and webassembly kubernetes discussion.'
 date: 2023-11-07
 ---
 

--- a/community/2023-11-15-community-meeting.mdx
+++ b/community/2023-11-15-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-11-15
+description: 'wasmCloud community call reviewing new control interface features: adjusting labels, runtime actor config, lame duck/cordon mode, and dynamic log levels.'
 date: 2023-11-15
 ---
 

--- a/community/2023-11-22-community-meeting.mdx
+++ b/community/2023-11-22-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-11-22
+description: 'wasmCloud community call demoing human-friendly wash CLI updates that remove 56-character ID prompts plus discussion of the Wasmtime 15 component model release.'
 date: 2023-11-22
 ---
 

--- a/community/2023-11-29-community-meeting.mdx
+++ b/community/2023-11-29-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-11-29
+description: 'wasmCloud community call demoing custom wash build commands with build-only and sign-only flags, plus discussion of the wasmCloud 1.0 milestone and Wasmtime 15.'
 date: 2023-11-29
 ---
 

--- a/community/2023-12-06-community-meeting.mdx
+++ b/community/2023-12-06-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-12-06
+description: 'wasmCloud community call demoing how to bring your own WebAssembly component, a Q3/Q4 roadmap retrospective, and the control interface stabilization RFC.'
 date: 2023-12-06
 ---
 

--- a/community/2023-12-13-community-meeting.mdx
+++ b/community/2023-12-13-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-12-13
+description: 'wasmCloud community call demoing wash inspect --wit for component WIT introspection plus a deep dive into the wasmCloud 1.0 roadmap and numbered milestones.'
 date: 2023-12-13
 ---
 

--- a/community/2023-12-20-community-meeting.mdx
+++ b/community/2023-12-20-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-12-20
+description: 'wasmCloud community call demoing the new components-first Hello World experience in Rust and TinyGo using wasi:http/incoming-handler and Wasmtime 16.'
 date: 2023-12-20
 ---
 

--- a/community/2023-12-27-community-meeting.mdx
+++ b/community/2023-12-27-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2023-12-27
+description: 'Short year-end wasmCloud community call with a quick check-in and Happy Holidays from the wasmCloud maintainers building the WebAssembly application platform.'
 date: 2023-12-27
 ---
 

--- a/community/2024-01-03-community-meeting.mdx
+++ b/community/2024-01-03-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-01-03
+description: 'wasmCloud community call welcoming 2024 with v0.81.0 on Wasmtime 16, WASI Preview 2 release-candidate progress, and the January 11 WebAssembly CG subgroup vote.'
 date: 2024-01-03
 ---
 

--- a/community/2024-01-10-community-meeting.mdx
+++ b/community/2024-01-10-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-01-10
+description: 'wasmCloud community call demoing a TypeScript hello world with jco and componentize-js, a roadmap check-in, and the formalize control interface RFC.'
 date: 2024-01-10
 ---
 

--- a/community/2024-01-17-community-meeting.mdx
+++ b/community/2024-01-17-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-01-17
+description: 'wasmCloud community call demoing how to build a wasmCloud component in any language with wash build, plus wadm 0.10.0 features and the weekly roadmap review.'
 date: 2024-01-17
 ---
 

--- a/community/2024-01-24-community-meeting.mdx
+++ b/community/2024-01-24-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-01-24
+description: 'wasmCloud community call introducing wRPC, the new component-to-component protocol, plus OTEL metrics progress and a wasmCloud 1.0 roadmap update.'
 date: 2024-01-24
 ---
 

--- a/community/2024-01-31-community-meeting.mdx
+++ b/community/2024-01-31-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-01-31
+description: 'wasmCloud community call featuring a Red Badger composed components demo, what WASI 0.2.0 means for wasmCloud, quickstart updates, and wRPC roadmap progress.'
 date: 2024-01-31
 ---
 

--- a/community/2024-02-07-community-meeting.mdx
+++ b/community/2024-02-07-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-02-07
+description: 'wasmCloud community call discussing wasmbus deprecation for 1.0, the wasmcloud-ollama LLM project, and roadmap progress on wRPC and OTEL observability.'
 date: 2024-02-07
 ---
 

--- a/community/2024-02-14-community-meeting.mdx
+++ b/community/2024-02-14-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-02-14
+description: 'wasmCloud community call demoing OTEL traces, logs, and metrics in wasmCloud 1.0, the final countdown to the 0.82 release, and a roadmap update toward 1.0.'
 date: 2024-02-14
 ---
 

--- a/community/2024-02-21-community-meeting.mdx
+++ b/community/2024-02-21-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-02-21
+description: 'wasmCloud community call demoing what is new in the 0.82 release with stable WASI 0.2, a call for community testing, and a roadmap check-in on wRPC progress.'
 date: 2024-02-21
 ---
 

--- a/community/2024-02-27-community-meeting.mdx
+++ b/community/2024-02-27-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-02-27
+description: 'wasmCloud community call demoing components communicating with wRPC over NATS, a wRPC MVP progress check-in, and a quick look at the wasmCloud 1.0 roadmap.'
 date: 2024-02-27
 ---
 

--- a/community/2024-03-06-community-meeting.mdx
+++ b/community/2024-03-06-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-03-06
+description: 'wasmCloud community call demoing the policy service with Open Policy Agent, a wRPC MVP check-in with the Redis provider, and 1.0 roadmap progress.'
 date: 2024-03-06
 ---
 

--- a/community/2024-03-13-community-meeting.mdx
+++ b/community/2024-03-13-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-03-13
+description: 'wasmCloud community call covering the 1.0.0-alpha.1 release, renaming actor to component, a roadmap check-in, and upcoming WASM I/O and KubeCon EU conferences.'
 date: 2024-03-13
 ---
 

--- a/community/2024-03-20-community-meeting.mdx
+++ b/community/2024-03-20-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-03-20
+description: 'Short wasmCloud community call streaming live from KubeCon CloudNativeCon EU in Paris with a look at wasmCloud 1.0 release candidates and how to get involved.'
 date: 2024-03-20
 ---
 

--- a/community/2024-03-27-community-meeting.mdx
+++ b/community/2024-03-27-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-03-27
+description: 'wasmCloud community call covering the wasmCloud 1.0 release update with wRPC and wadm finalization plus the open-sourced wasmCloud Kubernetes Operator.'
 date: 2024-03-27
 ---
 

--- a/community/2024-04-03-community-meeting.mdx
+++ b/community/2024-04-03-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-04-03
+description: 'wasmCloud community call demoing the 1.0 wadm manifest format with WIT-based links, capability providers in GHCR, and a final 1.0 roadmap check-in.'
 date: 2024-04-03
 ---
 

--- a/community/2024-04-10-community-meeting.mdx
+++ b/community/2024-04-10-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-04-10
+description: 'wasmCloud community call with a 1.0 quickstart showcase, performance improvements, globally scaled components, and a call to test the 1.0 release candidate.'
 date: 2024-04-10
 ---
 

--- a/community/2024-04-17-community-meeting.mdx
+++ b/community/2024-04-17-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-04-17
+description: 'wasmCloud community call celebrating the wasmCloud 1.0 release with a roadmap recap, a neovim WIT syntax highlighting PR, and a Postgres interface RFC.'
 date: 2024-04-17
 ---
 

--- a/community/2024-04-24-community-meeting.mdx
+++ b/community/2024-04-24-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-04-24
+description: 'wasmCloud community call hackathon showcase featuring Ollama, a messaging chatbot, Wasm workspaces, and wash CLI plugins for the WebAssembly platform.'
 date: 2024-04-24
 ---
 

--- a/community/2024-05-01-community-meeting.mdx
+++ b/community/2024-05-01-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-05-01
+description: 'wasmCloud community call demoing wash plugins part 2 with full lifecycle management plus a workshop on the next Q2 roadmap and documentation priorities.'
 date: 2024-05-01
 ---
 

--- a/community/2024-05-08-community-meeting.mdx
+++ b/community/2024-05-08-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-05-08
+description: 'wasmCloud community call demoing the wRPC Go implementation, a refreshed Golang provider SDK, and a Q2 roadmap review for the WebAssembly application platform.'
 date: 2024-05-08
 ---
 

--- a/community/2024-05-15-community-meeting.mdx
+++ b/community/2024-05-15-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-05-15
+description: 'wasmCloud community call featuring Wolfi-based SigStore signing, GitHub build attestations, wRPC Go support for streams and futures, and an H2 roadmap update.'
 date: 2024-05-15
 ---
 

--- a/community/2024-05-22-community-meeting.mdx
+++ b/community/2024-05-22-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-05-22
+description: 'wasmCloud community call covering the Postgres interface RFC and provider implementation, wrpc-keyvalue-nats CLI, Golang provider SDK, and a roadmap review.'
 date: 2024-05-22
 ---
 

--- a/community/2024-05-29-community-meeting.mdx
+++ b/community/2024-05-29-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-05-29
+description: 'wasmCloud community call demoing the WIT-based Postgres provider, an update on CNCF Incubation, the new wasmCloud secrets RFC, and using the wadm API.'
 date: 2024-05-29
 ---
 

--- a/community/2024-06-05-community-meeting.mdx
+++ b/community/2024-06-05-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-06-05
+description: 'wasmCloud community call featuring a Couchbase KV provider demo, a Golang custom provider template, and wash 0.29 features for the WebAssembly platform.'
 date: 2024-06-05
 ---
 

--- a/community/2024-06-12-community-meeting.mdx
+++ b/community/2024-06-12-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-06-12
+description: 'wasmCloud community call demoing the wasmCloud Kubernetes Operator deployment, plus discussion of WASI messaging and tracing/OTLP propagation fixes in the host.'
 date: 2024-06-12
 ---
 

--- a/community/2024-06-20-community-meeting.mdx
+++ b/community/2024-06-20-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-06-20
+description: 'wasmCloud community call featuring a community NATS key-value provider demo and a discussion of wasi-keyvalue buckets, stores, and wasmCloud link names.'
 date: 2024-06-20
 ---
 

--- a/community/2024-06-26-community-meeting.mdx
+++ b/community/2024-06-26-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-06-26
+description: 'wasmCloud community call demoing secrets support in wasmCloud with a NATS KV backend, a Q2 roadmap check-in, and wRPC updates including a new QUIC transport.'
 date: 2024-06-26
 ---
 

--- a/community/2024-07-02-community-meeting.mdx
+++ b/community/2024-07-02-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-07-02
+description: 'wasmCloud community call covering the Q3 roadmap with secrets management, wash app dev workflow, built-in HTTP server plans, and TinyGo wasip2 support landing.'
 date: 2024-07-02
 ---
 

--- a/community/2024-07-10-community-meeting.mdx
+++ b/community/2024-07-10-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-07-10
+description: 'wasmCloud community call demoing the wasmcloud-operator quickstart and examples, plus TinyGo wasip2 component compilation news for WebAssembly applications.'
 date: 2024-07-10
 ---
 

--- a/community/2024-07-17-community-meeting.mdx
+++ b/community/2024-07-17-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community Meeting - 2024-07-17
+description: 'Short wasmCloud community call featuring a wasmCloud link secrets demo, the wash dev v2 RFC, and a Q3 roadmap discussion for the WebAssembly platform.'
 date: 2024-07-17
 ---
 

--- a/community/2024-07-24-community-meeting.mdx
+++ b/community/2024-07-24-community-meeting.mdx
@@ -1,5 +1,6 @@
 ---
 title: 2024-07-24 Community Meeting
+description: 'wasmCloud community call demoing the secrets-nats-kv backend CLI with wash secret, Go provider SDK secrets support, and wasi-messaging 0.2.0-draft updates.'
 date: 2024-07-24
 ---
 

--- a/community/2024-07-31-community-meeting.mdx
+++ b/community/2024-07-31-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-07-31'
 title: 'Meeting Agenda - 2024-07-31'
+description: 'wasmCloud community call featuring a Kubernetes secrets demo with External Secrets, 1.1 beta testing, and WASI 0.2.1 feature gates with @since and @unstable.'
 ---
 
 ## Agenda

--- a/community/2024-08-07-community-meeting.mdx
+++ b/community/2024-08-07-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-08-07'
 title: 'Meeting Agenda - 2024-08-07'
+description: 'wasmCloud community call demoing wash and wadm developer experience improvements, the wash 0.30.0 release with wasmcloud-operator updates, and the 1.1 launch.'
 ---
 
 ## Agenda

--- a/community/2024-08-14-community-meeting.mdx
+++ b/community/2024-08-14-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-08-14'
 title: 'Meeting Agenda - 2024-08-14'
+description: 'wasmCloud community call demoing an improved wash spy for component debugging, Provider SDK updates in Rust and Go, and new Wasm language support for MoonBit.'
 ---
 
 ## Agenda

--- a/community/2024-08-21-community-meeting.mdx
+++ b/community/2024-08-21-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-08-21'
 title: 'Meeting Agenda - 2024-08-21'
+description: 'wasmCloud community call demoing streaming with Blobby over wasi-blobstore and wasi-http plus a preview of wasmCloud Innovation Day on September 18 with talks.'
 ---
 
 ## Agenda

--- a/community/2024-08-28-community-meeting.mdx
+++ b/community/2024-08-28-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-08-28'
 title: 'Meeting Agenda - 2024-08-28'
+description: 'wasmCloud community call showcasing the 1.2 release and wash 0.31 with config updates, blobstore streaming, a Q3 roadmap check-in, and Innovation Day news.'
 ---
 
 ## Agenda

--- a/community/2024-09-04-community-meeting.mdx
+++ b/community/2024-09-04-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-09-04'
 title: 'Meeting Agenda - 2024-09-04'
+description: 'wasmCloud community call demoing the wash --watch flag and sorted output, the wash 0.32 release, plus a discussion of component memory limits with wasmtime.'
 ---
 
 ## Agenda

--- a/community/2024-09-11-community-meeting.mdx
+++ b/community/2024-09-11-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-09-11'
 title: 'Meeting Agenda - 2024-09-11'
+description: 'wasmCloud community call demoing Go component testing with west, the new component-sdk-go for idiomatic Go components, and Q3 roadmap progress on resources.'
 ---
 
 ## Agenda

--- a/community/2024-09-18-community-meeting.mdx
+++ b/community/2024-09-18-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-09-18'
 title: 'Meeting Agenda - 2024-09-18'
+description: 'Short wasmCloud community call alongside Innovation Day with a tour of the wasmcloud-component crate, how to become a contributor, and a look ahead to Q4 plans.'
 ---
 
 ## Agenda

--- a/community/2024-09-25-community-meeting.mdx
+++ b/community/2024-09-25-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-09-25'
 title: 'Meeting Agenda - 2024-09-25'
+description: 'wasmCloud community call demoing Go component testing with WAdge, a Backstage plugin beta, wash build target changes to wasip1, and Q4 roadmap call for issues.'
 ---
 
 ## Agenda

--- a/community/2024-10-02-community-meeting.mdx
+++ b/community/2024-10-02-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-10-02'
 title: 'Meeting Agenda - 2024-10-02'
+description: 'wasmCloud community call demoing Go component IDE debugging, a wasmCloud LLaVA app with LLM and vision, wkg packaging tooling, and the Q4 2024 roadmap.'
 ---
 
 ## Agenda

--- a/community/2024-10-09-community-meeting.mdx
+++ b/community/2024-10-09-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-10-09'
 title: 'Meeting Agenda - 2024-10-09'
+description: 'wasmCloud community call dedicated to Q4 community roadmapping with a Q3 retrospective, docs improvements, CLI autocompletion, and Hacktoberfest issue picks.'
 ---
 
 ## Agenda

--- a/community/2024-10-16-community-meeting.mdx
+++ b/community/2024-10-16-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-10-16'
 title: 'Meeting Agenda - 2024-10-16'
+description: 'wasmCloud community call covering wasmCloud 1.3 features and link validation, embedding wasmcloud and wadm in wash, and Q4 roadmap progress for the project.'
 ---
 
 ## Agenda

--- a/community/2024-10-23-community-meeting.mdx
+++ b/community/2024-10-23-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-10-23'
 title: 'Meeting Agenda - 2024-10-23'
+description: 'wasmCloud community call featuring an updated TypeScript password checker example, a new wash dev quickstart, and discussion of removing Python from quickstart.'
 ---
 
 ## Agenda

--- a/community/2024-10-30-community-meeting.mdx
+++ b/community/2024-10-30-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-10-30'
 title: 'Meeting Agenda - 2024-10-30'
+description: 'wasmCloud community call demoing a Leptos full-stack Rust framework on Wasm, the wasmcloud-component HTTP wrappers, the wkg WIT package manager, and Q4 plans.'
 ---
 
 ## Agenda

--- a/community/2024-11-06-community-meeting.mdx
+++ b/community/2024-11-06-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-11-06'
 title: 'Meeting Agenda - 2024-11-06'
+description: 'wasmCloud community call demoing wash dev interface overrides, a discussion of Windows as a development target, and a Contribfest preview ahead of KubeCon NA.'
 ---
 
 ## Agenda

--- a/community/2024-11-13-community-meeting.mdx
+++ b/community/2024-11-13-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-11-13'
 title: 'Meeting Agenda - 2024-11-13'
+description: 'wasmCloud community call streaming live from KubeCon NA 2024 with a wash dev demo introducing component capability swapping after the CNCF Incubating promotion.'
 ---
 
 ## Agenda

--- a/community/2024-11-20-community-meeting.mdx
+++ b/community/2024-11-20-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-11-20'
 title: 'Meeting Agenda - 2024-11-20'
+description: 'Short wasmCloud community call featuring an OAuth2 Go Wasm component demo and a wrap-up of KubeCon NA and WasmCon 2024 highlights for the project community.'
 ---
 
 ## Agenda

--- a/community/2024-11-27-community-meeting.mdx
+++ b/community/2024-11-27-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-11-27'
 title: 'Meeting Agenda - 2024-11-27'
+description: 'wasmCloud community call covering securing supply chains with SBOMs using syft and grype, a Q4 roadmap check-in, and a recap of WasmCon and KubeCon playlists.'
 ---
 
 ## Agenda

--- a/community/2024-12-04-community-meeting.mdx
+++ b/community/2024-12-04-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-12-04'
 title: 'Meeting Agenda - 2024-12-04'
+description: 'wasmCloud community call demoing builtin-http and builtin-messaging providers for sub-millisecond performance, OTEL trace hierarchy, and host feature flags.'
 ---
 
 ## Agenda

--- a/community/2024-12-11-community-meeting.mdx
+++ b/community/2024-12-11-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-12-11'
 title: 'Meeting Agenda - 2024-12-11'
+description: 'wasmCloud community call demoing a Testbed wasmCloud benchmarking framework, Enzo Nocera''s Leptos WASI 0.2 contribution, and a Q4 roadmap check-in for 2024.'
 ---
 
 ## Agenda

--- a/community/2024-12-18-community-meeting.mdx
+++ b/community/2024-12-18-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-12-18'
 title: 'Meeting Agenda - 2024-12-18'
+description: 'wasmCloud community call demoing a Go banking app with GitHub OAuth and embedded UI, a Q4 roadmap check-in, and a heads-up on next week''s holiday meeting slot.'
 ---
 
 import Admonition from '@theme-original/Admonition';

--- a/community/2024-12-26-community-meeting.mdx
+++ b/community/2024-12-26-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2024-12-26'
 title: 'Meeting Agenda - 2024-12-26'
+description: 'Holiday wasmCloud community call discussing reorganizing wasmCloud project templates by language repo plus a Q1 2025 roadmap planning kickoff for the community.'
 ---
 
 ## Agenda

--- a/community/2025-01-02-community-meeting.mdx
+++ b/community/2025-01-02-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-01-02'
 title: 'Meeting Agenda - 2025-01-02'
+description: 'Short wasmCloud community call kicking off 2025 with a wasmCloud CI iteration demo, scheduling the Q1 roadmap session, and Innovation Day summary content.'
 ---
 
 ## Agenda

--- a/community/2025-01-08-community-meeting.mdx
+++ b/community/2025-01-08-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-01-08'
 title: 'Meeting Agenda - 2025-01-08'
+description: 'wasmCloud community call demoing the wasmCloud/go and wasmCloud/typescript monorepos plus a C2PA content credentials component and Q1 planning kickoff.'
 ---
 
 ## Agenda

--- a/community/2025-01-15-community-meeting.mdx
+++ b/community/2025-01-15-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-01-15'
 title: 'Meeting Agenda - 2025-01-15'
+description: 'wasmCloud community call dedicated to Q1 2025 roadmap planning covering wasi-nn, autocompletion, provenance, cronjob providers, and bundling wasmCloud in wash.'
 ---
 
 ## Agenda

--- a/community/2025-01-22-community-meeting.mdx
+++ b/community/2025-01-22-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-01-22'
 title: 'Meeting Agenda - 2025-01-22'
+description: 'wasmCloud community call welcoming new maintainers and demoing embedded wadm and wasmCloud in wash, a new Helm benchmark chart, and the Q1 roadmap walkthrough.'
 ---
 
 ## Agenda

--- a/community/2025-01-29-community-meeting.mdx
+++ b/community/2025-01-29-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-01-29'
 title: 'Meeting Agenda - 2025-01-29'
+description: 'wasmCloud community call demoing the host supervising capability providers, benchmark data aggregation, the wash 0.38 release, and a Q1 roadmap check-in.'
 ---
 
 ## Agenda

--- a/community/2025-02-05-community-meeting.mdx
+++ b/community/2025-02-05-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-02-05'
 title: 'Meeting Agenda - 2025-02-05'
+description: 'wasmCloud community call discussing a wash plugin RFC and a Workload Identity RFC for SPIFFE-based, secret-less authn across hosts, providers, and components.'
 ---
 
 ## Agenda

--- a/community/2025-02-12-community-meeting.mdx
+++ b/community/2025-02-12-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-02-12'
 title: 'Meeting Agenda - 2025-02-12'
+description: 'wasmCloud community call demoing SPIFFE/SPIRE workload identity, proposing JSONSchema for CloudEvents and structs, and a PR labeler for nicer release notes.'
 ---
 
 ## Agenda

--- a/community/2025-02-19-community-meeting.mdx
+++ b/community/2025-02-19-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-02-19'
 title: 'Meeting Agenda - 2025-02-19'
+description: 'Short wasmCloud community call discussing combining wash cli and wash lib crates plus a rollout/rollback RFC for upgrades and updates of wasmCloud applications.'
 ---
 
 ## Agenda

--- a/community/2025-02-26-community-meeting.mdx
+++ b/community/2025-02-26-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-02-26'
 title: 'Meeting Agenda - 2025-02-26'
+description: 'wasmCloud community call demoing custom interface error handling for distributed failures, a KubeCon EU 2025 preview, and a release notes and PR title update.'
 ---
 
 ## Agenda

--- a/community/2025-03-05-community-meeting.mdx
+++ b/community/2025-03-05-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-03-05'
 title: 'Meeting Agenda - 2025-03-05'
+description: 'Short wasmCloud community call covering the wash-cli and wash-lib consolidation PR plus an update on provenance and attestation work for build pipeline trust.'
 ---
 
 ## Agenda

--- a/community/2025-03-12-community-meeting.mdx
+++ b/community/2025-03-12-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-03-12'
 title: 'Meeting Agenda - 2025-03-12'
+description: 'wasmCloud community call demoing wadm config reconciliation speedups, completing the wash-cli and wash-lib merge into a single wash crate, and KubeCon EU news.'
 ---
 
 ## Agenda

--- a/community/2025-03-19-community-meeting.mdx
+++ b/community/2025-03-19-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-03-19'
 title: 'Meeting Agenda - 2025-03-19'
+description: 'wasmCloud community call demoing WebAssembly composition in wash build with WAC plugs and sockets, a virtual components proposal, and wasi-config feedback.'
 ---
 
 ## Agenda

--- a/community/2025-03-26-community-meeting.mdx
+++ b/community/2025-03-26-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-03-26'
 title: 'Meeting Agenda - 2025-03-26'
+description: 'Short wasmCloud community call with a wasi-config update, a look ahead to WASM I/O and KubeCon EU, and a Q1 roadmap check-in plus Q2 planning preview.'
 ---
 
 ## Agenda

--- a/community/2025-04-02-community-meeting.mdx
+++ b/community/2025-04-02-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-04-02'
 title: 'Meeting Agenda - 2025-04-02'
+description: 'wasmCloud community call streaming live from KubeCon EU 2025 in London with a WasmPay cross-border payments demo and a SPIFFE workload identity talk recap.'
 ---
 
 ## Agenda

--- a/community/2025-04-09-community-meeting.mdx
+++ b/community/2025-04-09-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-04-09'
 title: 'Meeting Agenda - 2025-04-09'
+description: 'wasmCloud community call demoing SPIFFE/SPIRE workload identity on Kubernetes plus discussion of WASI compatibility and Helm deployments with multiple NATS.'
 ---
 
 ## Agenda

--- a/community/2025-04-16-community-meeting.mdx
+++ b/community/2025-04-16-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-04-16'
 title: 'Meeting Agenda - 2025-04-16'
+description: 'wasmCloud community call discussing provenance and attestation findings, a demo of NATS compiled to a Wasm P1 module to embed in wash, and Q2 roadmap planning.'
 ---
 
 ## Agenda

--- a/community/2025-04-23-community-meeting.mdx
+++ b/community/2025-04-23-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-04-23'
 title: 'Meeting Agenda - 2025-04-23'
+description: 'wasmCloud community call dedicated to Q2 2025 roadmap planning with priorities for HTTP bugs, wash plugins, washboard with wash dev, and XDG directory support.'
 ---
 
 ## Agenda

--- a/community/2025-04-30-community-meeting.mdx
+++ b/community/2025-04-30-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-04-30'
 title: 'Meeting Agenda - 2025-04-30'
+description: 'wasmCloud community call demoing Hono on Wasm, component instance saturation metrics, host extension traits, and a statement on proposed CNCF NATS.io changes.'
 ---
 
 ## Agenda

--- a/community/2025-05-07-community-meeting.mdx
+++ b/community/2025-05-07-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-05-07'
 title: 'Meeting Agenda - 2025-05-07'
+description: 'Short wasmCloud community call with an update on the joint CNCF/Synadia NATS.io statement, transport-agnostic wRPC plans, and a Q2 2025 roadmap check-in.'
 ---
 
 ## Agenda

--- a/community/2025-05-14-community-meeting.mdx
+++ b/community/2025-05-14-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-05-14'
 title: 'Meeting Agenda - 2025-05-14'
+description: 'wasmCloud community call reviving Docs of the Week with wRPC error handling docs and a TypeScript showcase using the axios HTTP library in Wasm components.'
 ---
 
 ## Agenda

--- a/community/2025-05-21-community-meeting.mdx
+++ b/community/2025-05-21-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-05-21'
 title: 'Meeting Agenda - 2025-05-21'
+description: 'Short wasmCloud community call reflecting on a year of wasmCloud 1.0 with looks ahead to 2.0 plus issue and docs of the week for the WebAssembly platform.'
 ---
 
 ## Agenda

--- a/community/2025-05-28-community-meeting.mdx
+++ b/community/2025-05-28-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-05-28'
 title: 'Meeting Agenda - 2025-05-28'
+description: 'Short wasmCloud community call featuring a wasmtime run with components demo and a Q2 2025 roadmap update for the WebAssembly application platform community.'
 ---
 
 ## Agenda

--- a/community/2025-06-04-community-meeting.mdx
+++ b/community/2025-06-04-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-06-04'
 title: 'Meeting Agenda - 2025-06-04'
+description: 'Short wasmCloud community call featuring Mike''s architecture for a wasmCloud ETL pipeline platform built on WebAssembly components and capability providers.'
 ---
 
 ## Agenda

--- a/community/2025-06-11-community-meeting.mdx
+++ b/community/2025-06-11-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-06-11'
 title: 'Meeting Agenda - 2025-06-11'
+description: 'Short wasmCloud community call demoing a drag-and-drop to ETL pipeline workflow on wasmCloud with a consolidated NATS reference doc and Q3 2025 roadmap kickoff.'
 ---
 
 ## Agenda

--- a/community/2025-06-18-community-meeting.mdx
+++ b/community/2025-06-18-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-06-18'
 title: 'Meeting Agenda - 2025-06-18'
+description: 'wasmCloud community call demoing wasmcloud:postgres/transaction support plus a discussion of monorepo trade-offs, Nix actions, and CI complexity for the repo.'
 ---
 
 ## Agenda

--- a/community/2025-06-25-community-meeting.mdx
+++ b/community/2025-06-25-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-06-25'
 title: 'Meeting Agenda - 2025-06-25'
+description: 'wasmCloud community call featuring Elizabeth Gilbert''s whamm Wasm instrumentation DSL for dynamic analysis and a discussion of flaky tests and PR bankruptcy.'
 ---
 
 ## Agenda

--- a/community/2025-07-09-community-meeting.mdx
+++ b/community/2025-07-09-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-07-09'
 title: 'Meeting Agenda - 2025-07-09'
+description: 'wasmCloud community call for Q3 2025 roadmap planning covering in-process component calls, removing wascap and nkeys, shared providers, and wRPC servers.'
 ---
 
 ## Agenda

--- a/community/2025-07-16-community-meeting.mdx
+++ b/community/2025-07-16-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-07-16'
 title: 'Meeting Agenda - 2025-07-16'
+description: 'wasmCloud community call introducing wash: The Wasm Shell, a leaner plugin-driven CLI for component dev, plus a Q3 roadmap recap for the WebAssembly platform.'
 ---
 
 ## Agenda

--- a/community/2025-07-23-community-meeting.mdx
+++ b/community/2025-07-23-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-07-23'
 title: 'Meeting Agenda - 2025-07-23'
+description: 'Short wasmCloud community call demoing the setup-wash-action for GitHub Actions plus clap integration tips for the new wash Wasm Shell CLI for component devs.'
 ---
 
 ## Agenda

--- a/community/2025-07-30-community-meeting.mdx
+++ b/community/2025-07-30-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-07-30'
 title: 'Meeting Agenda - 2025-07-30'
+description: 'Short wasmCloud community call demoing a wash OAuth plugin, the wash contribution path back into wasmCloud, and celebrating 2,000 GitHub stars for the project.'
 ---
 
 ## Agenda

--- a/community/2025-08-13-community-meeting.mdx
+++ b/community/2025-08-13-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-08-13'
 title: 'Meeting Agenda - 2025-08-13'
+description: 'Short wasmCloud community call featuring Yordis on event sourcing with WebAssembly components and Wasm resources for opaque event and command handle types.'
 ---
 
 ## Agenda

--- a/community/2025-08-20-community-meeting.mdx
+++ b/community/2025-08-20-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-08-20'
 title: 'Meeting Agenda - 2025-08-20'
+description: 'wasmCloud community call covering a good first issues blog, the wash 1.0 beta Wasm Shell release, the setup-wash GitHub Action, and the wasmCloud 1.9 release.'
 ---
 
 ## Agenda

--- a/community/2025-09-03-community-meeting.mdx
+++ b/community/2025-09-03-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-09-03'
 title: 'Meeting Agenda - 2025-09-03'
+description: 'wasmCloud community call discussing in-process component-to-component calls for sub-microsecond latency, reducing host API surface, and wash CLI completions.'
 ---
 
 ## Agenda

--- a/community/2025-09-10-community-meeting.mdx
+++ b/community/2025-09-10-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-09-10'
 title: 'Meeting Agenda - 2025-09-10'
+description: 'Short wasmCloud community call with a status update on the Q3 2025 roadmap and a look ahead to Q4 planning for the WebAssembly application platform community.'
 ---
 
 ## Agenda

--- a/community/2025-09-17-community-meeting.mdx
+++ b/community/2025-09-17-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-09-17'
 title: 'Meeting Agenda - 2025-09-17'
+description: 'wasmCloud community call presenting the consolidated wasmcloud crate, a simplified workload-based Host API, host plugins for built-ins, and wasmCloud next.'
 ---
 
 ## Agenda

--- a/community/2025-09-24-community-meeting.mdx
+++ b/community/2025-09-24-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-09-24'
 title: 'Meeting Agenda - 2025-09-24'
+description: 'Short wasmCloud community call covering setup-wash-action enhancements, wash good first issues, and a new Kubernetes runtime-operator on the Workload API.'
 ---
 
 ## Agenda

--- a/community/2025-10-01-community-meeting.mdx
+++ b/community/2025-10-01-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-10-01'
 title: 'Meeting Agenda - 2025-10-01'
+description: 'Short wasmCloud community call presenting a GitHub Actions toolkit for wash with attestations, a wash non-interactive mode, and volume mounts for wash plugins.'
 ---
 
 ## Agenda

--- a/community/2025-10-08-community-meeting.mdx
+++ b/community/2025-10-08-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-10-08'
 title: 'Meeting Agenda - 2025-10-08'
+description: 'wasmCloud community call demoing a TypeScript MCP server component, an OpenAPI-to-MCP wash plugin, StarlingMonkey for JS in Wasm, and Q3/Q4 roadmap planning.'
 ---
 
 ## Agenda

--- a/community/2025-10-22-community-meeting.mdx
+++ b/community/2025-10-22-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-10-22'
 title: 'Meeting Agenda - 2025-10-22'
+description: 'wasmCloud community call demoing wasmCP for composing MCP tooling across Rust, Python, and TypeScript plus the new long-running wasmCloud services concept.'
 ---
 
 ## Agenda

--- a/community/2025-10-29-community-meeting.mdx
+++ b/community/2025-10-29-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-10-29'
 title: 'Meeting Agenda - 2025-10-29'
+description: 'Short wasmCloud community call announcing the new CNCF community calendar, demoing the openapi2mcp Wasm Shell plugin, and a WASI P3 JCO async progress update.'
 ---
 
 ## Agenda

--- a/community/2025-11-05-community-meeting.mdx
+++ b/community/2025-11-05-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-11-05'
 title: 'Meeting Agenda - 2025-11-05'
+description: 'wasmCloud community call demoing the wasmCloud v2 next host with Kubernetes runtime operator orchestration, the road to v2.0.0-rc1, and a WASI P3 update.'
 ---
 
 ## Agenda

--- a/community/2025-11-12-community-meeting.mdx
+++ b/community/2025-11-12-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-11-12'
 title: 'Meeting Agenda - 2025-11-12'
+description: 'Short wasmCloud community call for the weekly project check-in covering ongoing wasmCloud v2 work, WebAssembly ecosystem updates, and community contributions.'
 ---
 
 ## Agenda

--- a/community/2025-11-19-community-meeting.mdx
+++ b/community/2025-11-19-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-11-19'
 title: 'Meeting Agenda - 2025-11-19'
+description: 'wasmCloud community call demoing the v2 Helm install on Kubernetes, a new v2 HTTP implementation in wash, plus Wasmtime 38 to 40 progress for WASI P3 alignment.'
 ---
 
 ## Agenda

--- a/community/2025-11-26-community-meeting.mdx
+++ b/community/2025-11-26-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-11-26'
 title: 'Meeting Agenda - 2025-11-26'
+description: 'Short wasmCloud community call covering wasmCloud V2 docs updates with a V1 to V2 migration guide, modern C++ wit-http bindings, and gRPC/protobuf integration.'
 ---
 
 ## Agenda

--- a/community/2025-12-03-community-meeting.mdx
+++ b/community/2025-12-03-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-12-03'
 title: 'Meeting Agenda - 2025-12-03'
+description: 'Short wasmCloud community call demoing the new wasmCloud v2 services concept for stateful long-running workloads alongside the new WASI monorepo move.'
 ---
 
 ## Agenda

--- a/community/2025-12-10-community-meeting.mdx
+++ b/community/2025-12-10-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-12-10'
 title: 'Meeting Agenda - 2025-12-10'
+description: 'Short wasmCloud community call demoing VolumeMounts in wasmCloud v2, an HTTP Ingress discussion, and config changes for the WebAssembly application platform.'
 ---
 
 ## Agenda

--- a/community/2025-12-17-community-meeting.mdx
+++ b/community/2025-12-17-community-meeting.mdx
@@ -1,6 +1,7 @@
 ---
 date: '2025-12-17'
 title: 'Meeting Agenda - 2025-12-17 - wasmCloud v2 RC5 Update'
+description: 'wasmCloud community call on the v2 RC5 release with a refactored wash new from git URL templates, the Linux Foundation Agentic AI Foundation, and 2025 wrap-up.'
 ---
 
 import YouTube from 'react-player/youtube';

--- a/community/2026-01-07-community-meeting-transcript.mdx
+++ b/community/2026-01-07-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-07'
 title: 'Transcript: Path to wasmCloud v2 — RC6 Plan, gRPC, P2→P3 WIT Translator & WIT Map Support'
-description: 'Full transcript of the January 7, 2026 wasmCloud community call covering the RC6 plan, gRPC outbound as default, ossfellow''s P2→P3 WIT translator, and Yordis''s WIT map support work.'
+description: 'Full transcript of the January 7, 2026 wasmCloud community call covering the RC6 plan, an LLM P2 to P3 WIT translator, and WIT map support in wasm-tools.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-07-community-meeting-transcript.mdx
+++ b/community/2026-01-07-community-meeting-transcript.mdx
@@ -127,7 +127,7 @@ I'll refactor the whole approach and make it default instead of modular. I can g
 
 **Lucas Fontes** [23:57](https://youtu.be/WMUanmHsfKI?t=1437)
 
-People involved in PRs in flight: mainly Aditya, myself, Bailey, Pavel, iPhone. About 4-5 of those will have back-and-forth, rest are on me and Bailey. We're getting close to packaging this and getting it out. **RC6 will be our last one before the final release** — we'll call it feature-complete, then go testing testing testing.
+People involved in PRs in flight: mainly Aditya, myself, Bailey, and Pavel. About 4-5 of those will have back-and-forth, rest are on me and Bailey. We're getting close to packaging this and getting it out. **RC6 will be our last one before the final release** — we'll call it feature-complete, then go testing testing testing.
 
 **Schaffa, Frank** [25:27](https://youtu.be/WMUanmHsfKI?t=1527)
 

--- a/community/2026-01-07-community-meeting.mdx
+++ b/community/2026-01-07-community-meeting.mdx
@@ -224,7 +224,7 @@ The compromise emerging in the PR discussion is good: **restart at the runtime l
 
 ## Up Next
 
-Lucas, Bailey, Aditya, Pavel, and iPhone will close the remaining ~8 PRs to land **RC6 by end of the week**. Aditya's gRPC refactor and P3 build guide. Yordis's Wasmtime host bindings for map types and a follow-up on struct support after Luke Wagner addresses the cyclic-type discussion. ossfellow publishes the WIT translator to public GitHub and shares in the Bytecode Alliance Zulip + wasmCloud Slack. The repo migration is staged for after RC6 lands.
+Lucas, Bailey, Aditya, and Pavel will close the remaining ~8 PRs to land **RC6 by end of the week**. Aditya's gRPC refactor and P3 build guide. Yordis's Wasmtime host bindings for map types and a follow-up on struct support after Luke Wagner addresses the cyclic-type discussion. ossfellow publishes the WIT translator to public GitHub and shares in the Bytecode Alliance Zulip + wasmCloud Slack. The repo migration is staged for after RC6 lands.
 
 {/* TODO: Link to next meeting page once created */}
 

--- a/community/2026-01-07-community-meeting.mdx
+++ b/community/2026-01-07-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-07'
 title: 'Path to wasmCloud v2: RC6 Plan, gRPC, P2→P3 WIT Translator & WIT Map Support'
-description: 'wasmCloud community call covering the path to wasmCloud v2 RC6: validating open PRs, NATS authentication, Kubernetes workload IDs, in-memory Blobstore/KV in wash dev, ossfellow''s LLM-driven P2→P3 WIT translator, and Yordis Prieto landing WIT map support in wasm-tools.'
+description: 'wasmCloud community call covering the path to v2 RC6, an LLM-driven P2 to P3 WIT translator, and WIT map support landing in wasm-tools.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-14-community-meeting-transcript.mdx
+++ b/community/2026-01-14-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-14'
 title: 'Transcript: Blobby UI Demo, wash build/dev Project Inference & v2 Service/Component Workloads'
-description: 'Full transcript of the January 14, 2026 wasmCloud community call covering the Blobby UI demo, project inference changes in wash build/dev, persistent dev-loop storage plans, and the v2 Quick Start docs.'
+description: 'Full transcript of the January 14, 2026 wasmCloud community call covering the Blobby UI demo, project inference in wash build/dev, and v2 Quick Start docs.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-14-community-meeting.mdx
+++ b/community/2026-01-14-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-14'
 title: 'Blobby UI Demo, wash build/dev Project Inference & v2 Service/Component Workloads'
-description: 'wasmCloud community call covering Lucas Fontes'' Blobby UI demo, the move from implicit to explicit project inference in wash build/dev with custom build commands and environment variable interpolation, persistent dev-loop storage plans, and the new v2 Quick Start docs.'
+description: 'wasmCloud community call covering the Blobby UI demo, explicit project inference in wash build/dev with custom commands, and the new v2 Quick Start docs.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-21-community-meeting-transcript.mdx
+++ b/community/2026-01-21-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-21'
 title: 'Transcript: wash RC6 — Persistent Blobstore, Virtual TCP Loopback & The Path to wasmCloud v2'
-description: 'Full transcript of the January 21, 2026 wasmCloud community call covering the wash RC6 release: persistent Blobstore/KV, virtual TCP loopback, the QR code example, and the three items remaining before v2.'
+description: 'Full transcript of the January 21, 2026 wasmCloud community call covering the wash RC6 release with persistent Blobstore/KV and virtual TCP loopback.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-21-community-meeting.mdx
+++ b/community/2026-01-21-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-21'
 title: 'wash RC6: Persistent Blobstore, Virtual TCP Loopback & The Path to wasmCloud v2'
-description: 'wasmCloud community call covering wash RC6 — one of the largest release candidates yet — with filesystem-backed Blobstore/KV, virtual TCP loopback between components, a new QR code generator example, and the three remaining issues before the v2 release: Kubernetes identifier, NATS authentication, and gRPC-aware HTTP.'
+description: 'wasmCloud community call covering wash RC6 with filesystem-backed Blobstore/KV, virtual TCP loopback between components, and the path to v2.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-28-community-meeting-transcript.mdx
+++ b/community/2026-01-28-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-28'
 title: 'Transcript: wasmCloud v2 RC7 OTel Demo, Ten Years of Wasm & WASI Socket Forking'
-description: 'Full transcript of the January 28, 2026 wasmCloud community call covering the RC7 OpenTelemetry host plumbing demo, the ten-years-of-Wasm retrospective, and the wasmtime-wasi socket fork.'
+description: 'Full transcript of the January 28, 2026 wasmCloud call covering the RC7 OpenTelemetry demo, a ten-years-of-Wasm retrospective, and socket forking.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-01-28-community-meeting.mdx
+++ b/community/2026-01-28-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-01-28'
 title: 'wasmCloud v2 RC7 OTel Demo, Ten Years of Wasm Retrospective & WASI Socket Forking'
-description: 'wasmCloud community call covering Lucas Fontes'' RC7 OpenTelemetry host plumbing demo with Aspire (local and Kubernetes), Eric''s Ten Years of WebAssembly retrospective, and the wasmtime-wasi socket forking story behind wasmCloud''s service feature.'
+description: 'wasmCloud community call covering the RC7 OpenTelemetry host plumbing demo with Aspire, a Ten Years of WebAssembly retrospective, and WASI socket forking.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-04-community-meeting-transcript.mdx
+++ b/community/2026-02-04-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-04'
 title: 'Transcript: TypeScript Templates, Component Interposition Middleware & A C-Advisor for WebAssembly'
-description: 'Full transcript of the February 4, 2026 wasmCloud community call covering TypeScript template conventions, Elizabeth Gilbert''s component-interposition demo, Marcin Ziółkowski''s C-advisor work, and v2 RC7 status.'
+description: 'Full transcript of the February 4, 2026 wasmCloud community call covering TypeScript template conventions, a component-interposition demo, and v2 RC7.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-04-community-meeting.mdx
+++ b/community/2026-02-04-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-04'
 title: 'TypeScript Templates, Component Interposition Middleware & A C-Advisor for WebAssembly'
-description: 'wasmCloud community call covering Eric''s TypeScript template conventions for v2, Elizabeth Gilbert''s WASI P3 component-interposition middleware demo, Marcin Ziółkowski''s C-advisor for WebAssembly resource measurement, plus v2 RC7 and the wasmCloud repo reconciliation plan.'
+description: 'wasmCloud community call covering TypeScript template conventions for v2, a WASI P3 component-interposition demo, and a C-advisor for WebAssembly.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-11-community-meeting-transcript.mdx
+++ b/community/2026-02-11-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-11'
 title: 'Transcript: WASI OTel Host Plugin Demo, TypeScript Templates & v2 Service Docs'
-description: 'Full transcript of the February 11, 2026 wasmCloud community call covering the WASI OTel host plugin demo, TypeScript templates, expanded service docs, and WASI P3 progress.'
+description: 'Full transcript of the February 11, 2026 wasmCloud community call covering the WASI OTel host plugin demo, TypeScript templates, and WASI P3 progress.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-11-community-meeting.mdx
+++ b/community/2026-02-11-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-11'
 title: 'WASI OTel Host Plugin Demo, TypeScript Templates & v2 Service Docs'
-description: 'wasmCloud community call covering Jeremy''s WASI OTel host plugin live demo with Aspire, Eric''s new TypeScript HTTP templates with KV and Blobstore backends, expanded service and custom-host documentation, and WASI 0.2.10 plus P3 release-candidate progress.'
+description: 'wasmCloud community call covering a WASI OTel host plugin demo with Aspire, new TypeScript HTTP templates with KV and Blobstore, and WASI P3 RC progress.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-18-community-meeting-transcript.mdx
+++ b/community/2026-02-18-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-18'
 title: 'Transcript: wasmCloud v2 Templates with TCP Sockets, Excalidraw Tooling & WASI P3 Update'
-description: 'Full transcript of the February 18, 2026 wasmCloud community call covering v2 templates with TCP socket support, Excalidraw diagram tooling, WASI P3 progress, and the Plumbers Summit preview.'
+description: 'Full transcript of the February 18, 2026 wasmCloud community call covering v2 templates with TCP sockets, Excalidraw tooling, and WASI P3 progress.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-18-community-meeting.mdx
+++ b/community/2026-02-18-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-18'
 title: 'wasmCloud v2 Templates with TCP Sockets, Excalidraw Tooling & WASI P3 Update'
-description: 'wasmCloud community call covering Lucas Fontes'' v2 templates with TCP socket binding and per-workload localhost, Eric''s Excalidraw diagram tooling PR with a Claude skill, WASI P3 release-candidate progress, and a preview of the Bytecode Alliance Plumbers Summit.'
+description: 'wasmCloud community call covering v2 templates with TCP socket binding and per-workload localhost, Excalidraw diagram tooling, and WASI P3 RC progress.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-02-25-community-meeting.mdx
+++ b/community/2026-02-25-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-02-25'
 title: 'Lightweight wasmCloud Wednesday: Bytecode Alliance Plumbers Summit Co-Host'
-description: 'Very short wasmCloud Wednesday on February 25, 2026 — Liam Randall points the community to the concurrent Bytecode Alliance Plumbers Summit live stream and previews Wasm I/O and KubeCon EU.'
+description: 'A short wasmCloud Wednesday pointing the community to the concurrent Bytecode Alliance Plumbers Summit live stream, with Wasm I/O and KubeCon EU previews.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-04-community-meeting-transcript.mdx
+++ b/community/2026-03-04-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-04'
 title: 'Transcript: Bytecode Alliance Summit Recap, Named Interfaces & wasmCloud v2 Plugin Simplification'
-description: 'Full transcript of the March 4, 2026 wasmCloud community call covering the Bytecode Alliance Summit, named interfaces, wash CLI plugin simplification, and the v2 repo migration.'
+description: 'Full transcript of the March 4, 2026 wasmCloud community call covering the Bytecode Alliance Summit, named interfaces, and wash CLI plugin simplification.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-04-community-meeting.mdx
+++ b/community/2026-03-04-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-04'
 title: 'Bytecode Alliance Summit Recap, Named Interfaces & wasmCloud v2 Plugin Simplification'
-description: 'wasmCloud community call covering the Bytecode Alliance Summit road-to-1.0 talks, the new named interfaces feature for wasmCloud v2, the wash CLI plugin system simplification, and the repo migration plan for the v2 release.'
+description: 'wasmCloud community call covering Bytecode Alliance Summit road-to-1.0 talks, the new named interfaces feature for v2, and wash plugin simplification.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-11-community-meeting-transcript.mdx
+++ b/community/2026-03-11-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-11'
 title: 'Transcript: Couchbase Host Plugin Demo, Repo Reorganization & wasmCloud v2 RC8'
-description: 'Full transcript of the March 11, 2026 wasmCloud Wednesday covering the Couchbase host plugin demo, repo reorganization, v2 RC8 progress, and the new v2 templates and examples page.'
+description: 'Full transcript of the March 11, 2026 wasmCloud Wednesday covering the Couchbase host plugin demo, repo reorganization, and v2 RC8 progress.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-11-community-meeting.mdx
+++ b/community/2026-03-11-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-11'
 title: 'Couchbase Host Plugin Demo, Repo Reorganization & wasmCloud v2 RC8'
-description: 'wasmCloud community call covering Jeremy''s Couchbase host plugin demo, the monorepo reorganization moving wash into the main wasmCloud repo, and the v2 release candidate 8 with the final fuel-tracking feature and Wasmtime 42.'
+description: 'wasmCloud community call covering a Couchbase host plugin demo, the monorepo reorganization moving wash into the main repo, and v2 RC8 with fuel tracking.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-18-community-meeting-transcript.mdx
+++ b/community/2026-03-18-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-18'
 title: 'Transcript: wasmCloud v2 Pre-Launch, StarlingMonkey, componentize-js Rewrite & JCO P3 Streams'
-description: 'Full transcript of the March 18, 2026 wasmCloud Wednesday with deep dive on the JavaScript ecosystem: StarlingMonkey, componentize-js, componentize-qjs, JCO streams, and a JavaScript-based WebAssembly host.'
+description: 'Full transcript of the March 18, 2026 wasmCloud Wednesday with a deep dive on the JavaScript ecosystem: StarlingMonkey, componentize-js, and JCO streams.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-18-community-meeting.mdx
+++ b/community/2026-03-18-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-18'
 title: 'wasmCloud v2 Pre-Launch, StarlingMonkey, componentize-js Rewrite & JCO P3 Streams'
-description: 'wasmCloud community call covering the imminent v2 release cut at Wasm I/O Barcelona, a new StarlingMonkey release with Weval re-enabled, the componentize-js Rust rewrite using wit-dylib, componentize-qjs with QuickJS-NG, JCO streams support, and a JavaScript-based component-model host.'
+description: 'wasmCloud community call covering the imminent v2 release at Wasm I/O Barcelona, the componentize-js Rust rewrite with wit-dylib, and JCO P3 streams.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-03-25-community-meeting.mdx
+++ b/community/2026-03-25-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-03-25'
 title: 'wasmCloud v2.0.1 Released, KubeCon EU & Wasmcon Recap'
-description: 'A short wasmCloud Wednesday from KubeCon EU Amsterdam: Jeremy Fleitz announces the v2.0.1 release with the new docs site live, plus a quick update on the booth and WebAssembly''s rising profile at the conference.'
+description: 'A short wasmCloud Wednesday from KubeCon EU Amsterdam announcing the v2.0.1 release with the new docs site live, plus a booth update from the conference.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-01-community-meeting-transcript.mdx
+++ b/community/2026-04-01-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-01'
 title: 'Transcript: wasmCloud v2 Launch, Pod Finalizer Demo, WASI P3 Q2 Planning & Cooperative Threads'
-description: 'Full transcript of the April 1, 2026 wasmCloud community call covering Jeremy''s pod finalizer demo, v2 scheduling architecture, WASI P3 Q2 planning, Tokio/Mio WASI support, JCO progress, and KubeCon takeaways.'
+description: 'Full transcript of the April 1, 2026 wasmCloud community call covering a pod finalizer demo, v2 scheduling architecture, and WASI P3 Q2 planning.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-01-community-meeting.mdx
+++ b/community/2026-04-01-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-01'
 title: 'wasmCloud v2 Launch, Pod Finalizer Demo, WASI P3 Q2 Planning & Cooperative Threads'
-description: 'wasmCloud community call covering Jeremy''s pod finalizer demo cutting reconciliation from 2 minutes to 4 seconds, the wasmCloud v2 launch, WASI P3 Q2 planning, JCO reference implementation, cooperative threads in LLVM, and KubeCon/Wasm IO takeaways.'
+description: 'wasmCloud community call covering a pod finalizer demo cutting reconciliation from 2 minutes to 4 seconds, the v2 launch, and WASI P3 Q2 planning.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-08-community-meeting-transcript.mdx
+++ b/community/2026-04-08-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-08'
 title: 'Transcript: Q2 Roadmap Planning - Componentize the World, WASI P3, Multipath Routing & MCP Sandboxing'
-description: 'Full transcript of the April 8, 2026 wasmCloud Q2 roadmap planning session, covering componentize-the-world, sandboxing MCP, multipath routing, named interfaces, and a richer cron job provider.'
+description: 'Full transcript of the April 8, 2026 wasmCloud Q2 roadmap planning session covering componentize-the-world, MCP sandboxing, and multipath routing.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-08-community-meeting-transcript.mdx
+++ b/community/2026-04-08-community-meeting-transcript.mdx
@@ -294,11 +294,11 @@ That's basically a classic grid-computing problem. So whatever you use for your 
 
 **Aditya** [44:13](https://youtu.be/qXr5bM4JVR8?t=2653)
 
-Currently our host HTTP handler is tightly coupled to Wasmtime's default `send_request` for handling outgoing requests. The initial suggestion was to add the **outgoing request trait** and just implement your own outgoing handle function. That was done for, let's say, if someone wants to add their own custom TLS certification business logic. I think it was Pavel or iPhone. But with the addition of p3 we don't know how that's going to look — I haven't taken a look at the p3 merged code yet. I just wanted to bring this more into the circle.
+Currently our host HTTP handler is tightly coupled to Wasmtime's default `send_request` for handling outgoing requests. The initial suggestion was to add the **outgoing request trait** and just implement your own outgoing handle function. That was done for, let's say, if someone wants to add their own custom TLS certification business logic. I think it was Pavel. But with the addition of p3 we don't know how that's going to look — I haven't taken a look at the p3 merged code yet. I just wanted to bring this more into the circle.
 
 **Bailey Hayes** [45:09](https://youtu.be/qXr5bM4JVR8?t=2709)
 
-I think we need this one. You've run into it, iPhone ran into it, more people will as well. We have an issue or two filed and maybe one or two PRs. If you don't mind linking those all up so we're not forgetting anything — it seems like we tactically got the gRPC problems on, but left a couple other things valuable on the table. We don't have to do it again.
+I think we need this one. You've run into it, Pavel ran into it, more people will as well. We have an issue or two filed and maybe one or two PRs. If you don't mind linking those all up so we're not forgetting anything — it seems like we tactically got the gRPC problems on, but left a couple other things valuable on the table. We don't have to do it again.
 
 So everybody gets four dots — your dots. Put them on your favorite thing. Aditya, you added three more items. Talk to them.
 

--- a/community/2026-04-08-community-meeting.mdx
+++ b/community/2026-04-08-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-08'
 title: 'Q2 Roadmap Planning: Componentize the World, WASI P3, Multipath Routing & MCP Sandboxing'
-description: 'wasmCloud Q2 roadmap planning session covering component ecosystem priorities, WASI P3 readiness, sandboxing MCP workloads, multipath routing, named interfaces, and a richer cron job provider.'
+description: 'wasmCloud Q2 roadmap planning session covering component ecosystem priorities, WASI P3 readiness, MCP sandboxing, and multipath routing.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-15-community-meeting-transcript.mdx
+++ b/community/2026-04-15-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-15'
 title: 'Transcript: WASI P3 Roadmap, wasmCloud Secrets Plugin & NATS Messaging Interface'
-description: 'Full transcript of the April 15, 2026 wasmCloud community call covering the Q2 roadmap with WASI P3 support, wasmCloud secrets plugin, HTTP routing, and NATS messaging interface proposal.'
+description: 'Full transcript of the April 15, 2026 wasmCloud community call covering the Q2 roadmap with WASI P3 support, the secrets plugin, and a NATS interface.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-15-community-meeting.mdx
+++ b/community/2026-04-15-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-15'
 title: 'WASI P3 Roadmap, wasmCloud Secrets Plugin & NATS Messaging Interface'
-description: 'wasmCloud community call covering the Q2 roadmap with full WASI P3 wasm component model support, the new wasmCloud secrets plugin with typed declarative resources, HTTP routing via External ID, and a proposed NATS-specific WIT interface.'
+description: 'wasmCloud community call covering the Q2 roadmap with full WASI P3 support, the new secrets plugin with typed resources, and a NATS-specific WIT interface.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-22-community-meeting-transcript.mdx
+++ b/community/2026-04-22-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-22'
 title: 'Transcript: WASI WebGPU Demo, Train Release Model, HTTP Reuse & NATS Interface Proposal'
-description: 'Full transcript of the April 22, 2026 wasmCloud community call covering WASI WebGPU, the train release model, HTTP reuse benchmarks, component composition, and the NATS WIT interface proposal.'
+description: 'Full transcript of the April 22, 2026 wasmCloud community call covering WASI WebGPU, the train release model, and the NATS WIT interface proposal.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-22-community-meeting-transcript.mdx
+++ b/community/2026-04-22-community-meeting-transcript.mdx
@@ -395,7 +395,7 @@ In terms of feature development, once you started on it and got it shipped, for 
 
 **Yordis Prieto** [1:23:51](https://youtu.be/18VFhGzObdY?t=5031)
 
-I don't sleep — three or four in the morning on my weekends, "fuck it, I need to get this done." I'm so passionate about what you're doing in Bytecode Alliance and wasmCloud, and I'm so committed to make the experience that I have in my head — okay, whatever it takes, I'm just going to keep going. I don't want to trade off — I want exactly a very specific experience.
+I don't sleep — three or four in the morning on my weekends, "I need to get this done." I'm so passionate about what you're doing in Bytecode Alliance and wasmCloud, and I'm so committed to make the experience that I have in my head — okay, whatever it takes, I'm just going to keep going. I don't want to trade off — I want exactly a very specific experience.
 
 **Bailey Hayes** [1:24:38](https://youtu.be/18VFhGzObdY?t=5078)
 

--- a/community/2026-04-22-community-meeting.mdx
+++ b/community/2026-04-22-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-22'
 title: 'WASI WebGPU Demo, Train Release Model, HTTP Reuse & NATS Interface Proposal'
-description: 'wasmCloud community call covering Colin Murphy''s WASI WebGPU demo, a two-week automated train release model, HTTP reuse benchmarks, component composition for workload deploys, and a NATS-native WIT interface proposal.'
+description: 'wasmCloud community call covering a WASI WebGPU demo, a two-week automated train release model, and a NATS-native WIT interface proposal.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-29-community-meeting-transcript.mdx
+++ b/community/2026-04-29-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-29'
 title: 'Transcript: Template Refactor, Workload Config & Environment Variables, WASI TLS'
-description: 'Full transcript of the April 29, 2026 wasmCloud community call covering Rust and TypeScript template refactoring, workload configuration for environment variables and secrets, microbenchmarking, WASI TLS, and host component plugins.'
+description: 'Full transcript of the April 29, 2026 wasmCloud community call covering template refactoring, workload config for env vars and secrets, and WASI TLS.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-04-29-community-meeting.mdx
+++ b/community/2026-04-29-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-04-29'
 title: 'Template Refactor, Workload Config & Environment Variables, WASI TLS'
-description: 'wasmCloud community call covering Rust and TypeScript template refactoring with handler terminology, workload configuration for environment variables and secrets, microbenchmarking infrastructure, WASI TLS proposal, and host component plugin architecture.'
+description: 'wasmCloud community call covering Rust and TypeScript template refactoring, workload config for env vars and secrets, and the WASI TLS proposal.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-05-06-community-meeting-transcript.mdx
+++ b/community/2026-05-06-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-05-06'
 title: 'Transcript: WebGPU Demos, Namespace-Level Hosts & MySQL Connection Pooling'
-description: 'Full transcript of the May 6, 2026 wasmCloud community call covering WebGPU demos with TensorFlow.js, namespace-scoped Kubernetes hosts, workload configuration, and WASI socket connection pooling.'
+description: 'Full transcript of the May 6, 2026 wasmCloud community call covering WebGPU demos with TensorFlow.js, namespace-scoped hosts, and WASI socket pooling.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-05-06-community-meeting.mdx
+++ b/community/2026-05-06-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-05-06'
 title: 'WebGPU Demos, Namespace-Level Hosts & MySQL Connection Pooling'
-description: 'wasmCloud community call featuring WebGPU demos with TensorFlow.js and GPU compute, namespace-scoped Kubernetes host deployment, workload config with secrets, and WASI socket-based MySQL connection pooling.'
+description: 'wasmCloud community call featuring WebGPU demos with TensorFlow.js, namespace-scoped Kubernetes hosts, and WASI socket-based MySQL connection pooling.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-05-13-community-meeting-transcript.mdx
+++ b/community/2026-05-13-community-meeting-transcript.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-05-13'
 title: 'Transcript: wasmCloud CI Hardening, Cache Pre-Compilation & Benchmarking'
-description: 'Full transcript of the May 13, 2026 wasmCloud community call covering CI security hardening, cache artifact pre-compilation, Cranelift vs Pulley benchmarks, and the "Are We Fast Yet?" performance dashboard.'
+description: 'Full transcript of the May 13, 2026 wasmCloud call covering CI security hardening, cache pre-compilation, and the "Are We Fast Yet?" dashboard.'
 keywords:
   - wasmcloud
   - webassembly

--- a/community/2026-05-13-community-meeting.mdx
+++ b/community/2026-05-13-community-meeting.mdx
@@ -1,7 +1,7 @@
 ---
 date: '2026-05-13'
 title: 'wasmCloud CI Hardening, Cache Pre-Compilation & Benchmarking'
-description: 'wasmCloud community call covering CI security hardening with zizmor, OCI artifact publishing, cache artifact pre-compilation pipeline, Cranelift vs Pulley benchmarks, and the new "Are We Fast Yet?" performance dashboard.'
+description: 'wasmCloud community call covering CI security hardening with zizmor, cache artifact pre-compilation, and the new "Are We Fast Yet?" performance dashboard.'
 keywords:
   - wasmcloud
   - webassembly

--- a/docs/contributing/contributing-guide.mdx
+++ b/docs/contributing/contributing-guide.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Contributing Guide"
+title: 'Contributing Guide — wasmCloud Development'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: "How to make contributions"
+description: 'How to contribute to wasmCloud — development workflow, repository structure, code style, DCO requirements, and submitting your first pull request.'
 sidebar_position: 1
 type: 'docs'
 ---

--- a/docs/contributing/contributing-guide.mdx
+++ b/docs/contributing/contributing-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Contributing Guide — wasmCloud Development'
+sidebar_label: 'Contributing Guide'
 hide_title: true
 sidebar_label: 'Contributing Guide'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons

--- a/docs/contributing/contributing-guide.mdx
+++ b/docs/contributing/contributing-guide.mdx
@@ -1,10 +1,14 @@
 ---
 title: 'Contributing Guide — wasmCloud Development'
+hide_title: true
+sidebar_label: 'Contributing Guide'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'How to contribute to wasmCloud — development workflow, repository structure, code style, DCO requirements, and submitting your first pull request.'
 sidebar_position: 1
 type: 'docs'
 ---
+
+# Contributing Guide
 
 wasmCloud projects accept contributions via GitHub pull requests. This document outlines the process
 to help get your contribution accepted.

--- a/docs/contributing/contributing-guide.mdx
+++ b/docs/contributing/contributing-guide.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Contributing Guide — wasmCloud Development'
-sidebar_label: 'Contributing Guide'
 hide_title: true
 sidebar_label: 'Contributing Guide'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons

--- a/docs/contributing/documentation.mdx
+++ b/docs/contributing/documentation.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Documentation"
+title: 'Documentation Contribution Guide'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'How to contribute to documentation'
+description: 'Contribute to wasmCloud documentation — local setup, style guide, MDX conventions, and how to submit doc changes via pull request on GitHub.'
 sidebar_position: 2
 type: 'docs'
 ---

--- a/docs/contributing/documentation.mdx
+++ b/docs/contributing/documentation.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Documentation Contribution Guide'
+sidebar_label: 'Documentation'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'Contribute to wasmCloud documentation — local setup, style guide, MDX conventions, and how to submit doc changes via pull request on GitHub.'
 sidebar_position: 2

--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Contributing"
+title: 'Contributing to wasmCloud — Get Involved'
 toc_max_heading_level: 2
+description: 'Get involved with wasmCloud — contribute code, improve docs, attend community meetings, and help build the leading WebAssembly application platform.'
 ---
 
 ### wasmCloud is a community-driven project and welcomes contributions of all kinds. 

--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -1,8 +1,11 @@
 ---
 title: 'Contributing to wasmCloud — Get Involved'
+hide_title: true
 toc_max_heading_level: 2
 description: 'Get involved with wasmCloud — contribute code, improve docs, attend community meetings, and help build the leading WebAssembly application platform.'
 ---
+
+# Contributing
 
 ### wasmCloud is a community-driven project and welcomes contributions of all kinds. 
 

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'Templates & Examples — Build with wasmCloud'
+hide_title: true
+sidebar_label: "Templates & Examples"
 sidebar_position: 5
 toc_max_heading_level: 4
 description: 'Templates and complete example apps for wasmCloud v2 — scaffold a new WebAssembly component or learn from working code in Rust, Go, TypeScript, and more.'

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Templates & Examples"
+title: 'Templates & Examples — Build with wasmCloud'
 sidebar_position: 5
 toc_max_heading_level: 4
+description: 'Templates and complete example apps for wasmCloud v2 — scaffold a new WebAssembly component or learn from working code in Rust, Go, TypeScript, and more.'
 ---
 
 # Templates & Examples

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,7 +1,7 @@
 ---
-title: "FAQ"
+title: 'FAQ — Frequently Asked Questions'
 sidebar_position: 11
-description: "Frequently asked questions about wasmCloud v2, migration from v1, Kubernetes integration, and getting started."
+description: 'Frequently asked questions about wasmCloud v2, migration from v1, Kubernetes integration, WebAssembly components, and getting started with the platform.'
 ---
 
 This page includes frequently asked questions on wasmCloud v2, including common questions about [migration from wasmCloud v1](#migrating-from-wasmcloud-v1). For a comprehensive migration guide with architecture diagrams and practical instructions, see [Migration to v2](./migration.mdx).

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'FAQ — Frequently Asked Questions'
+hide_title: true
+sidebar_label: "FAQ"
 sidebar_position: 11
 description: 'Frequently asked questions about wasmCloud v2, migration from v1, Kubernetes integration, WebAssembly components, and getting started with the platform.'
 ---
+
+# FAQ
 
 This page includes frequently asked questions on wasmCloud v2, including common questions about [migration from wasmCloud v1](#migrating-from-wasmcloud-v1). For a comprehensive migration guide with architecture diagrams and practical instructions, see [Migration to v2](./migration.mdx).
 

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1,10 +1,14 @@
 ---
 title: 'Glossary — wasmCloud and WebAssembly Terms'
+hide_title: true
+sidebar_label: "Glossary"
 date: 2025-11-01T00:00:00+00:00
 description: 'Glossary of wasmCloud and WebAssembly terminology: components, hosts, capabilities, lattice, providers, interfaces, and the Wasm component model.'
 sidebar_position: 6
 type: 'docs'
 ---
+
+# Glossary
 
 wasmCloud uses several terms with distinct meanings in the context of the platform and the WebAssembly ecosystem.
 

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Glossary'
+title: 'Glossary — wasmCloud and WebAssembly Terms'
 date: 2025-11-01T00:00:00+00:00
-description: 'Glossary'
+description: 'Glossary of wasmCloud and WebAssembly terminology: components, hosts, capabilities, lattice, providers, interfaces, and the Wasm component model.'
 sidebar_position: 6
 type: 'docs'
 ---

--- a/docs/governance.mdx
+++ b/docs/governance.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'Governance — CNCF Incubating Project'
+hide_title: true
+sidebar_label: "Governance"
 sidebar_position: 9
 toc_max_heading_level: 2
 description: 'wasmCloud is a community-led CNCF Incubating project under the Apache 2.0 license. Learn about maintainers, TSC, and the contribution process.'

--- a/docs/governance.mdx
+++ b/docs/governance.mdx
@@ -1,12 +1,13 @@
 ---
-title: "Governance"
+title: 'Governance — CNCF Incubating Project'
 sidebar_position: 9
 toc_max_heading_level: 2
+description: 'wasmCloud is a community-led CNCF Incubating project under the Apache 2.0 license. Learn about maintainers, TSC, and the contribution process.'
 ---
 
 # Governance
 
-### wasmCloud is a community-led open source project Incubating with the Cloud Native Computing Foundation.
+## wasmCloud is a community-led open source project Incubating with the Cloud Native Computing Foundation.
 
 wasmCloud joined the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) as a Sandbox project in 2021 and was accepted as an [Incubating project](https://www.cncf.io/projects/wasmcloud/) in 2024.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 0
 toc_max_heading_level: 2
 title: 'What is wasmCloud? — WebAssembly Platform'
+hide_title: true
+sidebar_label: "What is wasmCloud?"
 description: 'wasmCloud is the leading WebAssembly application platform for cloud-native distributed apps. Run secure Wasm workloads on Kubernetes, edge, or any cloud.'
 ---
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,7 +9,7 @@ description: 'wasmCloud is the leading WebAssembly application platform for clou
 
 # wasmCloud
 
-## wasmCloud is a cloud native platform for running WebAssembly workloads across any cloud, Kubernetes, datacenter, or edge.
+### wasmCloud is a cloud native platform for running WebAssembly workloads across any cloud, Kubernetes, datacenter, or edge.
 
 Using wasmCloud, you can run workloads like microservices, functions, and agents as ultra-dense, deny-by-default **bytecode sandboxes** that are far more secure and efficient than traditional containers, *without* changing your operational model. 
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,12 +1,13 @@
 ---
 sidebar_position: 0
 toc_max_heading_level: 2
-title: "What is wasmCloud?"
+title: 'What is wasmCloud? — WebAssembly Platform'
+description: 'wasmCloud is the leading WebAssembly application platform for cloud-native distributed apps. Run secure Wasm workloads on Kubernetes, edge, or any cloud.'
 ---
 
 # wasmCloud
 
-### wasmCloud is a cloud native platform for running WebAssembly workloads across any cloud, Kubernetes, datacenter, or edge.
+## wasmCloud is a cloud native platform for running WebAssembly workloads across any cloud, Kubernetes, datacenter, or edge.
 
 Using wasmCloud, you can run workloads like microservices, functions, and agents as ultra-dense, deny-by-default **bytecode sandboxes** that are far more secure and efficient than traditional containers, *without* changing your operational model. 
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'Install wasmCloud — CLI and Kubernetes'
+sidebar_label: "Installation"
+hide_title: true
 sidebar_position: 1
 description: 'Install the wash CLI and deploy wasmCloud to Kubernetes for running secure WebAssembly components across any cloud, datacenter, or edge environment.'
 ---

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Installation'
+title: 'Install wasmCloud — CLI and Kubernetes'
 sidebar_position: 1
+description: 'Install the wash CLI and deploy wasmCloud to Kubernetes for running secure WebAssembly components across any cloud, datacenter, or edge environment.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/kubernetes-operator/api-reference.md
+++ b/docs/kubernetes-operator/api-reference.md
@@ -1,9 +1,13 @@
 ---
 title: 'API Reference — wasmCloud Kubernetes Operator'
+title: 'API Reference — wasmCloud Kubernetes Operator'
+hide_title: true
 sidebar_label: 'API Reference'
 sidebar_position: 3
 description: 'Full API reference for the wasmCloud Kubernetes operator — every Custom Resource Definition, field, and configuration option used to run Wasm workloads.'
 ---
+
+# API Reference
 
 ## Packages
 - [runtime.wasmcloud.dev/v1alpha1](#runtimewasmclouddevv1alpha1)

--- a/docs/kubernetes-operator/api-reference.md
+++ b/docs/kubernetes-operator/api-reference.md
@@ -1,6 +1,5 @@
 ---
 title: 'API Reference — wasmCloud Kubernetes Operator'
-title: 'API Reference — wasmCloud Kubernetes Operator'
 hide_title: true
 sidebar_label: 'API Reference'
 sidebar_position: 3

--- a/docs/kubernetes-operator/api-reference.md
+++ b/docs/kubernetes-operator/api-reference.md
@@ -1,6 +1,7 @@
 ---
-title: "API Reference"
+title: 'API Reference — wasmCloud Kubernetes Operator'
 sidebar_position: 3
+description: 'Full API reference for the wasmCloud Kubernetes operator — every Custom Resource Definition, field, and configuration option used to run Wasm workloads.'
 ---
 
 ## Packages

--- a/docs/kubernetes-operator/api-reference.md
+++ b/docs/kubernetes-operator/api-reference.md
@@ -1,5 +1,6 @@
 ---
 title: 'API Reference — wasmCloud Kubernetes Operator'
+sidebar_label: 'API Reference'
 sidebar_position: 3
 description: 'Full API reference for the wasmCloud Kubernetes operator — every Custom Resource Definition, field, and configuration option used to run Wasm workloads.'
 ---

--- a/docs/kubernetes-operator/crds.mdx
+++ b/docs/kubernetes-operator/crds.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Custom Resource Definitions (CRDs)"
+title: 'Custom Resource Definitions (CRDs)'
 sidebar_position: 2
+description: 'Reference for wasmCloud Custom Resource Definitions on Kubernetes — Host, Workload, WorkloadDeployment, and related CRDs that drive the platform.'
 ---
 
 When deployed to Kubernetes, the core primitives of wasmCloud are represented by [**custom resources definitions (CRDs)**](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'wasmCloud on Kubernetes — Introduction'
+title: 'WebAssembly on Kubernetes — wasmCloud Operator'
 sidebar_position: 1
 toc_max_heading_level: 2
-description: 'Run WebAssembly workloads on Kubernetes with the wasmCloud operator. Native CRDs, Helm-based install, and integration with your existing cluster.'
+description: 'Run WebAssembly on Kubernetes with the wasmCloud operator — native CRDs, Helm-based install, and ergonomic integration with your existing K8s cluster.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/kubernetes-operator/index.mdx
+++ b/docs/kubernetes-operator/index.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Introduction"
+title: 'wasmCloud on Kubernetes — Introduction'
 sidebar_position: 1
 toc_max_heading_level: 2
+description: 'Run WebAssembly workloads on Kubernetes with the wasmCloud operator. Native CRDs, Helm-based install, and integration with your existing cluster.'
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Kubernetes Operator
 
-### The wasmCloud operator makes it easy to run wasmCloud and WebAssembly workloads on Kubernetes.
+## The wasmCloud operator makes it easy to run wasmCloud and WebAssembly workloads on Kubernetes.
 
 We use the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to run wasmCloud on Kubernetes, leveraging the orchestrator to schedule wasmCloud infrastructure and workloads.
 

--- a/docs/kubernetes-operator/operator-manual/cicd.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'CI/CD and GitOps for wasmCloud'
+sidebar_label: 'CI/CD and GitOps'
 sidebar_position: 2
 description: 'Build CI/CD and GitOps pipelines for wasmCloud — publish components to OCI registries, roll out to Kubernetes, and integrate with Argo CD or Flux.'
 ---

--- a/docs/kubernetes-operator/operator-manual/cicd.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd.mdx
@@ -1,6 +1,7 @@
 ---
-title: "CI/CD and GitOps"
+title: 'CI/CD and GitOps for wasmCloud'
 sidebar_position: 2
+description: 'Build CI/CD and GitOps pipelines for wasmCloud — publish components to OCI registries, roll out to Kubernetes, and integrate with Argo CD or Flux.'
 ---
 
 ## Overview

--- a/docs/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
+++ b/docs/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Filesystems and Volumes"
+title: 'Filesystems and Volumes for Wasm Workloads'
+description: 'Mount Kubernetes volumes into wasmCloud WebAssembly workloads — preopened filesystems, WASI file access, and supported volume types on the platform.'
 ---
 
 ## Overview

--- a/docs/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
+++ b/docs/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Filesystems and Volumes for Wasm Workloads'
+sidebar_label: 'Filesystems and Volumes'
 description: 'Mount Kubernetes volumes into wasmCloud WebAssembly workloads — preopened filesystems, WASI file access, and supported volume types on the platform.'
 ---
 

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -2,7 +2,6 @@
 title: 'Helm Values Reference — runtime-operator'
 sidebar_label: 'Helm Values Reference'
 hide_title: true
-sidebar_label: 'Helm Values Reference'
 description: 'Commonly-used configuration values for the wasmCloud runtime-operator Helm chart — image overrides, namespaces, RBAC, and Kubernetes deployment options.'
 sidebar_position: 3
 ---

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Helm Values Reference'
-description: 'Commonly-used configuration values for the wasmCloud runtime-operator Helm chart'
+title: 'Helm Values Reference — runtime-operator'
+description: 'Commonly-used configuration values for the wasmCloud runtime-operator Helm chart — image overrides, namespaces, RBAC, and Kubernetes deployment options.'
 sidebar_position: 3
 ---
 

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'Helm Values Reference — runtime-operator'
+hide_title: true
+sidebar_label: 'Helm Values Reference'
 description: 'Commonly-used configuration values for the wasmCloud runtime-operator Helm chart — image overrides, namespaces, RBAC, and Kubernetes deployment options.'
 sidebar_position: 3
 ---
+
+# Helm Values Reference
 
 This page documents the configuration values you are most likely to override when installing the [`runtime-operator` Helm chart](https://github.com/wasmCloud/wasmCloud/tree/main/charts/runtime-operator). For the authoritative list of every value the chart supports, run:
 

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Helm Values Reference — runtime-operator'
+sidebar_label: 'Helm Values Reference'
 hide_title: true
 sidebar_label: 'Helm Values Reference'
 description: 'Commonly-used configuration values for the wasmCloud runtime-operator Helm chart — image overrides, namespaces, RBAC, and Kubernetes deployment options.'

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -2,7 +2,6 @@
 title: 'Lightweight Deployment for wasmCloud on K8s'
 sidebar_label: 'Lightweight Deployment'
 hide_title: true
-sidebar_label: 'Lightweight Deployment'
 sidebar_position: 1
 toc_max_heading_level: 2
 description: 'Deploy wasmCloud on Kubernetes with a minimal footprint — slim install, reduced RBAC, and resource-efficient configuration for edge and small clusters.'

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Lightweight Deployment for wasmCloud on K8s'
+sidebar_label: 'Lightweight Deployment'
 hide_title: true
 sidebar_label: 'Lightweight Deployment'
 sidebar_position: 1

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Lightweight Deployment"
+title: 'Lightweight Deployment for wasmCloud on K8s'
 sidebar_position: 1
 toc_max_heading_level: 2
+description: 'Deploy wasmCloud on Kubernetes with a minimal footprint — slim install, reduced RBAC, and resource-efficient configuration for edge and small clusters.'
 ---
 
 ### Run a complete, lightweight wasmCloud stack using K3s and Docker Compose.

--- a/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
+++ b/docs/kubernetes-operator/operator-manual/lightweight-deployments.mdx
@@ -1,9 +1,13 @@
 ---
 title: 'Lightweight Deployment for wasmCloud on K8s'
+hide_title: true
+sidebar_label: 'Lightweight Deployment'
 sidebar_position: 1
 toc_max_heading_level: 2
 description: 'Deploy wasmCloud on Kubernetes with a minimal footprint — slim install, reduced RBAC, and resource-efficient configuration for edge and small clusters.'
 ---
+
+# Lightweight Deployment
 
 ### Run a complete, lightweight wasmCloud stack using K3s and Docker Compose.
 

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'wasmCloud Operator Overview on Kubernetes'
+sidebar_label: 'Operator Overview'
 hide_title: true
 sidebar_label: 'Operator Overview'
 description: 'Overview of the wasmCloud Kubernetes operator architecture — runtime-operator, host pods, and CRDs that run WebAssembly workloads natively on K8s.'

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'wasmCloud Operator Overview on Kubernetes'
+hide_title: true
+sidebar_label: 'Operator Overview'
 description: 'Overview of the wasmCloud Kubernetes operator architecture — runtime-operator, host pods, and CRDs that run WebAssembly workloads natively on K8s.'
 sidebar_position: 1
 ---
+
+# Operator Overview
 
 There are three primary deployments that comprise wasmCloud in a Kubernetes cluster:
 

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -2,7 +2,6 @@
 title: 'wasmCloud Operator Overview on Kubernetes'
 sidebar_label: 'Operator Overview'
 hide_title: true
-sidebar_label: 'Operator Overview'
 description: 'Overview of the wasmCloud Kubernetes operator architecture — runtime-operator, host pods, and CRDs that run WebAssembly workloads natively on K8s.'
 sidebar_position: 1
 ---

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Operator Overview'
-description: 'Overview of the wasmCloud operator and its components on Kubernetes'
+title: 'wasmCloud Operator Overview on Kubernetes'
+description: 'Overview of the wasmCloud Kubernetes operator architecture — runtime-operator, host pods, and CRDs that run WebAssembly workloads natively on K8s.'
 sidebar_position: 1
 ---
 

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Private Registries and Air-Gapped Deployments'
-description: 'Mirror wasmCloud container images to a private registry for air-gapped or restricted environments'
+description: 'Mirror wasmCloud container images and OCI artifacts to a private registry for air-gapped or restricted Kubernetes environments and regulated infrastructure.'
 sidebar_position: 5
 ---
 

--- a/docs/kubernetes-operator/operator-manual/roles-and-rolebindings.mdx
+++ b/docs/kubernetes-operator/operator-manual/roles-and-rolebindings.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Roles and Role Bindings for wasmCloud'
+sidebar_label: 'Roles and Role Bindings'
 sidebar_position: 3
 description: 'Configure Kubernetes RBAC for wasmCloud — Role, ClusterRole, and RoleBinding resources that the operator and host pods require on your cluster.'
 ---

--- a/docs/kubernetes-operator/operator-manual/roles-and-rolebindings.mdx
+++ b/docs/kubernetes-operator/operator-manual/roles-and-rolebindings.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Roles and Role Bindings"
+title: 'Roles and Role Bindings for wasmCloud'
 sidebar_position: 3
+description: 'Configure Kubernetes RBAC for wasmCloud — Role, ClusterRole, and RoleBinding resources that the operator and host pods require on your cluster.'
 ---
 
 ## Overview

--- a/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
+++ b/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
@@ -2,7 +2,6 @@
 title: 'Secrets and Configuration Management on K8s'
 sidebar_label: 'Secrets and Configuration Management'
 hide_title: true
-sidebar_label: 'Secrets and Configuration Management'
 description: 'Supply environment variables, Kubernetes ConfigMaps, and Secrets to wasmCloud WebAssembly components through Workload and WorkloadDeployment manifests.'
 ---
 

--- a/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
+++ b/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Secrets and Configuration Management on K8s'
+sidebar_label: 'Secrets and Configuration Management'
 hide_title: true
 sidebar_label: 'Secrets and Configuration Management'
 description: 'Supply environment variables, Kubernetes ConfigMaps, and Secrets to wasmCloud WebAssembly components through Workload and WorkloadDeployment manifests.'

--- a/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
+++ b/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Secrets and Configuration Management'
-description: 'Supply environment variables, ConfigMaps, and Kubernetes Secrets to wasmCloud components'
+title: 'Secrets and Configuration Management on K8s'
+description: 'Supply environment variables, Kubernetes ConfigMaps, and Secrets to wasmCloud WebAssembly components through Workload and WorkloadDeployment manifests.'
 ---
 
 wasmCloud components receive configuration through the `localResources.environment` field in a `Workload` or `WorkloadDeployment` manifest. This field supports three sources that can be used individually or combined: inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. 

--- a/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
+++ b/docs/kubernetes-operator/operator-manual/secrets-and-configuration.mdx
@@ -1,7 +1,11 @@
 ---
 title: 'Secrets and Configuration Management on K8s'
+hide_title: true
+sidebar_label: 'Secrets and Configuration Management'
 description: 'Supply environment variables, Kubernetes ConfigMaps, and Secrets to wasmCloud WebAssembly components through Workload and WorkloadDeployment manifests.'
 ---
+
+# Secrets and Configuration Management
 
 wasmCloud components receive configuration through the `localResources.environment` field in a `Workload` or `WorkloadDeployment` manifest. This field supports three sources that can be used individually or combined: inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. 
 

--- a/docs/kubernetes-operator/workload-security.mdx
+++ b/docs/kubernetes-operator/workload-security.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Workload Security — wasmCloud on Kubernetes'
+sidebar_label: 'Workload Security'
 hide_title: true
 sidebar_label: 'Workload Security'
 description: 'Security model and controls for wasmCloud WebAssembly components on Kubernetes — sandboxed bytecode, capability-based isolation, and policy enforcement.'

--- a/docs/kubernetes-operator/workload-security.mdx
+++ b/docs/kubernetes-operator/workload-security.mdx
@@ -2,7 +2,6 @@
 title: 'Workload Security — wasmCloud on Kubernetes'
 sidebar_label: 'Workload Security'
 hide_title: true
-sidebar_label: 'Workload Security'
 description: 'Security model and controls for wasmCloud WebAssembly components on Kubernetes — sandboxed bytecode, capability-based isolation, and policy enforcement.'
 ---
 

--- a/docs/kubernetes-operator/workload-security.mdx
+++ b/docs/kubernetes-operator/workload-security.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Workload Security'
-description: 'Security model and controls for wasmCloud components running on Kubernetes'
+title: 'Workload Security — wasmCloud on Kubernetes'
+description: 'Security model and controls for wasmCloud WebAssembly components on Kubernetes — sandboxed bytecode, capability-based isolation, and policy enforcement.'
 ---
 
 wasmCloud workload security operates in two complementary layers:

--- a/docs/kubernetes-operator/workload-security.mdx
+++ b/docs/kubernetes-operator/workload-security.mdx
@@ -1,7 +1,11 @@
 ---
 title: 'Workload Security — wasmCloud on Kubernetes'
+hide_title: true
+sidebar_label: 'Workload Security'
 description: 'Security model and controls for wasmCloud WebAssembly components on Kubernetes — sandboxed bytecode, capability-based isolation, and policy enforcement.'
 ---
+
+# Workload Security
 
 wasmCloud workload security operates in two complementary layers:
 

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Migration to wasmCloud v2 — Upgrade Guide'
 hide_title: true
+sidebar_label: "Migration to v2"
 sidebar_position: 10
 toc_max_heading_level: 2
 description: 'Step-by-step guide to migrating from wasmCloud v1 to v2. Covers architecture changes, operational improvements, and practical upgrade instructions.'

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Migration to wasmCloud v2 — Upgrade Guide'
+hide_title: true
 sidebar_position: 10
 toc_max_heading_level: 2
 description: 'Step-by-step guide to migrating from wasmCloud v1 to v2. Covers architecture changes, operational improvements, and practical upgrade instructions.'

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -1,12 +1,13 @@
 ---
-title: "Migration to v2"
+title: 'Migration to wasmCloud v2 — Upgrade Guide'
 sidebar_position: 10
 toc_max_heading_level: 2
+description: 'Step-by-step guide to migrating from wasmCloud v1 to v2. Covers architecture changes, operational improvements, and practical upgrade instructions.'
 ---
 
 # Migration to v2
 
-### Migrating to wasmCloud v2 reduces operational complexity and dramatically improves performance.
+## Migrating to wasmCloud v2 reduces operational complexity and dramatically improves performance.
 
 This guide walks through the architectural differences between wasmCloud v1 and v2, the benefits of migrating, and practical steps for bringing your v1 workloads to v2.
 

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -6,7 +6,7 @@ toc_max_heading_level: 2
 description: 'Step-by-step guide to migrating from wasmCloud v1 to v2. Covers architecture changes, operational improvements, and practical upgrade instructions.'
 ---
 
-# Migration to v2
+# Migration to wasmCloud v2
 
 ## Migrating to wasmCloud v2 reduces operational complexity and dramatically improves performance.
 

--- a/docs/overview/hosts/index.mdx
+++ b/docs/overview/hosts/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Hosts'
+title: 'Hosts — wasmCloud Runtime Environment'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'The runtime environment for components and capability providers'
+description: 'The wasmCloud host is the runtime environment for WebAssembly components and capability providers — secure, dense, and portable across any infrastructure.'
 sidebar_position: 4
 type: 'docs'
 toc_max_heading_level: 2

--- a/docs/overview/hosts/index.mdx
+++ b/docs/overview/hosts/index.mdx
@@ -1,11 +1,14 @@
 ---
 title: 'Hosts — wasmCloud Runtime Environment'
+hide_title: true
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'The wasmCloud host is the runtime environment for WebAssembly components and capability providers — secure, dense, and portable across any infrastructure.'
 sidebar_position: 4
 type: 'docs'
 toc_max_heading_level: 2
 ---
+
+# Hosts
 
 ### The wasmCloud host is a runtime environment for WebAssembly (Wasm) workloads. 
 

--- a/docs/overview/hosts/plugins.mdx
+++ b/docs/overview/hosts/plugins.mdx
@@ -2,7 +2,6 @@
 title: 'Host Plugins — Extend wasmCloud Hosts'
 sidebar_label: 'Plugins'
 hide_title: true
-sidebar_label: 'Plugins'
 toc_max_heading_level: 2
 description: 'Host plugins extend wasmCloud hosts with additional capabilities — bring custom WASI implementations and integrations into your WebAssembly runtime.'
 ---

--- a/docs/overview/hosts/plugins.mdx
+++ b/docs/overview/hosts/plugins.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'Host Plugins — Extend wasmCloud Hosts'
+hide_title: true
+sidebar_label: 'Plugins'
 toc_max_heading_level: 2
 description: 'Host plugins extend wasmCloud hosts with additional capabilities — bring custom WASI implementations and integrations into your WebAssembly runtime.'
 ---
+
+# Plugins
 
 ### Host plugins extend hosts with additional capabilities.
 

--- a/docs/overview/hosts/plugins.mdx
+++ b/docs/overview/hosts/plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Host Plugins — Extend wasmCloud Hosts'
+sidebar_label: 'Plugins'
 hide_title: true
 sidebar_label: 'Plugins'
 toc_max_heading_level: 2

--- a/docs/overview/hosts/plugins.mdx
+++ b/docs/overview/hosts/plugins.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Plugins"
+title: 'Host Plugins — Extend wasmCloud Hosts'
 toc_max_heading_level: 2
+description: 'Host plugins extend wasmCloud hosts with additional capabilities — bring custom WASI implementations and integrations into your WebAssembly runtime.'
 ---
 
 ### Host plugins extend hosts with additional capabilities.

--- a/docs/overview/index.mdx
+++ b/docs/overview/index.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Platform Overview"
+title: 'wasmCloud Platform Overview'
 toc_max_heading_level: 2
+description: 'wasmCloud is the cloud native WebAssembly application platform for running Wasm workloads across any cloud, Kubernetes cluster, datacenter, or edge.'
 ---
 
 ### wasmCloud is a cloud native platform for running WebAssembly workloads across any cloud, Kubernetes, datacenter, or edge.

--- a/docs/overview/interfaces.mdx
+++ b/docs/overview/interfaces.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Interfaces — WASI and Wasm Component Model'
+sidebar_label: 'Interfaces'
 hide_title: true
 sidebar_label: 'Interfaces'
 date: 2020-05-01T00:00:00+00:00

--- a/docs/overview/interfaces.mdx
+++ b/docs/overview/interfaces.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Interfaces'
+title: 'Interfaces — WASI and Wasm Component Model'
 date: 2020-05-01T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'A quick guide to wasmCloud interfaces'
+description: 'wasmCloud interfaces are typed WIT contracts based on the Wasm Component Model and WASI standards — portable, language-agnostic capability boundaries.'
 sidebar_position: 3
 type: 'docs'
 toc_max_heading_level: 2

--- a/docs/overview/interfaces.mdx
+++ b/docs/overview/interfaces.mdx
@@ -2,7 +2,6 @@
 title: 'Interfaces — WASI and Wasm Component Model'
 sidebar_label: 'Interfaces'
 hide_title: true
-sidebar_label: 'Interfaces'
 date: 2020-05-01T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud interfaces are typed WIT contracts based on the Wasm Component Model and WASI standards — portable, language-agnostic capability boundaries.'

--- a/docs/overview/interfaces.mdx
+++ b/docs/overview/interfaces.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'Interfaces — WASI and Wasm Component Model'
+hide_title: true
+sidebar_label: 'Interfaces'
 date: 2020-05-01T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud interfaces are typed WIT contracts based on the Wasm Component Model and WASI standards — portable, language-agnostic capability boundaries.'
@@ -7,6 +9,8 @@ sidebar_position: 3
 type: 'docs'
 toc_max_heading_level: 2
 ---
+
+# Interfaces
 
 ### Interfaces are contracts that define the relationships between entities.
 

--- a/docs/overview/packaging.mdx
+++ b/docs/overview/packaging.mdx
@@ -2,7 +2,6 @@
 title: 'Packaging — OCI Artifacts for Wasm Components'
 sidebar_label: 'Packaging'
 hide_title: true
-sidebar_label: 'Packaging'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud packages WebAssembly components and interfaces as OCI artifacts for portable distribution through any OCI-compliant container registry.'
 type: 'docs'

--- a/docs/overview/packaging.mdx
+++ b/docs/overview/packaging.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Packaging — OCI Artifacts for Wasm Components'
+sidebar_label: 'Packaging'
 hide_title: true
 sidebar_label: 'Packaging'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons

--- a/docs/overview/packaging.mdx
+++ b/docs/overview/packaging.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Packaging"
+title: 'Packaging — OCI Artifacts for Wasm Components'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'Packaging and distribution with OCI artifacts'
+description: 'wasmCloud packages WebAssembly components and interfaces as OCI artifacts for portable distribution through any OCI-compliant container registry.'
 type: 'docs'
 sidebar_position: 5
 toc_max_heading_level: 2

--- a/docs/overview/packaging.mdx
+++ b/docs/overview/packaging.mdx
@@ -1,11 +1,16 @@
 ---
 title: 'Packaging — OCI Artifacts for Wasm Components'
+hide_title: true
+sidebar_label: 'Packaging'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud packages WebAssembly components and interfaces as OCI artifacts for portable distribution through any OCI-compliant container registry.'
 type: 'docs'
 sidebar_position: 5
 toc_max_heading_level: 2
 ---
+
+# Packaging
+
 ### Components and interfaces are packaged as OCI artifacts.
 
 The wasmCloud ecosystem uses the [Open Container Initiative (OCI) image specification](https://github.com/opencontainers/image-spec) to package components and interfaces as OCI artifacts according to the [standard OCI artifact format for Wasm](https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/).

--- a/docs/overview/transport.mdx
+++ b/docs/overview/transport.mdx
@@ -1,11 +1,16 @@
 ---
 title: 'Transport — NATS for wasmCloud Hosts'
+hide_title: true
+sidebar_label: 'Transport'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'NATS connective technology provides the distributed transport between wasmCloud hosts and the operator for control-plane and lattice communication.'
 type: 'docs'
 sidebar_position: 4
 toc_max_heading_level: 2
 ---
+
+# Transport
+
 ### NATS provides transport between hosts and the operator.
 
 In wasmCloud, transport between hosts and the operator is handled by [**NATS**](https://nats.io/), an open source connective technology hosted by the Cloud Native Computing Foundation (CNCF). NATS enables secure application-layer networking across diverse environments including edge, different vendors' clouds, and on-premise datacenters.

--- a/docs/overview/transport.mdx
+++ b/docs/overview/transport.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Transport — NATS for wasmCloud Hosts'
+sidebar_label: 'Transport'
 hide_title: true
 sidebar_label: 'Transport'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons

--- a/docs/overview/transport.mdx
+++ b/docs/overview/transport.mdx
@@ -2,7 +2,6 @@
 title: 'Transport — NATS for wasmCloud Hosts'
 sidebar_label: 'Transport'
 hide_title: true
-sidebar_label: 'Transport'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'NATS connective technology provides the distributed transport between wasmCloud hosts and the operator for control-plane and lattice communication.'
 type: 'docs'

--- a/docs/overview/transport.mdx
+++ b/docs/overview/transport.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Transport"
+title: 'Transport — NATS for wasmCloud Hosts'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'NATS connective technology for distributed systems'
+description: 'NATS connective technology provides the distributed transport between wasmCloud hosts and the operator for control-plane and lattice communication.'
 type: 'docs'
 sidebar_position: 4
 toc_max_heading_level: 2

--- a/docs/overview/workloads/components.mdx
+++ b/docs/overview/workloads/components.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Components'
+title: 'Components — Stateless Wasm Sandboxed Binaries'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'Stateless, sandboxed binaries'
+description: 'WebAssembly components are stateless, sandboxed binaries built on the Wasm component model — the core unit of compute that runs on wasmCloud hosts.'
 type: 'docs'
 sidebar_position: 1
 toc_max_heading_level: 2

--- a/docs/overview/workloads/components.mdx
+++ b/docs/overview/workloads/components.mdx
@@ -2,7 +2,6 @@
 title: 'Wasm Component Model — wasmCloud Components'
 sidebar_label: 'Components'
 hide_title: true
-sidebar_label: 'Components'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'The Wasm component model defines stateless, sandboxed WebAssembly binaries — the portable unit of compute that wasmCloud hosts run across cloud and edge.'

--- a/docs/overview/workloads/components.mdx
+++ b/docs/overview/workloads/components.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Components — Stateless Wasm Sandboxed Binaries'
+title: 'Wasm Component Model — wasmCloud Components'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'WebAssembly components are stateless, sandboxed binaries built on the Wasm component model — the core unit of compute that runs on wasmCloud hosts.'
+description: 'The Wasm component model defines stateless, sandboxed WebAssembly binaries — the portable unit of compute that wasmCloud hosts run across cloud and edge.'
 type: 'docs'
 sidebar_position: 1
 toc_max_heading_level: 2

--- a/docs/overview/workloads/components.mdx
+++ b/docs/overview/workloads/components.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'Wasm Component Model — wasmCloud Components'
+hide_title: true
+sidebar_label: 'Components'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'The Wasm component model defines stateless, sandboxed WebAssembly binaries — the portable unit of compute that wasmCloud hosts run across cloud and edge.'
@@ -7,6 +9,8 @@ type: 'docs'
 sidebar_position: 1
 toc_max_heading_level: 2
 ---
+
+# Components
 
 ### WebAssembly (Wasm) components are stateless, sandboxed binaries. 
 

--- a/docs/overview/workloads/components.mdx
+++ b/docs/overview/workloads/components.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Wasm Component Model — wasmCloud Components'
+sidebar_label: 'Components'
 hide_title: true
 sidebar_label: 'Components'
 date: 2025-09-24T00:00:00+00:00

--- a/docs/overview/workloads/index.mdx
+++ b/docs/overview/workloads/index.mdx
@@ -1,10 +1,13 @@
 ---
 title: 'Workloads — Wasm Components and Services'
+hide_title: true
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud workloads are composed of WebAssembly components and optional services — portable, sandboxed, polyglot units of compute that run anywhere.'
 type: 'docs'
 toc_max_heading_level: 2
 ---
+
+# Workloads
 
 ### Workloads are composed of one or more WebAssembly (Wasm) components and an optional service. 
 

--- a/docs/overview/workloads/index.mdx
+++ b/docs/overview/workloads/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Workloads'
+title: 'Workloads — Wasm Components and Services'
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'Portable, sandboxed, polyglot workloads'
+description: 'wasmCloud workloads are composed of WebAssembly components and optional services — portable, sandboxed, polyglot units of compute that run anywhere.'
 type: 'docs'
 toc_max_heading_level: 2
 ---

--- a/docs/overview/workloads/services.mdx
+++ b/docs/overview/workloads/services.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Services'
+title: 'Services — Stateful Wasm Components'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
-description: 'Stateful components'
+description: 'wasmCloud services are long-running stateful WebAssembly components — extend Wasm workloads with persistent state and background processing on hosts.'
 type: 'docs'
 sidebar_position: 2
 toc_max_heading_level: 2

--- a/docs/overview/workloads/services.mdx
+++ b/docs/overview/workloads/services.mdx
@@ -2,7 +2,6 @@
 title: 'Services — Stateful Wasm Components'
 sidebar_label: 'Services'
 hide_title: true
-sidebar_label: 'Services'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud services are long-running stateful WebAssembly components — extend Wasm workloads with persistent state and background processing on hosts.'

--- a/docs/overview/workloads/services.mdx
+++ b/docs/overview/workloads/services.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Services — Stateful Wasm Components'
+sidebar_label: 'Services'
 hide_title: true
 sidebar_label: 'Services'
 date: 2025-09-24T00:00:00+00:00

--- a/docs/overview/workloads/services.mdx
+++ b/docs/overview/workloads/services.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'Services — Stateful Wasm Components'
+hide_title: true
+sidebar_label: 'Services'
 date: 2025-09-24T00:00:00+00:00
 icon: 'ti-anchor' # themify icon pack : https://themify.me/themify-icons
 description: 'wasmCloud services are long-running stateful WebAssembly components — extend Wasm workloads with persistent state and background processing on hosts.'
@@ -7,6 +9,8 @@ type: 'docs'
 sidebar_position: 2
 toc_max_heading_level: 2
 ---
+
+# Services
 
 ### Services are persistent, stateful companions to stateless components.
 

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Deploy a Wasm Workload to Kubernetes'
+sidebar_label: 'Deploy a Wasm Workload'
 sidebar_position: 3
 description: 'Deploy a WebAssembly component to wasmCloud on Kubernetes — customize providers, write WorkloadDeployment manifests, and ship your app to production.'
 ---

--- a/docs/quickstart/deploy-a-webassembly-workload.mdx
+++ b/docs/quickstart/deploy-a-webassembly-workload.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Deploy a Wasm Workload'
+title: 'Deploy a Wasm Workload to Kubernetes'
 sidebar_position: 3
-description: "Deploy a WebAssembly component to wasmCloud: customize providers, write deployment manifests, and go to production."
+description: 'Deploy a WebAssembly component to wasmCloud on Kubernetes — customize providers, write WorkloadDeployment manifests, and ship your app to production.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/quickstart/develop-a-webassembly-component.mdx
+++ b/docs/quickstart/develop-a-webassembly-component.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Develop a Wasm Component'
+title: 'Develop a Wasm Component for wasmCloud'
 sidebar_position: 2
-description: "Add capabilities like HTTP, key-value, and logging to your WebAssembly component using standard WASI interfaces."
+description: 'Add capabilities like HTTP, key-value, and logging to your WebAssembly component using standard WASI interfaces and the Wasm component model.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/quickstart/develop-a-webassembly-component.mdx
+++ b/docs/quickstart/develop-a-webassembly-component.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Develop a Wasm Component for wasmCloud'
+sidebar_label: 'Develop a Wasm Component'
 sidebar_position: 2
 description: 'Add capabilities like HTTP, key-value, and logging to your WebAssembly component using standard WASI interfaces and the Wasm component model.'
 ---

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -1,7 +1,8 @@
 ---
-title: 'Quickstart'
+title: 'Quickstart — Build & Deploy Your First Wasm App'
 sidebar_position: 1
 toc_max_heading_level: 2
+description: 'Get started with wasmCloud — install wash, build a WebAssembly component, and deploy your first Wasm workload to Kubernetes in under 15 minutes.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/quickstart/index.mdx
+++ b/docs/quickstart/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Quickstart — Build & Deploy Your First Wasm App'
+hide_title: true
 sidebar_position: 1
 toc_max_heading_level: 2
 description: 'Get started with wasmCloud — install wash, build a WebAssembly component, and deploy your first Wasm workload to Kubernetes in under 15 minutes.'
@@ -8,6 +9,8 @@ description: 'Get started with wasmCloud — install wash, build a WebAssembly c
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HubspotForm from 'react-hubspot-form';
+
+# Quickstart
 
 ### Build WebAssembly (Wasm) applications and run them across any cloud, Kubernetes, datacenter, or edge.
 

--- a/docs/recipes/expose-workload-via-kubernetes-service.mdx
+++ b/docs/recipes/expose-workload-via-kubernetes-service.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Expose a Workload via Kubernetes Service'
-description: 'Route cluster traffic to a workload through a Kubernetes Service and EndpointSlice'
+title: 'Expose a Wasm Workload via Kubernetes Service'
+description: 'Route cluster traffic to a wasmCloud WebAssembly workload through a standard Kubernetes Service and EndpointSlice — internal DNS, ports, and selectors.'
 ---
 
 This recipe shows how to expose a wasmCloud workload to other services in your Kubernetes cluster using a standard [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service). The operator manages [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) that point to the host pods running the workload, so cluster-internal DNS (e.g. `my-service.default.svc.cluster.local`) resolves to the correct pods automatically.

--- a/docs/recipes/expose-workload-via-kubernetes-service.mdx
+++ b/docs/recipes/expose-workload-via-kubernetes-service.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Expose a Wasm Workload via Kubernetes Service'
+sidebar_label: 'Expose a Workload via Kubernetes Service'
 description: 'Route cluster traffic to a wasmCloud WebAssembly workload through a standard Kubernetes Service and EndpointSlice — internal DNS, ports, and selectors.'
 ---
 

--- a/docs/recipes/index.mdx
+++ b/docs/recipes/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Recipes'
+title: 'Recipes — wasmCloud How-To Guides'
 sidebar_position: 6
-description: "Task-oriented guides for common wasmCloud deployment and configuration scenarios with working examples."
+description: 'Task-oriented how-to guides for common wasmCloud deployment and configuration scenarios on Kubernetes — practical recipes with working examples.'
 ---
 
 # Recipes

--- a/docs/recipes/index.mdx
+++ b/docs/recipes/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Recipes — wasmCloud How-To Guides'
+hide_title: true
 sidebar_position: 6
 description: 'Task-oriented how-to guides for common wasmCloud deployment and configuration scenarios on Kubernetes — practical recipes with working examples.'
 ---

--- a/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
+++ b/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Inject Config from ConfigMaps & Secrets'
+sidebar_label: 'Inject Configuration from ConfigMaps and Secrets'
 description: 'Provide runtime configuration to a wasmCloud WebAssembly component from inline values, Kubernetes ConfigMaps, and Secrets via wasi:cli/environment.'
 ---
 

--- a/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
+++ b/docs/recipes/inject-configuration-from-configmaps-and-secrets.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Inject Configuration from ConfigMaps and Secrets'
-description: 'Provide runtime configuration to a component from inline values, ConfigMaps, and Secrets'
+title: 'Inject Config from ConfigMaps & Secrets'
+description: 'Provide runtime configuration to a wasmCloud WebAssembly component from inline values, Kubernetes ConfigMaps, and Secrets via wasi:cli/environment.'
 ---
 
 This recipe walks through providing runtime configuration to a wasmCloud component from three sources: inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. All three are delivered to the component through the same interface, `wasi:cli/environment`, so the component reads them the same way regardless of source.

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -2,7 +2,6 @@
 title: 'Plugin or Service? — wasmCloud Capabilities'
 sidebar_label: 'Plugin or Service?'
 hide_title: true
-sidebar_label: 'Plugin or Service?'
 description: 'Choose between a wasmCloud host plugin and a service to add capabilities — trade-offs, hard constraints, and a decision framework for your WebAssembly app.'
 ---
 

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Plugin or Service?'
-description: 'Decide whether to extend a wasmCloud host with a plugin or ship a wasmCloud service alongside your workload'
+title: 'Plugin or Service? — wasmCloud Capabilities'
+description: 'Choose between a wasmCloud host plugin and a service to add capabilities — trade-offs, hard constraints, and a decision framework for your WebAssembly app.'
 ---
 
 This recipe gives you a framework for choosing between two ways of providing capabilities to a wasmCloud application: extending the host with a [plugin](../overview/hosts/plugins.mdx), or shipping a [service](../overview/workloads/services.mdx) inside the workload. The two are not interchangeable&mdash;each has hard constraints that rule it out in some situations, and softer trade-offs in the rest.

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Plugin or Service? — wasmCloud Capabilities'
+sidebar_label: 'Plugin or Service?'
 hide_title: true
 sidebar_label: 'Plugin or Service?'
 description: 'Choose between a wasmCloud host plugin and a service to add capabilities — trade-offs, hard constraints, and a decision framework for your WebAssembly app.'

--- a/docs/recipes/plugin-or-service.mdx
+++ b/docs/recipes/plugin-or-service.mdx
@@ -1,7 +1,11 @@
 ---
 title: 'Plugin or Service? — wasmCloud Capabilities'
+hide_title: true
+sidebar_label: 'Plugin or Service?'
 description: 'Choose between a wasmCloud host plugin and a service to add capabilities — trade-offs, hard constraints, and a decision framework for your WebAssembly app.'
 ---
+
+# Plugin or Service?
 
 This recipe gives you a framework for choosing between two ways of providing capabilities to a wasmCloud application: extending the host with a [plugin](../overview/hosts/plugins.mdx), or shipping a [service](../overview/workloads/services.mdx) inside the workload. The two are not interchangeable&mdash;each has hard constraints that rule it out in some situations, and softer trade-offs in the rest.
 

--- a/docs/recipes/tls-bring-your-own-certificates.mdx
+++ b/docs/recipes/tls-bring-your-own-certificates.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'TLS with Bring-Your-Own Certificates'
-description: 'Serve HTTPS from a wasmCloud host group using your own TLS certificates'
+description: 'Serve HTTPS from a wasmCloud host group on Kubernetes using your own TLS certificates — secret mounts, cert rotation, and SNI configuration explained.'
 ---
 
 This recipe shows how to configure a wasmCloud host group to serve HTTPS using TLS certificates you provide.

--- a/docs/runtime/building-custom-hosts.mdx
+++ b/docs/runtime/building-custom-hosts.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Building Custom Hosts with wasmCloud'
+sidebar_label: 'Building Custom Hosts'
 sidebar_position: 3
 toc_max_heading_level: 2
 description: 'Build a custom WebAssembly host on top of the wasmCloud runtime — embed Wasm components in your own application with the wasmcloud-runtime library.'

--- a/docs/runtime/building-custom-hosts.mdx
+++ b/docs/runtime/building-custom-hosts.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Building Custom Hosts"
+title: 'Building Custom Hosts with wasmCloud'
 sidebar_position: 3
 toc_max_heading_level: 2
+description: 'Build a custom WebAssembly host on top of the wasmCloud runtime — embed Wasm components in your own application with the wasmcloud-runtime library.'
 ---
 
 ### Build custom wasmCloud hosts for specialized deployment scenarios.

--- a/docs/runtime/creating-host-plugins.mdx
+++ b/docs/runtime/creating-host-plugins.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Creating Host Plugins"
+title: 'Creating Host Plugins for wasmCloud'
 sidebar_position: 2
 toc_max_heading_level: 2
+description: 'Create wasmCloud host plugins that extend the runtime with new capabilities — implement WASI interfaces and ship custom integrations to any Wasm host.'
 ---
 
 ### Extend wasmCloud hosts with additional capabilities.

--- a/docs/runtime/creating-host-plugins.mdx
+++ b/docs/runtime/creating-host-plugins.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Creating Host Plugins for wasmCloud'
+sidebar_label: 'Creating Host Plugins'
 sidebar_position: 2
 toc_max_heading_level: 2
 description: 'Create wasmCloud host plugins that extend the runtime with new capabilities — implement WASI interfaces and ship custom integrations to any Wasm host.'

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -7,7 +7,7 @@ description: 'Introduction to the wasmCloud runtime — the embeddable WebAssemb
 
 # Runtime
 
-## wasmCloud's runtime (`wash-runtime`) is a simple, flexible runtime environment for WebAssembly workloads.
+### wasmCloud's runtime (`wash-runtime`) is a simple, flexible runtime environment for WebAssembly workloads.
 
 [`wash-runtime`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-runtime) is a Rust crate that includes Wasmtime as the underlying runtime engine, as well as the wasmCloud host, which serves as a runtime environment for WebAssembly components. A plugin system allows for extension of the host with new and custom capabilities.
 

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -1,12 +1,13 @@
 ---
-title: "Introduction"
+title: 'wasmCloud Runtime — Introduction'
 sidebar_position: 1
 toc_max_heading_level: 2
+description: 'Introduction to the wasmCloud runtime — the embeddable WebAssembly engine that hosts components and powers wash, washlet, and your custom hosts.'
 ---
 
 # Runtime
 
-### wasmCloud's runtime (`wash-runtime`) is a simple, flexible runtime environment for WebAssembly workloads.
+## wasmCloud's runtime (`wash-runtime`) is a simple, flexible runtime environment for WebAssembly workloads.
 
 [`wash-runtime`](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-runtime) is a Rust crate that includes Wasmtime as the underlying runtime engine, as well as the wasmCloud host, which serves as a runtime environment for WebAssembly components. A plugin system allows for extension of the host with new and custom capabilities.
 

--- a/docs/runtime/washlet.mdx
+++ b/docs/runtime/washlet.mdx
@@ -2,7 +2,6 @@
 title: 'Washlet — Cluster Hosts for wasmCloud'
 sidebar_label: 'Cluster Hosts (Washlet)'
 hide_title: true
-sidebar_label: 'Cluster Hosts (Washlet)'
 sidebar_position: 4
 toc_max_heading_level: 2
 description: 'Washlet is the wasmCloud cluster host — a lightweight Wasm runtime daemon that runs WebAssembly components on Kubernetes nodes inside host pods.'

--- a/docs/runtime/washlet.mdx
+++ b/docs/runtime/washlet.mdx
@@ -1,9 +1,13 @@
 ---
 title: 'Washlet — Cluster Hosts for wasmCloud'
+hide_title: true
+sidebar_label: 'Cluster Hosts (Washlet)'
 sidebar_position: 4
 toc_max_heading_level: 2
 description: 'Washlet is the wasmCloud cluster host — a lightweight Wasm runtime daemon that runs WebAssembly components on Kubernetes nodes inside host pods.'
 ---
+
+# Cluster Hosts (Washlet)
 
 ### Run a wasmCloud host as a cluster node connected to the operator mesh.
 

--- a/docs/runtime/washlet.mdx
+++ b/docs/runtime/washlet.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Cluster Hosts (Washlet)"
+title: 'Washlet — Cluster Hosts for wasmCloud'
 sidebar_position: 4
 toc_max_heading_level: 2
+description: 'Washlet is the wasmCloud cluster host — a lightweight Wasm runtime daemon that runs WebAssembly components on Kubernetes nodes inside host pods.'
 ---
 
 ### Run a wasmCloud host as a cluster node connected to the operator mesh.

--- a/docs/runtime/washlet.mdx
+++ b/docs/runtime/washlet.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Washlet — Cluster Hosts for wasmCloud'
+sidebar_label: 'Cluster Hosts (Washlet)'
 hide_title: true
 sidebar_label: 'Cluster Hosts (Washlet)'
 sidebar_position: 4

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,8 +1,12 @@
 ---
 title: 'Troubleshooting wasmCloud on Kubernetes'
+hide_title: true
+sidebar_label: "Troubleshooting"
 sidebar_position: 12
 description: 'Common errors and fixes when running wasmCloud workloads on Kubernetes — error messages, root causes, and step-by-step resolutions for the platform.'
 ---
+
+# Troubleshooting
 
 This page collects common errors you may encounter when running wasmCloud workloads and the resolutions for each. Entries include the literal error message, the underlying cause, and the fix.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Troubleshooting"
+title: 'Troubleshooting wasmCloud on Kubernetes'
 sidebar_position: 12
-description: "Common errors and their fixes when running wasmCloud workloads on Kubernetes."
+description: 'Common errors and fixes when running wasmCloud workloads on Kubernetes — error messages, root causes, and step-by-step resolutions for the platform.'
 ---
 
 This page collects common errors you may encounter when running wasmCloud workloads and the resolutions for each. Entries include the literal error message, the underlying cause, and the fix.

--- a/docs/wash/commands.mdx
+++ b/docs/wash/commands.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'wash Commands — CLI Reference'
+sidebar_label: 'Commands'
 hide_title: true
 sidebar_label: 'Commands'
 sidebar_position: 1

--- a/docs/wash/commands.mdx
+++ b/docs/wash/commands.mdx
@@ -2,7 +2,6 @@
 title: 'wash Commands — CLI Reference'
 sidebar_label: 'Commands'
 hide_title: true
-sidebar_label: 'Commands'
 sidebar_position: 1
 description: 'Complete command reference for the wash CLI — every subcommand, flag, and option for developing and publishing WebAssembly components on wasmCloud.'
 ---

--- a/docs/wash/commands.mdx
+++ b/docs/wash/commands.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Commands"
+title: 'wash Commands — CLI Reference'
 sidebar_position: 1
+description: 'Complete command reference for the wash CLI — every subcommand, flag, and option for developing and publishing WebAssembly components on wasmCloud.'
 ---
 
 # Wasm Shell CLI Command Reference

--- a/docs/wash/commands.mdx
+++ b/docs/wash/commands.mdx
@@ -1,5 +1,7 @@
 ---
 title: 'wash Commands — CLI Reference'
+hide_title: true
+sidebar_label: 'Commands'
 sidebar_position: 1
 description: 'Complete command reference for the wash CLI — every subcommand, flag, and option for developing and publishing WebAssembly components on wasmCloud.'
 ---

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Configuration"
+title: 'wash Configuration — User and Project Settings'
 sidebar_position: 4
-description: "Configure the wash CLI: user settings, project config files, and available options in YAML, JSON, or TOML."
+description: 'Configure the wash CLI for wasmCloud — user settings, project config files, and available options in YAML, JSON, or TOML for WebAssembly workflows.'
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'wash Configuration — User and Project Settings'
+sidebar_label: 'Configuration'
 sidebar_position: 4
 description: 'Configure the wash CLI for wasmCloud — user settings, project config files, and available options in YAML, JSON, or TOML for WebAssembly workflows.'
 ---

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -1,10 +1,11 @@
 ---
 title: 'wash Configuration — User and Project Settings'
+hide_title: true
 sidebar_label: 'Configuration'
 sidebar_position: 4
 description: 'Configure the wash CLI for wasmCloud — user settings, project config files, and available options in YAML, JSON, or TOML for WebAssembly workflows.'
 ---
-import Tabs from '@theme/Tabs';
+
 import TabItem from '@theme/TabItem';
 
 # Wasm Shell Configuration

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -6,6 +6,7 @@ sidebar_position: 4
 description: 'Configure the wash CLI for wasmCloud — user settings, project config files, and available options in YAML, JSON, or TOML for WebAssembly workflows.'
 ---
 
+import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Wasm Shell Configuration

--- a/docs/wash/developer-guide/build-and-publish.mdx
+++ b/docs/wash/developer-guide/build-and-publish.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'Building and Publishing Components'
+title: 'Building and Publishing Wasm Components'
 date: 2025-09-15T11:00:00+00:00
 sidebar_position: 1
 draft: false
+description: 'Build and publish WebAssembly components with wash — compile to wasm32-wasip2, run with wash dev, and push to an OCI registry for wasmCloud deployment.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/wash/developer-guide/create-services.mdx
+++ b/docs/wash/developer-guide/create-services.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'Creating Services'
+title: 'Creating wasmCloud Services with wash'
 date: 2025-09-15T11:00:00+00:00
 sidebar_position: 2
 draft: false
+description: 'Create stateful WebAssembly services with wash — persistent processes inside a wasmCloud workload that companion components can call as capabilities.'
 ---
 
 **Services** are WebAssembly (Wasm) binaries that can provide persistent, stateful processes within the [workload](../../overview/workloads/index.mdx) boundary for one or more companion Wasm components.

--- a/docs/wash/developer-guide/create-services.mdx
+++ b/docs/wash/developer-guide/create-services.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Creating wasmCloud Services with wash'
+sidebar_label: 'Creating Services'
 date: 2025-09-15T11:00:00+00:00
 sidebar_position: 2
 draft: false

--- a/docs/wash/developer-guide/debugging-components.mdx
+++ b/docs/wash/developer-guide/debugging-components.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Debugging Components"
+title: 'Debugging WebAssembly Components'
 sidebar_position: 4
-description: "Debug WebAssembly components on wasmCloud: diagnostic tools, common build errors, and resolution strategies."
+description: 'Debug WebAssembly components on wasmCloud — diagnostic tools, common build errors from the Wasm component model, and step-by-step resolution strategies.'
 ---
 
 Debugging WebAssembly components is different from debugging native applications. You can't attach a traditional debugger to a Wasm component, and error messages from the build toolchain can be cryptic if you're not familiar with the Component Model. This page covers the diagnostic tools available to you, common errors you'll encounter, and how to resolve them.

--- a/docs/wash/developer-guide/debugging-components.mdx
+++ b/docs/wash/developer-guide/debugging-components.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Debugging WebAssembly Components'
+sidebar_label: 'Debugging Components'
 sidebar_position: 4
 description: 'Debug WebAssembly components on wasmCloud — diagnostic tools, common build errors from the Wasm component model, and step-by-step resolution strategies.'
 ---

--- a/docs/wash/developer-guide/index.mdx
+++ b/docs/wash/developer-guide/index.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'Developer Guide'
+title: 'wash Developer Guide — Build Wasm Components'
 date: 2025-09-10T12:00:00+00:00
 sidebar_position: 0
 draft: false
+description: 'Build, debug, and publish WebAssembly components with wash on wasmCloud — language guides, capabilities, and the full Wasm component development workflow.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/wash/developer-guide/language-support/go/index.mdx
+++ b/docs/wash/developer-guide/language-support/go/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Go (TinyGo) Language Guide for WebAssembly'
+sidebar_label: 'Go (TinyGo) Language Guide'
 sidebar_position: 2
 description: 'Build WebAssembly components in Go with TinyGo for wasmCloud — toolchain setup, wit-bindgen-go bindings, and the Wasm component model integration guide.'
 ---

--- a/docs/wash/developer-guide/language-support/go/index.mdx
+++ b/docs/wash/developer-guide/language-support/go/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Go (TinyGo) Language Guide"
+title: 'Go (TinyGo) Language Guide for WebAssembly'
 sidebar_position: 2
-description: "Build WebAssembly components in Go with TinyGo: toolchain setup, bindings, and wasmCloud integration guide."
+description: 'Build WebAssembly components in Go with TinyGo for wasmCloud — toolchain setup, wit-bindgen-go bindings, and the Wasm component model integration guide.'
 ---
 
 wasmCloud uses [TinyGo](https://tinygo.org/) to build WebAssembly components from Go source code. TinyGo compiles a large subset of Go to the `wasip2` target, producing Wasm components that work with the Component Model and WASI 0.2.

--- a/docs/wash/developer-guide/language-support/index.mdx
+++ b/docs/wash/developer-guide/language-support/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Language Support"
+title: 'Language Support for WebAssembly Components'
 sidebar_position: 3
-description: "Language support for WebAssembly components on wasmCloud: Rust, Go, TypeScript, Python, C#, and more."
+description: 'Language support for WebAssembly components on wasmCloud — Rust, Go, TypeScript, Python, C#, .NET, and more for the Wasm component model and WASI P2.'
 ---
 
 wasmCloud runs standard [WebAssembly components](https://component-model.bytecodealliance.org/) targeting [WASI P2](https://wasi.dev/). Any language toolchain that can produce a Wasm component with WASI P2 support can build components that run on wasmCloud.

--- a/docs/wash/developer-guide/language-support/rust/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/rust/configuration.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Configuration'
+title: 'Configuration in Rust Wasm Components'
 sidebar_position: 4
-description: "Read runtime config in Rust Wasm components using wasi:cli/environment with ConfigMaps and Secrets."
+description: 'Read runtime configuration in Rust WebAssembly components on wasmCloud using wasi:cli/environment — Kubernetes ConfigMaps, Secrets, and inline values.'
 ---
 
 You can read runtime configuration values in a Rust component with the [`wasi:cli/environment`](https://github.com/WebAssembly/wasi-cli) interface. Configuration values can be supplied from inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. All arrive through the same interface regardless of source.

--- a/docs/wash/developer-guide/language-support/rust/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/rust/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Configuration in Rust Wasm Components'
+sidebar_label: 'Configuration'
 sidebar_position: 4
 description: 'Read runtime configuration in Rust WebAssembly components on wasmCloud using wasi:cli/environment — Kubernetes ConfigMaps, Secrets, and inline values.'
 ---

--- a/docs/wash/developer-guide/language-support/rust/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/rust/filesystem.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Filesystem'
+title: 'Filesystem Access in Rust Wasm Components'
 sidebar_position: 3
+description: 'Add filesystem capabilities to a Rust WebAssembly component on wasmCloud using the wasi:filesystem interface — preopened directories and capability-scoped I/O.'
 ---
 
 You can add filesystem capabilities to a Rust component with the [`wasi:filesystem`](https://github.com/WebAssembly/WASI/tree/main/proposals/filesystem) interface.

--- a/docs/wash/developer-guide/language-support/rust/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/rust/filesystem.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Filesystem Access in Rust Wasm Components'
+sidebar_label: 'Filesystem'
 sidebar_position: 3
 description: 'Add filesystem capabilities to a Rust WebAssembly component on wasmCloud using the wasi:filesystem interface — preopened directories and capability-scoped I/O.'
 ---

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Rust Language Guide"
+title: 'Rust Language Guide for WebAssembly'
 sidebar_position: 0
-description: "Build WebAssembly components in Rust: wasm32-wasip2 target, wstd async library, and wasmCloud integration."
+description: 'Build WebAssembly components in Rust for wasmCloud — wasm32-wasip2 target, wstd async library, cargo-component, and the full Wasm component model toolchain.'
 ---
 
 Rust has first-class support for building WebAssembly components. The `wasm32-wasip2` compiler target ships with the standard Rust toolchain, and the [`wstd`](https://crates.io/crates/wstd) crate provides an async standard library purpose-built for WASI 0.2 components.

--- a/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Key-Value Storage in Rust Wasm Components'
+sidebar_label: 'Key-Value Storage'
 sidebar_position: 1
 description: 'Add key-value storage to a Rust WebAssembly component on wasmCloud using the wasi:keyvalue interface — bucket access, atomics, and supported backends.'
 ---

--- a/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/rust/key-value-storage.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Key-Value Storage'
+title: 'Key-Value Storage in Rust Wasm Components'
 sidebar_position: 1
+description: 'Add key-value storage to a Rust WebAssembly component on wasmCloud using the wasi:keyvalue interface — bucket access, atomics, and supported backends.'
 ---
 
 You can add key-value capabilities to a Rust component with the [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue/) interface.

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Messaging'
+title: 'Messaging in Rust Wasm Components'
 sidebar_position: 2
+description: 'Add messaging capabilities to a Rust WebAssembly component on wasmCloud using the wasmcloud:messaging interface — publish, subscribe, and request/reply.'
 ---
 
 You can add messaging capabilities to a Rust component with the [`wasmcloud:messaging`](https://github.com/wasmCloud/wasmCloud/tree/main/wit/messaging.wit) interface.

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Messaging in Rust Wasm Components'
+sidebar_label: 'Messaging'
 sidebar_position: 2
 description: 'Add messaging capabilities to a Rust WebAssembly component on wasmCloud using the wasmcloud:messaging interface — publish, subscribe, and request/reply.'
 ---

--- a/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Blob Storage"
+title: 'Blob Storage in TypeScript Wasm Components'
 sidebar_position: 1
+description: 'Add blob storage capabilities to a TypeScript WebAssembly component on wasmCloud using the wasi:blobstore interface — object storage backends and APIs.'
 ---
 
 You can add blob storage capabilities to a component with the [`wasi:blobstore`](https://github.com/WebAssembly/wasi-blobstore/) interface.

--- a/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/blob-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Blob Storage in TypeScript Wasm Components'
+sidebar_label: 'Blob Storage'
 sidebar_position: 1
 description: 'Add blob storage capabilities to a TypeScript WebAssembly component on wasmCloud using the wasi:blobstore interface — object storage backends and APIs.'
 ---

--- a/docs/wash/developer-guide/language-support/typescript/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/configuration.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Configuration"
+title: 'Configuration in TypeScript Wasm Components'
 sidebar_position: 3
-description: "Read runtime config in TypeScript Wasm components using wasi:cli/environment with ConfigMaps and Secrets."
+description: 'Read runtime configuration in TypeScript WebAssembly components on wasmCloud using wasi:cli/environment — Kubernetes ConfigMaps, Secrets, and inline values.'
 ---
 
 You can read runtime configuration values in a TypeScript component with the [`wasi:cli/environment`](https://github.com/WebAssembly/wasi-cli) interface. Configuration values can be supplied from inline key-value pairs, Kubernetes ConfigMaps, and Kubernetes Secrets. All arrive through the same interface regardless of source.

--- a/docs/wash/developer-guide/language-support/typescript/configuration.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Configuration in TypeScript Wasm Components'
+sidebar_label: 'Configuration'
 sidebar_position: 3
 description: 'Read runtime configuration in TypeScript WebAssembly components on wasmCloud using wasi:cli/environment — Kubernetes ConfigMaps, Secrets, and inline values.'
 ---

--- a/docs/wash/developer-guide/language-support/typescript/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/filesystem.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Filesystem"
+title: 'Filesystem Access in TypeScript Wasm Components'
 sidebar_position: 3
+description: 'Add filesystem capabilities to a TypeScript WebAssembly component on wasmCloud using the wasi:filesystem interface — preopened directories and file I/O.'
 ---
 
 You can add filesystem capabilities to a component with the [`wasi:filesystem`](https://github.com/WebAssembly/WASI/tree/main/proposals/filesystem) interface.

--- a/docs/wash/developer-guide/language-support/typescript/filesystem.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/filesystem.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Filesystem Access in TypeScript Wasm Components'
+sidebar_label: 'Filesystem'
 sidebar_position: 3
 description: 'Add filesystem capabilities to a TypeScript WebAssembly component on wasmCloud using the wasi:filesystem interface — preopened directories and file I/O.'
 ---

--- a/docs/wash/developer-guide/language-support/typescript/index.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: "TypeScript Language Guide"
+title: 'TypeScript Language Guide for WebAssembly'
 sidebar_position: 1
-description: "Build WebAssembly components in TypeScript: toolchain, Hono integration, and wasmCloud patterns."
+description: 'Build WebAssembly components in TypeScript for wasmCloud — jco toolchain, componentize-js, Hono integration, and Wasm component model patterns.'
 ---
 
 TypeScript and JavaScript are first-class languages for building WebAssembly components on wasmCloud. This guide covers the toolchain, patterns for handling HTTP requests, framework integration with Hono, and practical guidance for library compatibility.

--- a/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Key-Value Storage in TypeScript Wasm Components'
+sidebar_label: 'Key-Value Storage'
 sidebar_position: 0
 description: 'Add key-value storage to a TypeScript WebAssembly component on wasmCloud using the wasi:keyvalue interface — bucket access and supported backends.'
 ---

--- a/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/key-value-storage.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Key-Value Storage"
+title: 'Key-Value Storage in TypeScript Wasm Components'
 sidebar_position: 0
+description: 'Add key-value storage to a TypeScript WebAssembly component on wasmCloud using the wasi:keyvalue interface — bucket access and supported backends.'
 ---
 
 You can add key-value capabilities to a component with the [`wasi:keyvalue`](https://github.com/WebAssembly/wasi-keyvalue/) interface.

--- a/docs/wash/developer-guide/language-support/typescript/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/messaging.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Messaging"
+title: 'Messaging in TypeScript Wasm Components'
 sidebar_position: 2
+description: 'Add messaging capabilities to a TypeScript WebAssembly component on wasmCloud using the wasmcloud:messaging interface — publish, subscribe, and request/reply.'
 ---
 
 You can add messaging capabilities to a component with the [`wasmcloud:messaging`](https://github.com/wasmCloud/wasmCloud/tree/main/wit/messaging.wit) interface.

--- a/docs/wash/developer-guide/language-support/typescript/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/messaging.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Messaging in TypeScript Wasm Components'
+sidebar_label: 'Messaging'
 sidebar_position: 2
 description: 'Add messaging capabilities to a TypeScript WebAssembly component on wasmCloud using the wasmcloud:messaging interface — publish, subscribe, and request/reply.'
 ---

--- a/docs/wash/developer-guide/network-access-and-socket-isolation.mdx
+++ b/docs/wash/developer-guide/network-access-and-socket-isolation.mdx
@@ -3,7 +3,7 @@ title: 'Network Access and Socket Isolation'
 date: 2026-03-19T00:00:00+00:00
 sidebar_position: 3
 draft: false
-description: "wasmCloud's socket policy and network isolation model: what's allowed, what's denied, and how to configure access."
+description: "wasmCloud's socket policy and network isolation for WebAssembly components — what's allowed, what's denied, and how to configure access on Kubernetes."
 ---
 
 wasmCloud enforces a well-defined socket policy at the host level, giving you predictable security boundaries without requiring components to implement their own restrictions. This page explains what's allowed and denied by default, how the isolation model works, and when to use each networking pattern.

--- a/docs/wash/developer-guide/useful-webassembly-tools.mdx
+++ b/docs/wash/developer-guide/useful-webassembly-tools.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Useful WebAssembly Tools and Utilities'
+sidebar_label: 'Useful WebAssembly Tools'
 date: 2024-04-08T00:00:00+00:00
 icon: "ti-map" # themify icon pack : https://themify.me/themify-icons
 description: 'A curated list of useful WebAssembly tools and utilities — wasm-tools, wit-bindgen, jco, componentize, and more for building Wasm components on wasmCloud.'

--- a/docs/wash/developer-guide/useful-webassembly-tools.mdx
+++ b/docs/wash/developer-guide/useful-webassembly-tools.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Useful WebAssembly Tools"
+title: 'Useful WebAssembly Tools and Utilities'
 date: 2024-04-08T00:00:00+00:00
 icon: "ti-map" # themify icon pack : https://themify.me/themify-icons
-description: "A collection of common WebAssembly tools"
+description: 'A curated list of useful WebAssembly tools and utilities — wasm-tools, wit-bindgen, jco, componentize, and more for building Wasm components on wasmCloud.'
 type: "docs"
 sidebar_position: 5
 ---

--- a/docs/wash/faq.mdx
+++ b/docs/wash/faq.mdx
@@ -1,9 +1,12 @@
 ---
 title: 'wash FAQ — Wasm Shell CLI Questions'
+title: 'wash FAQ — Wasm Shell CLI Questions'
+hide_title: true
 sidebar_label: 'FAQ'
 sidebar_position: 6
 description: 'Frequently asked questions about wash, the Wasm Shell CLI — installation, builds, publishing, and the wasmCloud WebAssembly development workflow.'
 ---
+
 # Wasm Shell Frequently Asked Questions (FAQ)
 
 ## General Questions

--- a/docs/wash/faq.mdx
+++ b/docs/wash/faq.mdx
@@ -1,6 +1,7 @@
 ---
-title: "FAQ"
+title: 'wash FAQ — Wasm Shell CLI Questions'
 sidebar_position: 6
+description: 'Frequently asked questions about wash, the Wasm Shell CLI — installation, builds, publishing, and the wasmCloud WebAssembly development workflow.'
 ---
 # Wasm Shell Frequently Asked Questions (FAQ)
 

--- a/docs/wash/faq.mdx
+++ b/docs/wash/faq.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'wash FAQ — Wasm Shell CLI Questions'
-title: 'wash FAQ — Wasm Shell CLI Questions'
 hide_title: true
 sidebar_label: 'FAQ'
 sidebar_position: 6

--- a/docs/wash/faq.mdx
+++ b/docs/wash/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'wash FAQ — Wasm Shell CLI Questions'
+sidebar_label: 'FAQ'
 sidebar_position: 6
 description: 'Frequently asked questions about wash, the Wasm Shell CLI — installation, builds, publishing, and the wasmCloud WebAssembly development workflow.'
 ---

--- a/docs/wash/index.mdx
+++ b/docs/wash/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'wash — Wasm Shell CLI for wasmCloud'
+hide_title: true
 sidebar_position: 0
 toc_max_heading_level: 2
 description: 'wash is the Wasm Shell CLI for developing, building, and publishing WebAssembly components on wasmCloud — your primary tool for the Wasm component model.'

--- a/docs/wash/index.mdx
+++ b/docs/wash/index.mdx
@@ -1,7 +1,8 @@
 ---
-title: 'Introduction'
+title: 'wash — Wasm Shell CLI for wasmCloud'
 sidebar_position: 0
 toc_max_heading_level: 2
+description: 'wash is the Wasm Shell CLI for developing, building, and publishing WebAssembly components on wasmCloud — your primary tool for the Wasm component model.'
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 # Wasm Shell (wash) CLI
 
-### **Wasm Shell** (`wash`) is the comprehensive command-line tool for developing, building, and publishing WebAssembly components. 
+## **Wasm Shell** (`wash`) is the comprehensive command-line tool for developing, building, and publishing WebAssembly components. 
 
 The CLI provides an intuitive developer experience for the modern Wasm ecosystem, from project scaffolding to building and pushing components to OCI registries.
 

--- a/docs/wash/registries.mdx
+++ b/docs/wash/registries.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'OCI Registries for WebAssembly Components'
+sidebar_label: 'Registries'
 sidebar_position: 5
 description: 'Push and pull WebAssembly components as OCI artifacts using wash with any OCI-compliant container registry — GHCR, Docker Hub, ECR, and private mirrors.'
 ---

--- a/docs/wash/registries.mdx
+++ b/docs/wash/registries.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Registries"
+title: 'OCI Registries for WebAssembly Components'
 sidebar_position: 5
-description: "Push and pull WebAssembly components as OCI artifacts using wash with any OCI-compliant container registry."
+description: 'Push and pull WebAssembly components as OCI artifacts using wash with any OCI-compliant container registry — GHCR, Docker Hub, ECR, and private mirrors.'
 ---
 
 # Wasm Shell and OCI Registries
@@ -10,7 +10,7 @@ Wasm Shell enables component developers to push WebAssembly components to Open C
 
 OCI artifacts include a wide range of content types such as WebAssembly components, Software Bill of Materials (SBOMs), and Helm charts as well as container images.
 
-### Authenticating to OCI registries
+## Authenticating to OCI registries
 
 `wash` supports loading Docker credentials. There are multiple [ways to authenticate with Docker credentials](https://docs.docker.com/reference/cli/docker/login/), including the `docker login` command with the docker CLI:
 
@@ -18,7 +18,7 @@ OCI artifacts include a wide range of content types such as WebAssembly componen
 docker login <registry> -u <username> -p <password-or-token> 
 ```
 
-### How to push a WebAssembly component to an OCI registry
+## How to push a WebAssembly component to an OCI registry
 
 Push the component to your registry:
 
@@ -29,7 +29,7 @@ wash oci push ghcr.io/cosmonic-labs/components/hello:0.2.0 ./dist/http-hello-wor
 * The target registry address (including artifact name and tag) are specified for the first option with `wash oci push`.
 * The second option defines the target path for the component binary to push.
 
-### How to pull a WebAssembly component from an OCI registry
+## How to pull a WebAssembly component from an OCI registry
 
 Pull the component from your registry:
 
@@ -37,7 +37,7 @@ Pull the component from your registry:
 wash oci pull ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
 ```
 
-### Further reading
+## Further reading
 
 * `wash` uses the `oras` client library (Rust) for OCI functionality. See the [`oras` documentation](https://oras.land/docs/) for more information.
 * Learn more about the OCI standard at [https://opencontainers.org/](https://opencontainers.org/).

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -256,6 +256,10 @@ const config = (async (): Promise<Config> => {
 
     themeConfig: {
       image: '/logo/wasmcloud-social.png',
+      metadata: [
+        { property: 'og:type', content: 'website' },
+        { name: 'twitter:site', content: '@wasmcloud' },
+      ],
       navbar: {
         title: 'wasmCloud',
         logo: {

--- a/src/pages/_index/index.tsx
+++ b/src/pages/_index/index.tsx
@@ -18,8 +18,8 @@ import { Cncf } from './_components/cncf';
 function ContactForm() {
   return (
     <Layout
-      title={`wasmCloud - A CNCF Project`}
-      description="Build secure, cloud-native platforms and applications with WebAssembly"
+      title={`The WebAssembly Application Platform`}
+      description="wasmCloud is the leading WebAssembly application platform for cloud-native distributed apps. CNCF project with Kubernetes-native deployment."
       wrapperClassName="navbar-glass"
     >
       <main className={styles.main}>

--- a/src/pages/_index/index.tsx
+++ b/src/pages/_index/index.tsx
@@ -19,7 +19,7 @@ function ContactForm() {
   return (
     <Layout
       title={`The WebAssembly Application Platform`}
-      description="wasmCloud is the leading WebAssembly application platform for platform engineering teams — build cloud-native Wasm components and IDPs on Kubernetes."
+      description="wasmCloud is the leading WebAssembly application platform for platform engineering teams — Sandbox Vibe Coded Apps, Functions, Agents, Triggers, Apps, and more on Kubernetes."
       wrapperClassName="navbar-glass"
     >
       <main className={styles.main}>

--- a/src/pages/_index/index.tsx
+++ b/src/pages/_index/index.tsx
@@ -19,7 +19,7 @@ function ContactForm() {
   return (
     <Layout
       title={`The WebAssembly Application Platform`}
-      description="wasmCloud is the leading WebAssembly application platform for cloud-native distributed apps. CNCF project with Kubernetes-native deployment."
+      description="wasmCloud is the leading WebAssembly application platform for platform engineering teams — build cloud-native Wasm components and IDPs on Kubernetes."
       wrapperClassName="navbar-glass"
     >
       <main className={styles.main}>

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -6,8 +6,8 @@ function ContactForm() {
 
     return (
         <Layout
-            title={`Contact`}
-            description="wasmCloud - Why stop at the Edge?">
+            title={`Get in Touch — Contact Sales & Support`}
+            description="Contact the wasmCloud team for sales, support, or community questions about our WebAssembly application platform and Kubernetes integration.">
             <main>
                 <div style={{ display: "flex", flexDirection: "row" }}>
                     <div style={{ width: "25%" }}></div>

--- a/src/pages/feedback/backstage/index.mdx
+++ b/src/pages/feedback/backstage/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Feedback: wasmCloud + Backstage'
-description: 'Tell us how you use Backstage'
+title: 'Backstage Integration Feedback Survey'
+description: 'Share how you use Backstage with wasmCloud. Your feedback helps us build better internal developer platform integrations for the WebAssembly community.'
 ---
 
 import HubspotForm from 'react-hubspot-form';

--- a/src/pages/gather/index.tsx
+++ b/src/pages/gather/index.tsx
@@ -11,7 +11,7 @@ function ContactForm() {
   }, []);
 
   return (
-    <Layout title={`Contact`} description="wasmCloud - Why stop at the Edge?">
+    <Layout title={`Innovation Day — Gather Hangout`} description="Redirecting to the wasmCloud Innovation Day Gather hangout — meet maintainers and build WebAssembly applications together.">
       <main style={{ margin: '0 auto', width: 'max-content', paddingTop: '10vh' }}>
         <Heading
           as="h1"

--- a/src/pages/innovation-day/index.mdx
+++ b/src/pages/innovation-day/index.mdx
@@ -1,11 +1,13 @@
 ---
-title: 'wasmCloud Innovation Day 2024'
-description: 'Register for wasmCloud Innovation Day 2024'
+title: 'Innovation Day 2024 — Virtual Wasm Event'
+description: 'Register for wasmCloud Innovation Day 2024 — a one-day virtual event exploring WebAssembly, the wasmCloud platform, and real-world use cases.'
 ---
 import HubspotForm from 'react-hubspot-form';
 import styles from './_assets/innovation-day.module.css';
 
 ![wasmCloud Innovation Day](./_assets/innovation-day.png)
+
+# wasmCloud Innovation Day 2024
 
 **Time:** Wednesday, September 18, 2024 @ 10am - 6pm Eastern  
 **Place:** Virtual

--- a/src/pages/privacy-policy/index.mdx
+++ b/src/pages/privacy-policy/index.mdx
@@ -1,11 +1,11 @@
 ---
-title : "Privacy Policy"
+title: 'Privacy Policy — How We Protect Your Data'
 date: 2021-02-03T14:15:59-06:00
-description : "Wasmcloud Privacy Policy"
-draft : false
+description: 'Learn how wasmCloud collects, uses, and protects your personal information when you use our WebAssembly application platform website and services.'
+draft: false
 ---
 
-Privacy Policy
+# Privacy Policy
 
 Last updated: March 04, 2021
 
@@ -14,15 +14,15 @@ This Privacy Policy describes Our policies and procedures on the collection, use
 We use Your Personal data to provide and improve the Service. By using the Service, You agree to the collection and use of information in accordance with this Privacy Policy.
 
 
-# Interpretation and Definitions
+## Interpretation and Definitions
 
 
-## Interpretation
+### Interpretation
 
 The words of which the initial letter is capitalized have meanings defined under the following conditions. The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.
 
 
-## Definitions
+### Definitions
 
 For the purposes of this Privacy Policy:
 
@@ -71,13 +71,13 @@ For the purposes of the CCPA, Personal Data means any information that identifie
 Under GDPR (General Data Protection Regulation), You can be referred to as the Data Subject or as the User as you are the individual using the Service.
 
 
-# Collecting and Using Your Personal Data
+## Collecting and Using Your Personal Data
 
 
-## Types of Data Collected
+### Types of Data Collected
 
 
-### Personal Data
+#### Personal Data
 
 While using Our Service, We may ask You to provide Us with certain personally identifiable information that can be used to contact or identify You. Personally identifiable information may include, but is not limited to:
 
@@ -92,7 +92,7 @@ Address, State, Province, ZIP/Postal code, City
 Usage Data
 
 
-### Usage Data
+#### Usage Data
 
 Usage Data is collected automatically when using the Service.
 
@@ -103,7 +103,7 @@ When You access the Service by or through a mobile device, We may collect certai
 We may also collect information that Your browser sends whenever You visit our Service or when You access the Service by or through a mobile device.
 
 
-### Information from Third-Party Social Media Services
+#### Information from Third-Party Social Media Services
 
 The Company allows You to create an account and log in to use the Service through the following Third-party Social Media Services:
 
@@ -124,7 +124,7 @@ If You decide to register through or otherwise grant us access to a Third-Party 
 You may also have the option of sharing additional information with the Company through Your Third-Party Social Media Service's account. If You choose to provide such information and Personal Data, during registration or otherwise, You are giving the Company permission to use, share, and store it in a manner consistent with this Privacy Policy.
 
 
-### Tracking Technologies and Cookies
+#### Tracking Technologies and Cookies
 
 We use Cookies and similar tracking technologies to track the activity on Our Service and store certain information. Tracking technologies used are beacons, tags, and scripts to collect and track information and to improve and analyze Our Service. The technologies We use may include:
 
@@ -179,7 +179,7 @@ Purpose: These Cookies are used to track information about traffic to the Websit
 For more information about the cookies we use and your choices regarding cookies, please visit our Cookies Policy or the Cookies section of our Privacy Policy.
 
 
-## Use of Your Personal Data
+### Use of Your Personal Data
 
 The Company may use Personal Data for the following purposes:
 
@@ -226,14 +226,14 @@ We may share Your personal information in the following situations:
 *   
 **With Your consent**: We may disclose Your personal information for any other purpose with Your consent.
 
-## Retention of Your Personal Data
+### Retention of Your Personal Data
 
 The Company will retain Your Personal Data only for as long as is necessary for the purposes set out in this Privacy Policy. We will retain and use Your Personal Data to the extent necessary to comply with our legal obligations (for example, if we are required to retain your data to comply with applicable laws), resolve disputes, and enforce our legal agreements and policies.
 
 The Company will also retain Usage Data for internal analysis purposes. Usage Data is generally retained for a shorter period of time, except when this data is used to strengthen the security or to improve the functionality of Our Service, or We are legally obligated to retain this data for longer time periods.
 
 
-## Transfer of Your Personal Data
+### Transfer of Your Personal Data
 
 Your information, including Personal Data, is processed at the Company's operating offices and in any other places where the parties involved in the processing are located. It means that this information may be transferred to — and maintained on — computers located outside of Your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from Your jurisdiction.
 
@@ -242,20 +242,20 @@ Your consent to this Privacy Policy followed by Your submission of such informat
 The Company will take all steps reasonably necessary to ensure that Your data is treated securely and in accordance with this Privacy Policy and no transfer of Your Personal Data will take place to an organization or a country unless there are adequate controls in place including the security of Your data and other personal information.
 
 
-## Disclosure of Your Personal Data
+### Disclosure of Your Personal Data
 
 
-### Business Transactions
+#### Business Transactions
 
 If the Company is involved in a merger, acquisition or asset sale, Your Personal Data may be transferred. We will provide notice before Your Personal Data is transferred and becomes subject to a different Privacy Policy.
 
 
-### Law enforcement
+#### Law enforcement
 
 Under certain circumstances, the Company may be required to disclose Your Personal Data if required to do so by law or in response to valid requests by public authorities (e.g. a court or a government agency).
 
 
-### Other legal requirements
+#### Other legal requirements
 
 The Company may disclose Your Personal Data in the good faith belief that such action is necessary to:
 
@@ -280,17 +280,17 @@ Protect the personal safety of Users of the Service or the public
 *   
 Protect against legal liability
 
-## Security of Your Personal Data
+### Security of Your Personal Data
 
 The security of Your Personal Data is important to Us, but remember that no method of transmission over the Internet, or method of electronic storage is 100% secure. While We strive to use commercially acceptable means to protect Your Personal Data, We cannot guarantee its absolute security.
 
 
-# Detailed Information on the Processing of Your Personal Data
+## Detailed Information on the Processing of Your Personal Data
 
 The Service Providers We use may have access to Your Personal Data. These third-party vendors collect, store, use, process and transfer information about Your activity on Our Service in accordance with their Privacy Policies.
 
 
-## Analytics
+### Analytics
 
 We may use third-party Service providers to monitor and analyze the use of our Service.
 
@@ -307,7 +307,7 @@ For more information on the privacy practices of Google, please visit the Google
 Their Privacy Policy can be viewed at [https://segment.com/legal/privacy/](https://segment.com/legal/privacy/)
 
 
-## Email Marketing
+### Email Marketing
 
 We may use Your Personal Data to contact You with newsletters, marketing or promotional materials and other information that may be of interest to You. You may opt-out of receiving any, or all, of these communications from Us by following the unsubscribe link or instructions provided in any email We send or by contacting Us.
 
@@ -320,10 +320,10 @@ Mailchimp is an email marketing sending service provided by The Rocket Science G
 For more information on the privacy practices of Mailchimp, please visit their Privacy policy: [https://mailchimp.com/legal/privacy/](https://mailchimp.com/legal/privacy/)
 
 
-# GDPR Privacy
+## GDPR Privacy
 
 
-## Legal Basis for Processing Personal Data under GDPR
+### Legal Basis for Processing Personal Data under GDPR
 
 We may process Personal Data under the following conditions:
 
@@ -354,7 +354,7 @@ We may process Personal Data under the following conditions:
 In any case, the Company will gladly help to clarify the specific legal basis that applies to the processing, and in particular whether the provision of Personal Data is a statutory or contractual requirement, or a requirement necessary to enter into a contract.
 
 
-## Your Rights under the GDPR
+### Your Rights under the GDPR
 
 The Company undertakes to respect the confidentiality of Your Personal Data and to guarantee You can exercise Your rights.
 
@@ -385,17 +385,17 @@ You have the right under this Privacy Policy, and by law if You are within the E
 *   
 **Withdraw Your consent.** You have the right to withdraw Your consent on using your Personal Data. If You withdraw Your consent, We may not be able to provide You with access to certain specific functionalities of the Service.
 
-## Exercising of Your GDPR Data Protection Rights
+### Exercising of Your GDPR Data Protection Rights
 
 You may exercise Your rights of access, rectification, cancellation and opposition by contacting Us. Please note that we may ask You to verify Your identity before responding to such requests. If You make a request, We will try our best to respond to You as soon as possible.
 
 You have the right to complain to a Data Protection Authority about Our collection and use of Your Personal Data. For more information, if You are in the European Economic Area (EEA), please contact Your local data protection authority in the EEA.
 
 
-# Facebook Fan Page
+## Facebook Fan Page
 
 
-## Data Controller for the Facebook Fan Page
+### Data Controller for the Facebook Fan Page
 
 The Company is the Data Controller of Your Personal Data collected while using the Service. As operator of the Facebook Fan Page [https://www.facebook.com/WasmCloud/](https://www.facebook.com/WasmCloud/), the Company and the operator of the social network Facebook are Joint Controllers.
 
@@ -404,7 +404,7 @@ The Company has entered into agreements with Facebook that define the terms for 
 Visit the Facebook Privacy Policy [https://www.facebook.com/policy.php](https://www.facebook.com/policy.php) for more information about how Facebook manages Personal data or contact Facebook online, or by mail: Facebook, Inc. ATTN, Privacy Operations, 1601 Willow Road, Menlo Park, CA 94025, United States.
 
 
-## Facebook Insights
+### Facebook Insights
 
 We use the Facebook Insights function in connection with the operation of the Facebook Fan Page and on the basis of the GDPR, in order to obtain anonymized statistical data about Our users.
 
@@ -415,12 +415,12 @@ Facebook receives, records and processes the information stored in the Cookie, e
 For more information on the privacy practices of Facebook, please visit Facebook Privacy Policy here: [https://www.facebook.com/full_data_use_policy](https://www.facebook.com/full_data_use_policy)
 
 
-# CCPA Privacy
+## CCPA Privacy
 
 This privacy notice section for California residents supplements the information contained in Our Privacy Policy and it applies solely to all visitors, users, and others who reside in the State of California.
 
 
-## Categories of Personal Information Collected
+### Categories of Personal Information Collected
 
 We collect information that identifies, relates to, describes, references, is capable of being associated with, or could reasonably be linked, directly or indirectly, with a particular Consumer or Device. The following is a list of categories of personal information which we may collect or may have been collected from California residents within the last twelve (12) months.
 
@@ -516,7 +516,7 @@ Health or medical information covered by the Health Insurance Portability and Ac
 *   
 Personal Information covered by certain sector-specific privacy laws, including the Fair Credit Reporting Act (FRCA), the Gramm-Leach-Bliley Act (GLBA) or California Financial Information Privacy Act (FIPA), and the Driver's Privacy Protection Act of 1994
 
-## Sources of Personal Information
+### Sources of Personal Information
 
 We obtain the categories of personal information listed above from the following categories of sources:
 
@@ -537,7 +537,7 @@ We obtain the categories of personal information listed above from the following
 *   
 **From Service Providers**. For example, third-party vendors to monitor and analyze the use of our Service, or other third-party vendors that We use to provide the Service to You.
 
-## Use of Personal Information for Business Purposes or Commercial Purposes
+### Use of Personal Information for Business Purposes or Commercial Purposes
 
 We may use or disclose personal information We collect for "business purposes" or "commercial purposes" (as defined under the CCPA), which may include the following examples:
 
@@ -574,7 +574,7 @@ Please note that the examples provided above are illustrative and not intended t
 If We decide to collect additional categories of personal information or use the personal information We collected for materially different, unrelated, or incompatible purposes We will update this Privacy Policy.
 
 
-## Disclosure of Personal Information for Business Purposes or Commercial Purposes
+### Disclosure of Personal Information for Business Purposes or Commercial Purposes
 
 We may use or disclose and may have used or disclosed in the last twelve (12) months the following categories of personal information for business or commercial purposes:
 
@@ -589,7 +589,7 @@ Please note that the categories listed above are those defined in the CCPA. This
 When We disclose personal information for a business purpose or a commercial purpose, We enter a contract that describes the purpose and requires the recipient to both keep that personal information confidential and not use it for any purpose except performing the contract.
 
 
-## Sale of Personal Information
+### Sale of Personal Information
 
 As defined in the CCPA, "sell" and "sale" mean selling, renting, releasing, disclosing, disseminating, making available, transferring, or otherwise communicating orally, in writing, or by electronic or other means, a consumer's personal information by the business to a third party for valuable consideration. This means that We may have received some kind of benefit in return for sharing personal information, but not necessarily a monetary benefit.
 
@@ -604,7 +604,7 @@ Category B: Personal information categories listed in the California Customer Re
 Category F: Internet or other similar network activity
 
 
-## Share of Personal Information
+### Share of Personal Information
 
 We may share Your personal information identified in the above categories with the following categories of third parties:
 
@@ -617,7 +617,7 @@ Our business partners
 Third party vendors to whom You or Your agents authorize Us to disclose Your personal information in connection with products or services We provide to You
 
 
-## Sale of Personal Information of Minors Under 16 Years of Age
+### Sale of Personal Information of Minors Under 16 Years of Age
 
 We do not knowingly collect personal information from minors under the age of 16 through our Service, although certain third party websites that we link to may do so. These third-party websites have their own terms of use and privacy policies and we encourage parents and legal guardians to monitor their children's Internet usage and instruct their children to never provide information on other websites without their permission.
 
@@ -626,7 +626,7 @@ We do not sell the personal information of Consumers We actually know are less t
 If You have reason to believe that a child under the age of 13 (or 16) has provided Us with personal information, please contact Us with sufficient detail to enable Us to delete that information.
 
 
-## Your Rights under the CCPA
+### Your Rights under the CCPA
 
 The CCPA provides California residents with specific rights regarding their personal information. If You are a resident of California, You have the following rights:
 
@@ -735,7 +735,7 @@ Providing a different level or quality of goods or services to You
 *   
 Suggesting that You will receive a different price or rate for goods or services or a different level or quality of goods or services
 
-## Exercising Your CCPA Data Protection Rights
+### Exercising Your CCPA Data Protection Rights
 
 In order to exercise any of Your rights under the CCPA, and if You are a California resident, You can contact Us:
 
@@ -772,7 +772,7 @@ Any disclosures We provide will only cover the 12-month period preceding the ver
 For data portability requests, We will select a format to provide Your personal information that is readily useable and should allow You to transmit the information from one entity to another entity without hindrance.
 
 
-## Do Not Sell My Personal Information
+### Do Not Sell My Personal Information
 
 You have the right to opt-out of the sale of Your personal information. Once We receive and confirm a verifiable consumer request from You, we will stop selling Your personal information. To exercise Your right to opt-out, please contact Us.
 
@@ -781,7 +781,7 @@ The Service Providers we partner with (for example, our analytics or advertising
 Please note that any opt out is specific to the browser You use. You may need to opt out on every browser that You use.
 
 
-### Website
+#### Website
 
 You can opt out of receiving ads that are personalized as served by our Service Providers by following our instructions presented on the Service:
 
@@ -800,7 +800,7 @@ The DAA's opt-out platform: [http://optout.aboutads.info/?c=2&lang=EN](http://op
 The opt out will place a cookie on Your computer that is unique to the browser You use to opt out. If you change browsers or delete the cookies saved by your browser, You will need to opt out again.
 
 
-### Mobile Devices
+#### Mobile Devices
 
 Your mobile device may give You the ability to opt out of the use of information about the apps You use in order to serve You ads that are targeted to Your interests:
 
@@ -815,28 +815,28 @@ Your mobile device may give You the ability to opt out of the use of information
 You can also stop the collection of location information from Your mobile device by changing the preferences on Your mobile device.
 
 
-# "Do Not Track" Policy as Required by California Online Privacy Protection Act (CalOPPA)
+## "Do Not Track" Policy as Required by California Online Privacy Protection Act (CalOPPA)
 
 Our Service does not respond to Do Not Track signals.
 
 However, some third party websites do keep track of Your browsing activities. If You are visiting such websites, You can set Your preferences in Your web browser to inform websites that You do not want to be tracked. You can enable or disable DNT by visiting the preferences or settings page of Your web browser.
 
 
-# Children's Privacy
+## Children's Privacy
 
 Our Service does not address anyone under the age of 13. We do not knowingly collect personally identifiable information from anyone under the age of 13. If You are a parent or guardian and You are aware that Your child has provided Us with Personal Data, please contact Us. If We become aware that We have collected Personal Data from anyone under the age of 13 without verification of parental consent, We take steps to remove that information from Our servers.
 
 If We need to rely on consent as a legal basis for processing Your information and Your country requires consent from a parent, We may require Your parent's consent before We collect and use that information.
 
 
-# Your California Privacy Rights (California's Shine the Light law)
+## Your California Privacy Rights (California's Shine the Light law)
 
 Under California Civil Code Section 1798 (California's Shine the Light law), California residents with an established business relationship with us can request information once a year about sharing their Personal Data with third parties for the third parties' direct marketing purposes.
 
 If you'd like to request more information under the California Shine the Light law, and if You are a California resident, You can contact Us using the contact information provided below.
 
 
-# California Privacy Rights for Minor Users (California Business and Professions Code Section 22581)
+## California Privacy Rights for Minor Users (California Business and Professions Code Section 22581)
 
 California Business and Professions Code section 22581 allow California residents under the age of 18 who are registered users of online sites, services or applications to request and obtain removal of content or information they have publicly posted.
 
@@ -845,14 +845,14 @@ To request removal of such data, and if You are a California resident, You can c
 Be aware that Your request does not guarantee complete or comprehensive removal of content or information posted online and that the law may not permit or require removal in certain circumstances.
 
 
-# Links to Other Websites
+## Links to Other Websites
 
 Our Service may contain links to other websites that are not operated by Us. If You click on a third party link, You will be directed to that third party's site. We strongly advise You to review the Privacy Policy of every site You visit.
 
 We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.
 
 
-# Changes to this Privacy Policy
+## Changes to this Privacy Policy
 
 We may update Our Privacy Policy from time to time. We will notify You of any changes by posting the new Privacy Policy on this page.
 
@@ -861,7 +861,7 @@ We will let You know via email and/or a prominent notice on Our Service, prior t
 You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
 
 
-# Contact Us
+## Contact Us
 
 If you have any questions about this Privacy Policy, You can contact us:
 

--- a/src/pages/swag/index.mdx
+++ b/src/pages/swag/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'wasmCloud Swag'
-description: 'Get your wasmCloud swag here!'
+title: 'Swag Store — Stickers, Shirts & More'
+description: 'Get official wasmCloud swag including stickers, t-shirts, and apparel for the WebAssembly application platform community. Free to claim while supplies last.'
 ---
 
 import HubspotForm from 'react-hubspot-form';

--- a/src/pages/terms-conditions/index.mdx
+++ b/src/pages/terms-conditions/index.mdx
@@ -1,26 +1,26 @@
 ---
-title : "Terms & Conditions"
+title: 'Terms & Conditions — Service Agreement'
 date: 2021-02-03T14:15:59-06:00
-description : "Wasmcloud Terms & Conditions"
-draft : false
+description: 'The terms and conditions governing use of the wasmCloud WebAssembly application platform website, documentation, and community resources.'
+draft: false
 ---
 
-Terms and Conditions
+# Terms and Conditions
 
 Last updated: March 04, 2021
 
 Please read these terms and conditions carefully before using Our Service.
 
 
-# Interpretation and Definitions
+## Interpretation and Definitions
 
 
-## Interpretation
+### Interpretation
 
 The words of which the initial letter is capitalized have meanings defined under the following conditions. The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.
 
 
-## Definitions
+### Definitions
 
 For the purposes of these Terms and Conditions:
 
@@ -58,7 +58,7 @@ For the purposes of these Terms and Conditions:
 **You** means the individual accessing or using the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.
 
 
-# Acknowledgment
+## Acknowledgment
 
 These are the Terms and Conditions governing the use of this Service and the agreement that operates between You and the Company. These Terms and Conditions set out the rights and obligations of all users regarding the use of the Service.
 
@@ -71,14 +71,14 @@ You represent that you are over the age of 18. The Company does not permit those
 Your access to and use of the Service is also conditioned on Your acceptance of and compliance with the Privacy Policy of the Company. Our Privacy Policy describes Our policies and procedures on the collection, use and disclosure of Your personal information when You use the Application or the Website and tells You about Your privacy rights and how the law protects You. Please read Our Privacy Policy carefully before using Our Service.
 
 
-# Promotions
+## Promotions
 
 Any Promotions made available through the Service may be governed by rules that are separate from these Terms.
 
 If You participate in any Promotions, please review the applicable rules as well as our Privacy policy. If the rules for a Promotion conflict with these Terms, the Promotion rules will apply.
 
 
-# Intellectual Property
+## Intellectual Property
 
 The Service and its original content (excluding Content provided by You or other users), features and functionality are and will remain the exclusive property of the Company and its licensors.
 
@@ -87,12 +87,12 @@ The Service is protected by copyright, trademark, and other laws of both the Cou
 Our trademarks and trade dress may not be used in connection with any product or service without the prior written consent of the Company.
 
 
-# Your Feedback to Us
+## Your Feedback to Us
 
 You assign all rights, title and interest in any Feedback You provide the Company. If for any reason such assignment is ineffective, You agree to grant the Company a non-exclusive, perpetual, irrevocable, royalty free, worldwide right and license to use, reproduce, disclose, sub-license, distribute, modify and exploit such Feedback without restriction.
 
 
-# Links to Other Websites
+## Links to Other Websites
 
 Our Service may contain links to third-party web sites or services that are not owned or controlled by the Company.
 
@@ -101,14 +101,14 @@ The Company has no control over, and assumes no responsibility for, the content,
 We strongly advise You to read the terms and conditions and privacy policies of any third-party web sites or services that You visit.
 
 
-# Termination
+## Termination
 
 We may terminate or suspend Your access immediately, without prior notice or liability, for any reason whatsoever, including without limitation if You breach these Terms and Conditions.
 
 Upon termination, Your right to use the Service will cease immediately.
 
 
-# Limitation of Liability
+## Limitation of Liability
 
 Notwithstanding any damages that You might incur, the entire liability of the Company and any of its suppliers under any provision of this Terms and Your exclusive remedy for all of the foregoing shall be limited to the amount actually paid by You through the Service or 100 USD if You haven't purchased anything through the Service.
 
@@ -117,7 +117,7 @@ To the maximum extent permitted by applicable law, in no event shall the Company
 Some states do not allow the exclusion of implied warranties or limitation of liability for incidental or consequential damages, which means that some of the above limitations may not apply. In these states, each party's liability will be limited to the greatest extent permitted by law.
 
 
-# "AS IS" and "AS AVAILABLE" Disclaimer
+## "AS IS" and "AS AVAILABLE" Disclaimer
 
 The Service is provided to You "AS IS" and "AS AVAILABLE" and with all faults and defects without warranty of any kind. To the maximum extent permitted under applicable law, the Company, on its own behalf and on behalf of its Affiliates and its and their respective licensors and service providers, expressly disclaims all warranties, whether express, implied, statutory or otherwise, with respect to the Service, including all implied warranties of merchantability, fitness for a particular purpose, title and non-infringement, and warranties that may arise out of course of dealing, course of performance, usage or trade practice. Without limitation to the foregoing, the Company provides no warranty or undertaking, and makes no representation of any kind that the Service will meet Your requirements, achieve any intended results, be compatible or work with any other software, applications, systems or services, operate without interruption, meet any performance or reliability standards or be error free or that any errors or defects can or will be corrected.
 
@@ -126,52 +126,52 @@ Without limiting the foregoing, neither the Company nor any of the company's pro
 Some jurisdictions do not allow the exclusion of certain types of warranties or limitations on applicable statutory rights of a consumer, so some or all of the above exclusions and limitations may not apply to You. But in such a case the exclusions and limitations set forth in this section shall be applied to the greatest extent enforceable under applicable law.
 
 
-# Governing Law
+## Governing Law
 
 The laws of the Country, excluding its conflicts of law rules, shall govern this Terms and Your use of the Service. Your use of the Application may also be subject to other local, state, national, or international laws.
 
 
-# Disputes Resolution
+## Disputes Resolution
 
 If You have any concern or dispute about the Service, You agree to first try to resolve the dispute informally by contacting the Company.
 
 
-# For European Union (EU) Users
+## For European Union (EU) Users
 
 If You are a European Union consumer, you will benefit from any mandatory provisions of the law of the country in which you are resident in.
 
 
-# United States Legal Compliance
+## United States Legal Compliance
 
 You represent and warrant that (i) You are not located in a country that is subject to the United States government embargo, or that has been designated by the United States government as a "terrorist supporting" country, and (ii) You are not listed on any United States government list of prohibited or restricted parties.
 
 
-# Severability and Waiver
+## Severability and Waiver
 
 
-## Severability
+### Severability
 
 If any provision of these Terms is held to be unenforceable or invalid, such provision will be changed and interpreted to accomplish the objectives of such provision to the greatest extent possible under applicable law and the remaining provisions will continue in full force and effect.
 
 
-## Waiver
+### Waiver
 
 Except as provided herein, the failure to exercise a right or to require performance of an obligation under this Terms shall not effect a party's ability to exercise such right or require such performance at any time thereafter nor shall be the waiver of a breach constitute a waiver of any subsequent breach.
 
 
-# Translation Interpretation
+## Translation Interpretation
 
 These Terms and Conditions may have been translated if We have made them available to You on our Service. You agree that the original English text shall prevail in the case of a dispute.
 
 
-# Changes to These Terms and Conditions
+## Changes to These Terms and Conditions
 
 We reserve the right, at Our sole discretion, to modify or replace these Terms at any time. If a revision is material We will make reasonable efforts to provide at least 30 days' notice prior to any new terms taking effect. What constitutes a material change will be determined at Our sole discretion.
 
 By continuing to access or use Our Service after those revisions become effective, You agree to be bound by the revised terms. If You do not agree to the new terms, in whole or in part, please stop using the website and the Service.
 
 
-# Contact Us
+## Contact Us
 
 If you have any questions about these Terms and Conditions, You can contact us:
 


### PR DESCRIPTION
…ructure

- Normalized all page titles to 30-60 characters with target keywords
- Added/fixed meta descriptions (120-160 chars) on all pages
- Added complete Open Graph and Twitter Card meta tags
- Fixed H1 tags: one per page, keyword-aligned
- Corrected heading hierarchy (no skipped levels)
- Added canonical URLs where missing


