### PR TITLE
docs: bump wash version references to 2.2.0

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -25,7 +25,7 @@ Install the parts of the [wasmCloud platform](./overview/index.mdx) that you nee
 <Tabs groupId="macoslinux-method" queryString>
   <TabItem value="script" label="Install script" default>
 
-In your terminal, run the installation script to download and install the latest version of `wash` (**`2.0.4`**):
+In your terminal, run the installation script to download and install the latest version of `wash` (**`{{WASMCLOUD_VERSION}}`**):
 
 ```shell
 curl -fsSL https://wasmcloud.com/sh | bash

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -106,7 +106,7 @@ Specify the `wash` version for this project.
 Example:
 
 ```yaml
-version: 2.0.1
+version: 2.2.0
 ```
 
 ### `build` configuration

--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,1 +1,1 @@
-export const WASMCLOUD_VERSION = '2.0.6';
+export const WASMCLOUD_VERSION = '2.2.0';


### PR DESCRIPTION
Bumps the canonical `WASMCLOUD_VERSION` constant to 2.2.0, fixes one hardcoded `2.0.4` in the installation page, and updates the example `version` field in `docs/wash/config.mdx`.