### PR TITLE
docs: cover wasmCloud 2.2.0 features

### DIFF
--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -89,7 +89,9 @@ operator:
     - team-b
 ```
 
-When `watchNamespaces` is populated, the chart generates namespace-scoped `Role` and `RoleBinding` resources for each listed namespace (instead of a single `ClusterRole`).
+When `watchNamespaces` is populated, the chart narrows the operator's reach into per-workload resources. The rules for `configmaps`, `secrets`, `events`, and `services` move out of the operator's main `ClusterRole` and into a separate `ClusterRole` (`<release>-workload-namespace`) that's bound via a `RoleBinding` in each listed namespace. The operator's core grants (workload, host, and CRD APIs) stay on the main `ClusterRole` + `ClusterRoleBinding`, since they need to be cluster-wide regardless of which namespaces hold workloads.
+
+The net effect is that the operator's read/write access to namespaced workload inputs (config, secrets) and outputs (events, services) is scoped to exactly the namespaces in `watchNamespaces`, while the cluster-scoped resources it manages remain available everywhere.
 
 ### `operator.hostNamespaces`
 

--- a/docs/overview/interfaces.mdx
+++ b/docs/overview/interfaces.mdx
@@ -147,6 +147,11 @@ Additionally, wasmCloud supports proposed WASI APIs that are in the process of i
 | https://github.com/WebAssembly/wasi-blobstore | 0.2.0-draft |
 | https://github.com/WebAssembly/wasi-keyvalue  | 0.2.0-draft |
 | https://github.com/WebAssembly/wasi-logging   | 0.1.0-draft |
+| https://github.com/WebAssembly/wasi-tls       | 0.3.0-draft |
+
+:::info[wasi-tls]
+`wasi:tls` (added in wasmCloud 2.2) lets components terminate TLS connections themselves over `wasi:sockets` using the WASI Preview 3 `wasi:tls/client` and `wasi:tls/types` interfaces. Support is opt-in via the `wasi-tls` Cargo feature on `wash-runtime` while the upstream WIT stabilizes. Embedders can register a custom TLS provider through `EngineBuilder::with_tls_provider` — see [Building Custom Hosts](../runtime/building-custom-hosts.mdx#tls-for-wasitls-components) for details.
+:::
 
 ### wasmCloud interfaces
 

--- a/docs/runtime/building-custom-hosts.mdx
+++ b/docs/runtime/building-custom-hosts.mdx
@@ -112,6 +112,31 @@ let engine = Engine::builder()
 The pooling allocator is automatically enabled on machines with sufficient virtual memory. You can override this behavior with the `with_pooling_allocator()` method.
 :::
 
+### TLS for `wasi:tls` components
+
+`wash-runtime` 2.2 added support for the WASI Preview 3 [`wasi:tls`](https://github.com/WebAssembly/wasi-tls) interfaces, letting components terminate TLS connections themselves over `wasi:sockets`. This is distinct from [host-side HTTPS termination](../recipes/tls-bring-your-own-certificates.mdx) — `wasi:tls` is the option to reach for when a component needs to own the TLS session (for example, to connect to a third-party service or a database that requires TLS).
+
+To enable it, build `wash-runtime` with the `wasi-tls` Cargo feature:
+
+```toml
+[dependencies]
+wash-runtime = { version = "2.2", features = ["wasi-tls"] }
+```
+
+The feature is opt-in while the underlying WIT interfaces (`wasi:tls/client` and `wasi:tls/types@0.3.0-draft`) stabilize. When enabled, the engine wires `wasmtime-wasi-tls` into the linker and uses its default `rustls`-backed provider.
+
+To override the provider — to install a custom root store, pin a specific certificate, or bridge to an HSM-backed key — register a `SharedTlsProvider` on the engine builder:
+
+```rust
+use wash_runtime::engine::Engine;
+
+let engine = Engine::builder()
+    .with_tls_provider(my_custom_provider)
+    .build()?;
+```
+
+If the `wasi-tls` feature is enabled but no provider is set, the runtime falls back to the `wasmtime-wasi-tls` default and logs a warning recommending `EngineBuilder::with_tls_provider`.
+
 ## Building the Host
 
 Use `HostBuilder` to construct a host with your desired configuration. All capabilities (HTTP, key-value, configuration, etc.) are provided as plugins:
@@ -156,6 +181,33 @@ let host = host.start().await?;
 | `with_label(key, value)` | Add metadata labels for identification |
 | `with_http_handler(Arc<dyn HostHandler>)` | Register the HTTP handler (`HttpServer` implements `HostHandler`, not `HostPlugin`) |
 | `with_plugin(Arc<dyn HostPlugin>)` | Register a plugin (can be called multiple times; IDs must be unique) |
+
+### Customizing outgoing HTTP requests
+
+By default, every outbound HTTP request from a component flows through `wasmtime-wasi-http`'s `default_send_request`. For most embedders that's the right behavior — but if you need to thread custom TLS configuration through outgoing calls, swap in an alternative transport (an internal RPC system, for example), or insert middleware-style policy at the egress boundary, `wash-runtime` 2.2 introduced the `OutgoingHandler` trait as a pluggable extension point on the HTTP server.
+
+Implement `OutgoingHandler` on your own type, then supply it to `HttpServerBuilder::outgoing_handler` when constructing the HTTP server:
+
+```rust
+use wash_runtime::host::http::{HttpServer, DevRouter, OutgoingHandler};
+
+struct MyEgressHandler { /* ... */ }
+
+impl OutgoingHandler for MyEgressHandler {
+    // ...
+}
+
+let http_handler = HttpServer::builder()
+    .router(DevRouter::default())
+    .bind_address("127.0.0.1:8080".parse()?)
+    .outgoing_handler(MyEgressHandler { /* ... */ })
+    .build()
+    .await?;
+```
+
+The runtime calls into your handler for every outbound HTTP request from any component the host runs. If you don't register one, `DefaultOutgoingHandler` is used, which delegates to `wasmtime_wasi_http::p2::default_send_request` (or the P3 equivalent for P3 components).
+
+`OutgoingHandler` and `wasi:tls` are complementary: `wasi:tls` lets *components* own their TLS session, while `OutgoingHandler` lets the *host* shape egress uniformly across every component it runs.
 
 ## Managing workloads
 

--- a/docs/wash/commands.mdx
+++ b/docs/wash/commands.mdx
@@ -100,6 +100,8 @@ View configuration for wash.
 * `init` - Initialize a new configuration file for wash
 * `info` - Print the current version and local directories used by wash
 * `show` - Print the current configuration file for wash
+* `cleanup` - Remove the wash cache and/or data directories
+* `validate` - Check the current configuration for hard errors
 
 ###### **Options:**
 
@@ -111,14 +113,16 @@ View configuration for wash.
 
 ## `wash config init`
 
-Initialize a new configuration file for wash.
+Initialize a new configuration file for wash. Writes to the project-local `.wash/` directory.
 
 **Usage:** `wash config init [OPTIONS]`
 
 ###### **Options:**
 
 * `--force` - Overwrite existing configuration
-* `--global` - Overwrite global configuration instead of project
+* `--format <CONFIG_FORMAT>` - Serialization format for the generated file (`yaml`, `yml`, `json`, or `toml`) [default: `yaml`]
+* `--example` - Populate every section with illustrative example values
+* `--global` - Deprecated and has no effect; the command always writes to the project-local `.wash/` directory
 * `-l`, `--log-level <LOG_LEVEL>` — Set the log level (`trace`, `debug`, `info`, `warn`, `error`) [default: `info`]
 * `--non-interactive` - Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
 * `-o`, `--output <OUTPUT_FORMAT>` — Specify output format (`text` or `json`) [default: `text`]
@@ -149,6 +153,41 @@ Print the current configuration file for wash.
 
 ###### **Options:**
 
+* `-l`, `--log-level <LOG_LEVEL>` — Set the log level (`trace`, `debug`, `info`, `warn`, `error`) [default: `info`]
+* `--non-interactive` - Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
+* `-o`, `--output <OUTPUT_FORMAT>` — Specify output format (`text` or `json`) [default: `text`]
+* `--user-config <USER_CONFIG>` - Path to user configuration file.
+* `--verbose` - Enable verbose output
+* `-h`, `--help` - Print help
+
+## `wash config cleanup`
+
+Remove the wash cache and/or data directories. Useful for reclaiming disk space or recovering from a corrupted cache.
+
+**Usage:** `wash config cleanup [OPTIONS]`
+
+###### **Options:**
+
+* `--cache` - Remove only the wash cache directory
+* `--data` - Remove only the wash data directory
+* `--all` - Remove both the cache and data directories
+* `--dry-run` - Print what would be removed (with per-directory sizes) without deleting anything
+* `-l`, `--log-level <LOG_LEVEL>` — Set the log level (`trace`, `debug`, `info`, `warn`, `error`) [default: `info`]
+* `--non-interactive` - Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
+* `-o`, `--output <OUTPUT_FORMAT>` — Specify output format (`text` or `json`) [default: `text`]
+* `--user-config <USER_CONFIG>` - Path to user configuration file.
+* `--verbose` - Enable verbose output
+* `-h`, `--help` - Print help
+
+## `wash config validate`
+
+Check the loaded configuration for hard errors before you run anything against it. Validation covers socket-address syntax, `redis://`/`nats://`/`postgres://` URL schemes, paired TLS cert and key files, WebGPU availability on Windows, non-empty build commands, well-formed WIT registry URLs, and local WIT source paths that actually exist on disk. Remote sources (HTTP, Git, OCI) are skipped. Errors are collected from every section before the command returns, so every issue surfaces in one pass.
+
+**Usage:** `wash config validate [OPTIONS]`
+
+###### **Options:**
+
+* `--file <FILE>` - Validate a specific config file instead of the merged project config
 * `-l`, `--log-level <LOG_LEVEL>` — Set the log level (`trace`, `debug`, `info`, `warn`, `error`) [default: `info`]
 * `--non-interactive` - Run in non-interactive mode (skip terminal checks for host exec). Automatically enabled when stdin is not a TTY
 * `-o`, `--output <OUTPUT_FORMAT>` — Specify output format (`text` or `json`) [default: `text`]

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -28,6 +28,56 @@ Configuration is merged with the following precedence (highest to lowest):
 4. User config (`$HOME/.config/wash/config.yaml`)
 5. Default values
 
