### PR TITLE
docs: clarify wasmCloud's rustls + aws-lc-rs default in building-custom-hosts

### DIFF
--- a/docs/runtime/building-custom-hosts.mdx
+++ b/docs/runtime/building-custom-hosts.mdx
@@ -123,7 +123,7 @@ To enable it, build `wash-runtime` with the `wasi-tls` Cargo feature:
 wash-runtime = { version = "2.2", features = ["wasi-tls"] }
 ```
 
-The feature is opt-in while the underlying WIT interfaces (`wasi:tls/client` and `wasi:tls/types@0.3.0-draft`) stabilize. When enabled, the engine wires `wasmtime-wasi-tls` into the linker and uses its default `rustls`-backed provider.
+The feature is opt-in while the underlying WIT interfaces (`wasi:tls/client` and `wasi:tls/types@0.3.0-draft`) stabilize. When enabled, the engine wires `wasmtime-wasi-tls` into the linker. wasmCloud standardizes on [`rustls`](https://github.com/rustls/rustls) backed by [`aws-lc-rs`](https://github.com/aws/aws-lc-rs), not the upstream `ring` default: `wash-runtime`'s `init_crypto()` installs `aws-lc-rs` as the process-level rustls provider at startup, and the workspace `rustls` pin compiles `ring` out of the dependency tree entirely.
 
 To override the provider — to install a custom root store, pin a specific certificate, or bridge to an HSM-backed key — register a `SharedTlsProvider` on the engine builder:
 


### PR DESCRIPTION
Same correction @ricochet flagged on the 2.2.0 blog draft (#1160), applied to the corresponding paragraph in `docs/runtime/building-custom-hosts.mdx`. wasmCloud pins rustls with `aws-lc-rs` (not `ring`); `wash-runtime`'s `init_crypto()` installs it at startup and the workspace Cargo.toml compiles `ring` out of the dep tree.