+## Managing the config file
+
+`wash` ships three subcommands for managing the project-local config file in `.wash/`. Together they cover the typical lifecycle: scaffold a working file, check it before you run anything against it, and clean up stale state when something goes wrong.
+
+### Creating a new config
+
+Use `wash config init` to create a starter file. The `--example` flag populates every section with illustrative values, which is the fastest way to see what `wash` accepts:
+
+```shell
+wash config init --example
+```
+
+The `--format` flag selects the serialization format. `yaml` is the default; `yml`, `json`, and `toml` are also supported:
+
+```shell
+wash config init --format toml --example
+```
+
+`init` always writes to the project-local `.wash/` directory. The legacy `--global` flag is deprecated and has no effect.
+
+### Validating a config
+
+Run `wash config validate` to catch hard errors in the merged project configuration before they show up at runtime:
+
+```shell
+wash config validate
+```
+
+Validation covers socket-address syntax, `redis://` / `nats://` / `postgres://` URL schemes, paired TLS cert and key files, WebGPU availability on Windows, non-empty build commands, well-formed WIT registry URLs, and local WIT source paths that actually exist on disk. Remote sources (HTTP, Git, OCI) are skipped — `validate` doesn't reach out to the network. Errors are collected across every section before the command returns, so every issue surfaces in one pass.
+
+To validate a specific file instead of the merged project config (useful when working with multiple variants), pass `--file`:
+
+```shell
+wash config validate --file ./alternate-config.yaml
+```
+
+### Cleaning up cache and data directories
+
+`wash config cleanup` removes the wash cache and/or data directories. Use it to reclaim disk space or to recover from a corrupted cache. Always preview with `--dry-run` first to see what would be removed and how much space it would free:
+
+```shell
+# Preview
+wash config cleanup --all --dry-run
+
+# Apply
+wash config cleanup --all
+```
+
+Use `--cache` or `--data` instead of `--all` to target a single directory.
+
 ## User configuration
 
 By default, user configuration files are found at `$HOME/.config/wash/config.yaml`. 

--- a/docs/wash/registries.mdx
+++ b/docs/wash/registries.mdx
@@ -38,6 +38,27 @@ Pull the component from your registry:
 wash oci pull ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
 ```
 
+## wasmCloud first-party WIT interfaces
+
+Starting in wasmCloud 2.2, the project's first-party WIT packages are published to GitHub Container Registry at `ghcr.io/wasmcloud/interfaces/<name>:<version>`. Each package is built with `wash wit build`, has provenance embedded via `wasm-tools metadata add`, and ships with a [GitHub attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) that the publish workflow attaches at release time. Stable version tags are immutable — re-pushing an existing tag is a no-op — so consumers can pin to a specific version with confidence.
+
+Available today:
+
+* `ghcr.io/wasmcloud/interfaces/wasmcloud-messaging`
+* `ghcr.io/wasmcloud/interfaces/wasmcloud-secrets`
+
+Additional interfaces will follow as the project-root inventory grows. To pull one into a `wash` project, add it as a WIT dependency in `.wash/config.yaml`:
+
+```yaml
+wit:
+  registries:
+    - url: "ghcr.io/wasmcloud/interfaces"
+  sources:
+    "wasmcloud:messaging": "ghcr.io/wasmcloud/interfaces/wasmcloud-messaging:0.2.0"
+```
+
+Or fetch a package directly with the OCI client of your choice (e.g. `wkg`, `oras`).
+
 ## Further reading
 
 * `wash` uses the `oras` client library (Rust) for OCI functionality. See the [`oras` documentation](https://oras.land/docs/) for more information.


### PR DESCRIPTION
Documents the user-facing changes that shipped in wasmCloud 2.2.0, mirroring the [release blog](https://github.com/wasmCloud/wasmcloud.com/blob/wasmcloud-2.2.0-blog/blog/2026-05-21-wasmcloud-2.2.0/index.mdx).