### PR TITLE
fix(community): replace invalid paragraph wrappers around YouTube links

### DIFF
--- a/community/2025-05-14-community-meeting-transcript.mdx
+++ b/community/2025-05-14-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=bD_ECH8vg5U" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=bD_ECH8vg5U" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=bD_ECH8vg5U" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, May 14, 2025 · 37 minutes*
 

--- a/community/2025-05-14-community-meeting.mdx
+++ b/community/2025-05-14-community-meeting.mdx
@@ -33,13 +33,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=bD_ECH8vg5U" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=bD_ECH8vg5U" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=bD_ECH8vg5U" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 14, 2025 wasmCloud community call brings back the "Documentation of the Week" and "Issue of the Week" segments and digs into two practical threads in the **Wasm component model**. Brooks Townsend walks through the experimental **error handling for custom interfaces** landed in wasmCloud 1.8 — where wRPC surfaces platform-level transport errors to the guest instead of panicking — and turns the gap in its docs into an Issue of the Week. Victor Adossi then demos a new TypeScript example that runs the popular **axios** HTTP library inside a WebAssembly component, and the team gives kudos for a new cron job capability provider and per-component memory limits.
 

--- a/community/2025-05-21-community-meeting-transcript.mdx
+++ b/community/2025-05-21-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=_3GQ1WHjvFI" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=_3GQ1WHjvFI" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=_3GQ1WHjvFI" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, May 21, 2025 · 25 minutes*
 

--- a/community/2025-05-21-community-meeting.mdx
+++ b/community/2025-05-21-community-meeting.mdx
@@ -32,13 +32,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=_3GQ1WHjvFI" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=_3GQ1WHjvFI" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=_3GQ1WHjvFI" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 21, 2025 wasmCloud community call is a short, reflective one centered on the **Wasm component model** and the standards beneath it. Brooks Townsend walks through his new blog post celebrating **a year of wasmCloud 1.0** — built on WASI 0.2, WIT, and the component model — and the deliberate bet on WebAssembly standards that drove community growth. Taylor Thomas and Liam Randall look ahead to wasmCloud 2.0, WASI 0.3, and a more pluggable host shaped by user design feedback. The call closes with an Issue of the Week and a Documentation of the Week highlighting a new capability-provider icon.
 

--- a/community/2025-05-28-community-meeting-transcript.mdx
+++ b/community/2025-05-28-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=BWlfrXOXALc" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=BWlfrXOXALc" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=BWlfrXOXALc" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, May 28, 2025 · 72 minutes*
 

--- a/community/2025-05-28-community-meeting.mdx
+++ b/community/2025-05-28-community-meeting.mdx
@@ -37,13 +37,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=BWlfrXOXALc" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=BWlfrXOXALc" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=BWlfrXOXALc" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 28, 2025 wasmCloud community call is a short, hands-on session about testing **Wasm component model** functions. Brooks Townsend demos `wasmtime run --invoke` — a new flag in Wasmtime 33 that calls any exported function on a WebAssembly component directly from the command line, passing strongly typed arguments via the **WebAssembly Value Encoding (WAVE)** syntax. That sparks a discussion about bringing the same ergonomics to wasmCloud's `wash call`. The team then reviews the Q2 2025 roadmap, and Florian Fürstenberg presents a detailed investigation into why an overloaded Hello World component can deadlock the whole application — tracing it to wRPC handshakes, NATS subscriptions, and the host's invocation semaphore.
 

--- a/community/2025-06-04-community-meeting-transcript.mdx
+++ b/community/2025-06-04-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=mkMOpNQXGAE" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=mkMOpNQXGAE" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=mkMOpNQXGAE" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jun 4, 2025 · 29 minutes*
 

--- a/community/2025-06-04-community-meeting.mdx
+++ b/community/2025-06-04-community-meeting.mdx
@@ -38,13 +38,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=mkMOpNQXGAE" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=mkMOpNQXGAE" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=mkMOpNQXGAE" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The June 4, 2025 wasmCloud community call is a design review for a data-processing platform built on the **Wasm component model**. Mike Nikles walks through an architecture diagram for a drag-and-drop **ETL pipeline platform** built on wasmCloud, where each pipeline step composes trusted in/out components around an untrusted customer-authored business-logic component. Brooks Townsend recognizes the design as wasmCloud's **platform harness pattern**, and the group works through capability providers, HTTP-server density, and lattice-per-customer versus lattice-per-pipeline isolation. With many maintainers at a Cosmonic off-site doing roadmapping, this is a lighter, feedback-focused call.
 

--- a/community/2025-06-11-community-meeting-transcript.mdx
+++ b/community/2025-06-11-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=G88dFwO6OAU" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=G88dFwO6OAU" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=G88dFwO6OAU" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jun 11, 2025 · 59 minutes*
 

--- a/community/2025-06-11-community-meeting.mdx
+++ b/community/2025-06-11-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=G88dFwO6OAU" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=G88dFwO6OAU" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=G88dFwO6OAU" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The June 11, 2025 wasmCloud community call opens with a fast-turnaround demo from Mike Nikles, who in seven days went from boxes on a whiteboard to a working **drag-and-drop ETL pipeline builder** running on wasmCloud. Each pipeline stage is a **Wasm component** — composed with `wac`, deployed as a `wadm` manifest, and wired together over **NATS** messaging. The discussion that follows digs into composing components statically vs. linking them dynamically with **wRPC**, the case for WASI P3 streams, and HTTP/2 support for agentic protocols. Brooks Townsend then kicks off the Q3 2025 roadmap planning and walks through a new consolidated NATS reference doc.
 

--- a/community/2025-06-18-community-meeting-transcript.mdx
+++ b/community/2025-06-18-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zELxAv7jInE" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zELxAv7jInE" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zELxAv7jInE" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jun 18, 2025 · 64 minutes*
 

--- a/community/2025-06-18-community-meeting.mdx
+++ b/community/2025-06-18-community-meeting.mdx
@@ -35,13 +35,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zELxAv7jInE" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zELxAv7jInE" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zELxAv7jInE" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The June 18, 2025 wasmCloud community call pairs a live demo with a candid project-structure debate. Brooks Townsend demos new transaction support in the **`wasmcloud:postgres`** interface — committing several SQL updates atomically through a single [WebAssembly component](/docs/overview/workloads/components/) and showing how an invalid query rolls the whole thing back. The team then opens a wide-ranging discussion on the **wasmCloud monorepo**: whether to keep it and invest in monorepo tooling or split repositories along language lines, how to replace Nix-based CI with GitHub Actions, and how to make contributing to wasmCloud simpler.
 

--- a/community/2025-06-25-community-meeting-transcript.mdx
+++ b/community/2025-06-25-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=HclZChWxD40" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=HclZChWxD40" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=HclZChWxD40" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jun 25, 2025 · 45 minutes*
 

--- a/community/2025-06-25-community-meeting.mdx
+++ b/community/2025-06-25-community-meeting.mdx
@@ -34,13 +34,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=HclZChWxD40" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=HclZChWxD40" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=HclZChWxD40" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The June 25, 2025 wasmCloud community call welcomes Elizabeth Gilbert, a Carnegie Mellon PhD student researching **WebAssembly instrumentation**, who demos **whamm** — a DTrace-inspired DSL for dynamic analysis that rewrites Wasm bytecode (or hooks an engine at runtime) to count calls, profile branches, and build flame graphs. The conversation turns to bringing whamm to the **Wasm component model**, then the maintainers declare "pull request bankruptcy" — a plan to unblock a backlog of high-quality PRs stuck behind flaky tests — and congratulate two new maintainers.
 

--- a/community/2025-07-09-community-meeting-transcript.mdx
+++ b/community/2025-07-09-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=nIW494eWLsQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=nIW494eWLsQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=nIW494eWLsQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jul 9, 2025 · 102 minutes*
 

--- a/community/2025-07-09-community-meeting.mdx
+++ b/community/2025-07-09-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=nIW494eWLsQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=nIW494eWLsQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=nIW494eWLsQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The July 9, 2025 wasmCloud community call was the **Q3 2025 community roadmap planning** session. Brooks Townsend recapped a Q2 driven largely by community contributors, then walked a slate of proposals that all push toward a simpler, more standards-aligned platform built on the **[Wasm component model](https://component-model.bytecodealliance.org/)**: in-process component-to-component calls, dropping wasmCloud-specific signing for standards like Sigstore, shared platform-level capability providers, reframing providers as **wRPC servers**, trimming built-in WASI interfaces, reducing host responsibilities so an external scheduler drives the host, and making wasmCloud's distributed networking intentional rather than implicit. WASI Preview 3, expected in August, frames much of the work.
 

--- a/community/2025-07-16-community-meeting-transcript.mdx
+++ b/community/2025-07-16-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=cNovOusQE7M" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=cNovOusQE7M" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=cNovOusQE7M" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jul 16, 2025 · 61 minutes*
 

--- a/community/2025-07-16-community-meeting.mdx
+++ b/community/2025-07-16-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=cNovOusQE7M" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=cNovOusQE7M" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=cNovOusQE7M" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The July 16, 2025 wasmCloud community call is a ground-up rewrite of **wash** — "the Wasm Shell" — into a lean, plugin-driven CLI focused purely on **[Wasm component model](https://component-model.bytecodealliance.org/)** development: build, run a dev loop, and push to an OCI registry, with everything wasmCloud-specific moving out into WebAssembly-component plugins. Brooks Townsend demos building and running components with no `wasmcloud.toml`, implementing a draft WASI interface with a component plugin, and hooking the dev loop with an Aspire dashboard plugin. The call closes with Eric Gregory's Q3 2025 roadmap recap, an issue of the week, and a new community Excalidraw room for diagrams.
 

--- a/community/2025-07-23-community-meeting-transcript.mdx
+++ b/community/2025-07-23-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=RrUzTSKzSo4" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=RrUzTSKzSo4" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=RrUzTSKzSo4" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jul 23, 2025 · 61 minutes*
 

--- a/community/2025-07-23-community-meeting.mdx
+++ b/community/2025-07-23-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=RrUzTSKzSo4" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=RrUzTSKzSo4" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=RrUzTSKzSo4" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The July 23, 2025 wasmCloud community call is a developer-tooling deep dive built around **Wasm components**. Bailey Hayes walks through her exploration of GitHub Actions for the reimagined `wash` CLI — demoing a `setup-wash-action`, comparing composite, TypeScript, and Docker action styles, and digging into caching and CI supply-chain security. Brooks Townsend then shows the new **wash plugin system**, where every plugin is a WebAssembly component, and demonstrates how `clap` integration gives plugins native subcommands, flags, and environment variables. The group closes on how to trust third-party plugins by leaning on the Wasm sandbox and capability-based security.
 

--- a/community/2025-07-30-community-meeting-transcript.mdx
+++ b/community/2025-07-30-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=QGsbX689MiQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=QGsbX689MiQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=QGsbX689MiQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Jul 30, 2025 · 47 minutes*
 

--- a/community/2025-07-30-community-meeting.mdx
+++ b/community/2025-07-30-community-meeting.mdx
@@ -32,13 +32,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=QGsbX689MiQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=QGsbX689MiQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=QGsbX689MiQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The July 30, 2025 wasmCloud community call shows off the **Wasm component model** as a plugin system. Brooks Townsend demos an **OAuth plugin** for the `wash` CLI — a TinyGo WebAssembly component that runs a full OAuth login flow, stores credentials, and stays sandboxed in its own little file system — then lays out the migration path that takes the next-generation Wasm Shell into the wasmCloud org. Along the way the team agrees to ship the current `wash` as 1.0, call a feature freeze, surface a batch of good first issues, and check in on the Q3 roadmap, including the move to wRPC-based capability providers. Oh, and wasmCloud just passed **2,000 GitHub stars**.
 

--- a/community/2025-08-06-community-meeting-transcript.mdx
+++ b/community/2025-08-06-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=1pB61vbkoAo" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=1pB61vbkoAo" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=1pB61vbkoAo" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Aug 6, 2025 · 26 minutes*
 

--- a/community/2025-08-06-community-meeting.mdx
+++ b/community/2025-08-06-community-meeting.mdx
@@ -33,13 +33,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=1pB61vbkoAo" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=1pB61vbkoAo" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=1pB61vbkoAo" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The August 6, 2025 wasmCloud community call turned into a live debugging session around the **Wasm component model** in production. Mike, who runs a pipeline platform on wasmCloud, walked through what looked like either a misunderstanding or a bug: when he updated one of his deployed components to a new **OCI image reference**, [wadm](https://github.com/wasmCloud/wadm) scaled the component but kept the old image — and, more worryingly, dropped the component's config. Brooks Townsend reproduced the issue alongside him, traced it to an incomplete diff in wadm's upgrade logic, and showed how to use **NATS** key-value buckets and event subscriptions to debug the running system.
 

--- a/community/2025-08-13-community-meeting-transcript.mdx
+++ b/community/2025-08-13-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=rZSZ87g_82M" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=rZSZ87g_82M" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=rZSZ87g_82M" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Aug 13, 2025 · 55 minutes*
 

--- a/community/2025-08-13-community-meeting.mdx
+++ b/community/2025-08-13-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=rZSZ87g_82M" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=rZSZ87g_82M" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=rZSZ87g_82M" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The August 13, 2025 wasmCloud community call is a deep conversation on the **Wasm component model** applied to event sourcing. Brooks Townsend walks through an experimental repo that models an entire event-sourcing system purely from the composability of **WebAssembly components** — command handlers, event handlers, an event sourcer, and an event store — using Wasm **resources** as opaque handles so the core system can pass commands and events around as bytes without knowing their structure. Yordis Prieto then shares his multi-year journey from Elixir event sourcing into WebAssembly, why he chases Wasm to control indeterminism, and the concrete WIT features (maps, structs, recursive types, generics) he is pushing for upstream — including a recent conversation with Luke Wagner.
 

--- a/community/2025-08-20-community-meeting-transcript.mdx
+++ b/community/2025-08-20-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=iOjIbjWfYpM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=iOjIbjWfYpM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=iOjIbjWfYpM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Aug 20, 2025 · 14 minutes*
 

--- a/community/2025-08-20-community-meeting.mdx
+++ b/community/2025-08-20-community-meeting.mdx
@@ -32,13 +32,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=iOjIbjWfYpM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=iOjIbjWfYpM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=iOjIbjWfYpM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The August 20, 2025 wasmCloud community call is a quick, contributor-focused update centered on the new **`wash` 1.0 beta** — a greenfield "Wasm Shell" whose plugins are themselves **Wasm components**, written in either Rust or Go. Brooks Townsend walks through Eric's fresh "good first issues" blog mapped to the Q3 2025 roadmap, highlights the **setup-wash GitHub Action** now headed for the Actions marketplace, and recaps the **wasmCloud 1.9** minor release: XDG base-directory support, a dashboard for `wash dev`, and a new built-in HTTP client provider.
 

--- a/community/2025-08-27-community-meeting-transcript.mdx
+++ b/community/2025-08-27-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=PnBGuEKab0o" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=PnBGuEKab0o" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=PnBGuEKab0o" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Aug 27, 2025 · 36 minutes*
 

--- a/community/2025-08-27-community-meeting.mdx
+++ b/community/2025-08-27-community-meeting.mdx
@@ -37,13 +37,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=PnBGuEKab0o" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=PnBGuEKab0o" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=PnBGuEKab0o" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The August 27, 2025 wasmCloud community call digs into how the **Wasm component model** is reshaping wasmCloud's architecture. Brooks Townsend tours the new **wash plugin system** — hooks, dev register plugins, and top-level commands, all powered by WebAssembly components — and opens a Q3 roadmap discussion with maintainer Aditya on rethinking the application abstraction and increasing provider density. Brooks and Bailey Hayes make the case for leaning into **wRPC** over the capability-provider SDK and for letting components, with WASI P3 on the horizon, take over many jobs that native providers do today through bin packing, dynamic linking, and Cranelift optimizations.
 

--- a/community/2025-09-03-community-meeting-transcript.mdx
+++ b/community/2025-09-03-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=CbE9Uzfkb2I" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=CbE9Uzfkb2I" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=CbE9Uzfkb2I" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Sep 3, 2025 · 62 minutes*
 

--- a/community/2025-09-03-community-meeting.mdx
+++ b/community/2025-09-03-community-meeting.mdx
@@ -33,13 +33,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=CbE9Uzfkb2I" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=CbE9Uzfkb2I" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=CbE9Uzfkb2I" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The September 3, 2025 wasmCloud community call digs into the **Wasm component model** as the foundation for a leaner, more modular runtime. Brooks Townsend walks through in-process **component-to-component calls** — letting two components on the same host talk directly instead of going over wRPC/NATS, dropping latency from hundreds of microseconds to single-digit nanoseconds — and a broader effort to shrink the wasmCloud host's responsibility down to component lifecycle management, with capabilities provided through an optional plugin layer. Bailey Hayes closes with a quick demo of new shell auto-completions in the `wash` CLI.
 

--- a/community/2025-09-10-community-meeting-transcript.mdx
+++ b/community/2025-09-10-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=BtOseiHpgmk" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=BtOseiHpgmk" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=BtOseiHpgmk" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Sep 10, 2025 · 48 minutes*
 

--- a/community/2025-09-10-community-meeting.mdx
+++ b/community/2025-09-10-community-meeting.mdx
@@ -33,13 +33,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=BtOseiHpgmk" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=BtOseiHpgmk" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=BtOseiHpgmk" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The September 10, 2025 wasmCloud community call started as "the quickest wasmCloud Wednesday ever" — no agenda, with the team heads-down on the last items of the Q3 roadmap — and then turned into a wide-ranging hallway conversation about the hard edges of the **Wasm component model**. Brooks Townsend, Colin Murphy, and Victor Adossi dig into why adding system time-zone support to Wasmtime takes a year and a half, how a wasmCloud **host plugin** could route around runtime bottlenecks, Christophe's shared-memory proof of concept, and why **first-class functions** in WIT are the missing piece for generating polyglot SDKs — all while looking ahead to what WASI 0.3 (Preview 3) unlocks.
 

--- a/community/2025-09-17-community-meeting-transcript.mdx
+++ b/community/2025-09-17-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=vTbKtMkWxBQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=vTbKtMkWxBQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=vTbKtMkWxBQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Sep 17, 2025 · 57 minutes*
 

--- a/community/2025-09-17-community-meeting.mdx
+++ b/community/2025-09-17-community-meeting.mdx
@@ -35,13 +35,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=vTbKtMkWxBQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=vTbKtMkWxBQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=vTbKtMkWxBQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The September 17, 2025 wasmCloud community call is a deep dive into **wasmCloud V2** — also called wasmCloud Next — Brooks Townsend's proposal for a "radical simplification" of the platform. He walks through a pull request that introduces a consolidated `wasmcloud` crate (merging the host, runtime, and core libraries), a simplified **Host API** focused on scheduling workloads built from **[WebAssembly components](/docs/overview/workloads/components/)**, **host plugins** that replace built-in capability providers and make the wRPC transport opt-in, and **in-process component-to-component calls** for components running on the same host. Brooks presents C4-style architecture diagrams for the new model, and Eric Gregory previews a `next` version of the docs.
 

--- a/community/2025-09-24-community-meeting-transcript.mdx
+++ b/community/2025-09-24-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zKfrkhb_yvw" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zKfrkhb_yvw" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zKfrkhb_yvw" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Sep 24, 2025 · 90 minutes*
 

--- a/community/2025-09-24-community-meeting.mdx
+++ b/community/2025-09-24-community-meeting.mdx
@@ -38,13 +38,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zKfrkhb_yvw" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zKfrkhb_yvw" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zKfrkhb_yvw" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The September 24, 2025 wasmCloud community call is all about running **WebAssembly on Kubernetes**. Lucas Fontes walks through a new Kubernetes-native **runtime operator** for wasmCloud v2 that stores all workload state in Kubernetes via custom resources (CRDs), aligns naming with pods, replica sets, and deployments, and replaces external capability providers with secure in-process host plugins. Bailey Hayes covers a wave of `wash` and `setup-wash-action` improvements for the next major version, and shares that Wasmtime has shipped the first WASI P3 release candidate.
 

--- a/community/2025-10-01-community-meeting-transcript.mdx
+++ b/community/2025-10-01-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=_0y8TXead8E" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=_0y8TXead8E" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=_0y8TXead8E" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Oct 1, 2025 · 47 minutes*
 

--- a/community/2025-10-01-community-meeting.mdx
+++ b/community/2025-10-01-community-meeting.mdx
@@ -38,13 +38,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=_0y8TXead8E" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=_0y8TXead8E" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=_0y8TXead8E" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 For the latest **WebAssembly news**, the October 1, 2025 wasmCloud community call walks an end-to-end demo of a new **GitHub Actions toolkit** for the `wash` CLI — built around supply-chain security with binary **attestation**, SBOM generation via cargo auditable, and a language-agnostic build/publish flow. Bailey Hayes also previews a new non-interactive mode for CI and proposed volume mounts for `wash` plugins, while Colin Murphy and the team explore WebGPU, hybrid AI inferencing, and the road to the next version of wasmCloud and the **Wasm component model**.
 

--- a/community/2025-10-08-community-meeting-transcript.mdx
+++ b/community/2025-10-08-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=aQ_SpvOfWSQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=aQ_SpvOfWSQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=aQ_SpvOfWSQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Oct 8, 2025 · 64 minutes*
 

--- a/community/2025-10-08-community-meeting.mdx
+++ b/community/2025-10-08-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=aQ_SpvOfWSQ" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=aQ_SpvOfWSQ" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=aQ_SpvOfWSQ" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The October 8, 2025 wasmCloud community call shows off an **MCP server as a Wasm component**. Bailey Hayes builds a Model Context Protocol server from idiomatic TypeScript, generates its tools from an OpenAPI spec with a new `wash` plugin, and compiles the whole thing to a portable, sandboxed WebAssembly component via JCO and StarlingMonkey. Victor Adossi traces the road to running plain JavaScript and WASI Preview 3 components in Wasm, and Brooks Townsend lands the wasmCloud runtime crate into `wash` ahead of Q4 roadmap planning.
 

--- a/community/2025-10-15-community-meeting-transcript.mdx
+++ b/community/2025-10-15-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=3DlUjl8gQVs" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=3DlUjl8gQVs" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=3DlUjl8gQVs" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Oct 15, 2025 · 59 minutes*
 

--- a/community/2025-10-15-community-meeting.mdx
+++ b/community/2025-10-15-community-meeting.mdx
@@ -37,13 +37,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=3DlUjl8gQVs" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=3DlUjl8gQVs" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=3DlUjl8gQVs" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The October 15, 2025 wasmCloud community call dives into the **Wasm component model** through a new wasmCloud runtime crate. Brooks Townsend walks through the crate — an opinionated embedding of **Wasmtime** that auto-links components via workload resolution, adds host plugins for WASI and custom interfaces, and exposes a much-simplified host API. The conversation widens into how component instances are managed across requests, how that shapes WIT design, and the community's push toward common agentic protocols like MCP and ACP.
 

--- a/community/2025-10-22-community-meeting-transcript.mdx
+++ b/community/2025-10-22-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=XcegvHapaao" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=XcegvHapaao" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=XcegvHapaao" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Oct 22, 2025 · 62 minutes*
 

--- a/community/2025-10-22-community-meeting.mdx
+++ b/community/2025-10-22-community-meeting.mdx
@@ -35,13 +35,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=XcegvHapaao" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=XcegvHapaao" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=XcegvHapaao" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The October 22, 2025 wasmCloud community call is a two-demo deep dive into the **Wasm component model**. Corey and Ian demo **wasmCP**, a framework for building Model Context Protocol (MCP) servers as composable WebAssembly components in Rust, Python, and TypeScript — scaffolding tools, chaining them through a transport-agnostic WIT-defined middleware pattern, and running the result on Wasmtime, wash, or Cosmonic Control. Brooks Townsend then introduces **wasmCloud services**: long-running components targeting the WASI CLI world that open the door to component-native capability providers.
 

--- a/community/2025-10-29-community-meeting-transcript.mdx
+++ b/community/2025-10-29-community-meeting-transcript.mdx
@@ -23,13 +23,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=flWU7tw1jkM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=flWU7tw1jkM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=flWU7tw1jkM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Oct 29, 2025 · 16 minutes*
 

--- a/community/2025-10-29-community-meeting.mdx
+++ b/community/2025-10-29-community-meeting.mdx
@@ -33,13 +33,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=flWU7tw1jkM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=flWU7tw1jkM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=flWU7tw1jkM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The October 29, 2025 wasmCloud community call is a short, demo-led session focused on the **Wasm component model** and the tooling around it. Liam Randall demos the new **openapi2mcp** plugin for Wasm Shell, which turns an OpenAPI specification into a ready-to-run MCP server packaged as a WebAssembly component, then shows pushing it to Kubernetes and wiring it into Claude. Victor Adossi gives a WASI P3 update: the P3 feature set is essentially complete on the Rust side, and his JCO async work — transpiling P3 components to JavaScript for Node and the browser — is on track to become the second WASI P3 reference implementation.
 

--- a/community/2025-11-05-community-meeting-transcript.mdx
+++ b/community/2025-11-05-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=FbLNlZgzWOU" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=FbLNlZgzWOU" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=FbLNlZgzWOU" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Nov 5, 2025 · 61 minutes*
 

--- a/community/2025-11-05-community-meeting.mdx
+++ b/community/2025-11-05-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=FbLNlZgzWOU" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=FbLNlZgzWOU" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=FbLNlZgzWOU" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The November 5, 2025 wasmCloud community call is centered on **WebAssembly on Kubernetes**. Lucas Fontes demos the next generation of wasmCloud — **wasmCloud v2** — bringing up a Kubernetes cluster, installing the **runtime operator** and a new wasmCloud host over NATS via Helm, and scheduling a workload onto one of three host groups using nothing but `kubectl get host`. The new **`wash host`** command turns the single `wash` binary into a cluster host, with all scheduling intelligence moved into the operator so you can bring your own scheduler — or even your own host. Bailey Hayes frames the road to **v2.0.0-rc1**, and Victor Adossi closes with an update on **JCO** standing up as a second reference implementation for **WASI Preview 3**.
 

--- a/community/2025-11-12-community-meeting-transcript.mdx
+++ b/community/2025-11-12-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=e0oZW8yEiC8" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=e0oZW8yEiC8" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=e0oZW8yEiC8" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Nov 12, 2025 · 28 minutes*
 

--- a/community/2025-11-12-community-meeting.mdx
+++ b/community/2025-11-12-community-meeting.mdx
@@ -33,13 +33,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=e0oZW8yEiC8" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=e0oZW8yEiC8" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=e0oZW8yEiC8" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The November 12, 2025 wasmCloud community call — broadcast live from the project pavilion at KubeCon — focuses on the **Wasm component model** and the JavaScript tooling reaching it. Victor Adossi gives a tour of **[JCO](https://github.com/bytecodealliance/jco)**, the toolchain for building and running WebAssembly components in JavaScript, including new standalone `jco transpile` releases, the first stable release of **jco-stl** with a **Hono** WebAssembly integration, and ongoing **JCO async** work for the WASI P3 component model. Bailey Hayes shares that **wash 2.0.0 RC3** is out, previewing the simpler new wasmCloud v2 runtime and its plugin-based custom-host story.
 

--- a/community/2025-11-19-community-meeting-transcript.mdx
+++ b/community/2025-11-19-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=EqvKzu-e9gw" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=EqvKzu-e9gw" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=EqvKzu-e9gw" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Nov 19, 2025 · 62 minutes*
 

--- a/community/2025-11-19-community-meeting.mdx
+++ b/community/2025-11-19-community-meeting.mdx
@@ -35,13 +35,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=EqvKzu-e9gw" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=EqvKzu-e9gw" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=EqvKzu-e9gw" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The November 19, 2025 wasmCloud community call is a deep dive into running **WebAssembly on Kubernetes** with the new wasmCloud v2 runtime. Eric Gregory demos a fresh end-to-end install of the v2.0 release-candidate Kubernetes operator using Helm and kind, then Lucas Fontes walks through a major rework of HTTP in the `wash` runtime that pulls HTTP, gRPC, and HTTP/2 handling close to the runtime instead of routing it over the network. Bailey Hayes closes with the road to WASI P3 — why P3 components will align on Wasmtime 40 in December — and the group untangles how wasmCloud actually relates to Kubernetes, wRPC, and the schedulers that place workloads.
 

--- a/community/2025-11-26-community-meeting-transcript.mdx
+++ b/community/2025-11-26-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=tf5z_K4krfM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=tf5z_K4krfM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=tf5z_K4krfM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Nov 26, 2025 · 36 minutes*
 

--- a/community/2025-11-26-community-meeting.mdx
+++ b/community/2025-11-26-community-meeting.mdx
@@ -37,13 +37,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=tf5z_K4krfM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=tf5z_K4krfM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=tf5z_K4krfM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The November 26, 2025 wasmCloud community call is a hands-on tour of the **Wasm component model** maturing across the C/C++ toolchain and into wasmCloud v2. Bailey Hayes demos a Bytecode Alliance example that builds a 67 KB WebAssembly HTTP server using modern, ergonomic C++ bindings on `wasi:http`, walks through how cooperative threads and exception handling are landing in `wasi-libc`, and shows protobuf compiling out of the box. The call closes with how gRPC rides over a protocol-agnostic `wasi:http`, plus a deep discussion of how workload identity works in wasmCloud v2 on Kubernetes — replacing v1's identity delegation with a unique workload ID assigned at scheduling time.
 

--- a/community/2025-12-03-community-meeting-transcript.mdx
+++ b/community/2025-12-03-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=_aBptBrH-Gg" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=_aBptBrH-Gg" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=_aBptBrH-Gg" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Dec 3, 2025 · 61 minutes*
 

--- a/community/2025-12-03-community-meeting.mdx
+++ b/community/2025-12-03-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=_aBptBrH-Gg" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=_aBptBrH-Gg" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=_aBptBrH-Gg" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The December 3, 2025 wasmCloud community call digs into how the **Wasm component model** shapes wasmCloud v2, where a workload is composed of stateless components plus a new stateful primitive called a **service**. Lucas Fontes demos a service that opens TCP sockets and acts as `localhost` for the components in a workload — ideal for connection pooling, proxying, and persistent state — and the team explains how it leans on cooperative threads coming in **WASI P3**. The call also covers the move of WASI to a monorepo, the rename of the wasmCloud operator to the wadm operator, the C++ challenges behind compiling protobuf to WebAssembly, and the progress of the wasi-tls proposal.
 

--- a/community/2025-12-10-community-meeting-transcript.mdx
+++ b/community/2025-12-10-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=aV93ZUb5U-Y" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=aV93ZUb5U-Y" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=aV93ZUb5U-Y" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Dec 10, 2025 · 35 minutes*
 

--- a/community/2025-12-10-community-meeting.mdx
+++ b/community/2025-12-10-community-meeting.mdx
@@ -35,13 +35,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=aV93ZUb5U-Y" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=aV93ZUb5U-Y" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=aV93ZUb5U-Y" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The December 10, 2025 wasmCloud community call is all about running **WebAssembly on Kubernetes** in production. Eric Gregory walks through a new doc and demo for mounting Kubernetes volumes into a Rust component in wasmCloud v2, then shares a fresh overview of **workload services** as the stateful companions to stateless components. Lucas Fontes lays out the project's biggest remaining deficiency — HTTP ingress across many hosts — and proposes an intelligent ingress gateway that routes by ephemeral workload ID for zero-downtime deployments, all without tying wasmCloud to Kubernetes.
 

--- a/community/2025-12-17-community-meeting-transcript.mdx
+++ b/community/2025-12-17-community-meeting-transcript.mdx
@@ -23,13 +23,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=S2n8FgYGE_c" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=S2n8FgYGE_c" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=S2n8FgYGE_c" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, Dec 17, 2025 · 16 minutes*
 

--- a/community/2025-12-17-community-meeting.mdx
+++ b/community/2025-12-17-community-meeting.mdx
@@ -34,13 +34,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=S2n8FgYGE_c" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=S2n8FgYGE_c" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=S2n8FgYGE_c" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The December 17, 2025 wasmCloud community call is a short, focused look at **wasmCloud v2 Release Candidate 5** and the developer experience for building **Wasm component model** projects. Eric Gregory walks through how `wash new` has been refactored — the old interactive templating wizard is gone, replaced by cloning an example repo directly from a Git URL — and demos the updated Rust hello world that now uses the **wstd** standard library for Wasm components. Liam Randall closes with the news that the Linux Foundation has launched an Agentic AI Foundation, with Anthropic donating the **Model Context Protocol (MCP)**.
 

--- a/community/2026-01-07-community-meeting-transcript.mdx
+++ b/community/2026-01-07-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=WMUanmHsfKI" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=WMUanmHsfKI" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=WMUanmHsfKI" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, January 7, 2026 · 57m 42s*
 

--- a/community/2026-01-07-community-meeting.mdx
+++ b/community/2026-01-07-community-meeting.mdx
@@ -40,13 +40,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=WMUanmHsfKI" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=WMUanmHsfKI" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=WMUanmHsfKI" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The first wasmCloud community call of 2026 — January 7 — focuses on the **release plan for wasmCloud v2 RC6**. **Lucas Fontes** walks through a GitHub project dashboard of the issues and PRs still open, what's validated vs needs validation, and which features land in v2.0 vs a fast-follow point release. The big additions targeted for RC6: **multi-Wasm dev** (services + components side-by-side), **NATS authentication** for the host and operator, **Kubernetes workload IDs** for resiliency, **in-memory Blobstore and `wasi-keyvalue`** in `wash dev`, and a published **WIT package for wash**. Deferred to point releases: **component restart** (semantics conflict with orchestrator behavior in clusters), **virtual TCP/UDP loopback** (waiting for Wasmtime 41 to avoid a Wasmtime fork), and integration tests with the new fixture handling. **Aditya** commits to refactoring the **gRPC PR** to be default behavior (not modular) by end of week. **ossfellow** shares his **LLM-driven P2→P3 WIT translator** built as a Goose recipe, which sparks a broader conversation about where this kind of tooling could live (personal repo first, possibly `wasm-tools` later). **Yordis Prieto** lands a major **WIT map type** addition to wasm-tools and is working on the Wasmtime host bindings for it next. Bailey closes with the v2 syntax changes from the latest WASI P3 RC and a discussion of the wash → wasmCloud monorepo move ahead.
 

--- a/community/2026-01-14-community-meeting-transcript.mdx
+++ b/community/2026-01-14-community-meeting-transcript.mdx
@@ -19,13 +19,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=wyT5-QM4k00" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=wyT5-QM4k00" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=wyT5-QM4k00" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, January 14, 2026 · 35m 1s*
 

--- a/community/2026-01-14-community-meeting.mdx
+++ b/community/2026-01-14-community-meeting.mdx
@@ -40,13 +40,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=wyT5-QM4k00" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=wyT5-QM4k00" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=wyT5-QM4k00" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The January 14, 2026 wasmCloud community call is anchored by **Lucas Fontes' Blobby UI demo and a deep architectural change to `wash build` and `wash dev`**. Blobby — the long-running Blobstore example — gets a proper web UI that uploads, downloads, copies links, and shows a recent-activity bar, with both the UI and the API served by the same WebAssembly component. Under the hood, `wash build` and `wash dev` move from **implicit file-sniffing project inference** to **explicit build commands in config** — solving the monorepo problem, enabling environment-variable interpolation in build commands, separate debug vs release commands, and direct integration with Make or any other build tool. Service-and-component co-development is now first-class through the new `wash dev` config that lets you bring additional Wasm files into the workload (demoed with a cron service + cron component). **Bailey Hayes** highlights the importance of explicit configuration as a long-term maintenance win. **luk3ark** asks how plugins compare to bringing in components for backend interfaces, and Lucas explains the host-plugin model. **Eric** introduces the new **v2 Glossary** and the **draft Quick Start guide** with a local Kubernetes deployment step. The team closes with notes on the next WASI P3 release candidate landing in Wasmtime and a refreshed Go component SDK compatible with the latest tinygo and `wasm-tools`.
 

--- a/community/2026-01-21-community-meeting-transcript.mdx
+++ b/community/2026-01-21-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=UKtDFuFXVfE" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=UKtDFuFXVfE" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=UKtDFuFXVfE" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, January 21, 2026 · 19m 24s*
 

--- a/community/2026-01-21-community-meeting.mdx
+++ b/community/2026-01-21-community-meeting.mdx
@@ -34,13 +34,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=UKtDFuFXVfE" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=UKtDFuFXVfE" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=UKtDFuFXVfE" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The January 21, 2026 wasmCloud community call covers **wash RC6** — one of the largest release candidates yet — with significant behavior and API changes focused on simplicity and a narrower scope for the v2.0 release. **Lucas Fontes** walks through the RC6 highlights: a **filesystem-backed Blobstore and `wasi-keyvalue`** (so data persists across `wash dev` restarts), **virtual TCP loopback** between components in the same workload (so two workloads can both bind port 80 with no collision), and significant correctness improvements in service-to-component context passing. A new **QR code generator example** in 71 lines of Rust demonstrates HTTP, POST handling, error handling, and PNG generation server-side. The team identifies three remaining items before the v2 release: an internal Kubernetes identifier change, NATS authentication support in the operator and `wash host`, and gRPC-aware outbound transport. **Eric** has the RC6 doc rev in PR; **ossfellow** asks about the wash → wasmCloud repo move and Bailey confirms the plan: v1 goes to its own repo, v2 takes over the main `wasmcloud/wasmcloud` repo, artifacts release from there.
 

--- a/community/2026-01-28-community-meeting-transcript.mdx
+++ b/community/2026-01-28-community-meeting-transcript.mdx
@@ -20,13 +20,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=4zUisbs97C8" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=4zUisbs97C8" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=4zUisbs97C8" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, January 28, 2026 · 41m 40s*
 

--- a/community/2026-01-28-community-meeting.mdx
+++ b/community/2026-01-28-community-meeting.mdx
@@ -42,13 +42,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=4zUisbs97C8" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=4zUisbs97C8" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=4zUisbs97C8" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The January 28, 2026 wasmCloud community call lands on the **RC7 observability story**: **Lucas Fontes** demos the new **OpenTelemetry host plumbing** that ships with RC7, showing traces, logs, and metrics flowing into [Aspire dashboard](https://github.com/dotnet/aspire) from both `wash dev` and a Kubernetes deployment — with **automatic instrumentation** of any component that uses host-implemented WASI APIs (no plugin-author code needed). **Eric**'s "[Ten Years of WebAssembly: A Retrospective](https://bytecodealliance.org/articles/ten-years-of-webassembly-a-retrospective)" goes live as the doc of the week, with Bailey teasing what the next two months of WebAssembly adoption could look like as **cooperative threads** land and Python, Go, and TypeScript get first-class component compilation. Frank Schaffa drives an extended discussion on **LLM-assisted Rust adoption** as the real enterprise unlock. The call closes with Bailey and Aditya unpacking why wasmCloud has a forked `wasmtime-wasi` crate — the **TCP-loopback** enhancement needed for wasmCloud's **service feature** — and the upstreaming work that will eventually retire the fork.
 

--- a/community/2026-02-04-community-meeting-transcript.mdx
+++ b/community/2026-02-04-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=F0adyCd2RMs" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=F0adyCd2RMs" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=F0adyCd2RMs" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, February 4, 2026 · 58m 22s*
 

--- a/community/2026-02-04-community-meeting.mdx
+++ b/community/2026-02-04-community-meeting.mdx
@@ -40,13 +40,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=F0adyCd2RMs" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=F0adyCd2RMs" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=F0adyCd2RMs" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The February 4, 2026 wasmCloud community call covers the home stretch of v2 hardening and two strong outside demos. **Eric** walks through the new **TypeScript template conventions** for v2 — interface-named templates, standardized `config.yaml` for auto dev/build, package and world naming, gitignored generated artifacts — landing in the [wasmCloud TypeScript repo](https://github.com/wasmcloud/typescript). **Elizabeth Gilbert** demos [`component-interposition`](https://github.com/ejrgilbert/component-interposition), her WASI P3 project that **interposes middleware components** between an HTTP request and a service — single middleware, then three nested onion-style — with the full WAT walkthrough showing exactly how the [wac](https://github.com/bytecodealliance/wac) DSL composes the chain. **Marcin Ziółkowski** presents his work on a **C-advisor equivalent for WebAssembly**, hitting the wall of how to measure per-instance resource consumption when Wasm runtimes don't sit cleanly inside cgroups; Lucas walks him through the thread-pinning angle, and the call connects him with Elizabeth and the Wizard research engine community. Bailey also covers v2 RC7, the upcoming repo reconciliation that merges `wash` into `wasmcloud/wasmcloud`, the imminent WASI 0.2.10 release, and the next WASI P3 RC.
 

--- a/community/2026-02-11-community-meeting-transcript.mdx
+++ b/community/2026-02-11-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=Ak1_69dbfJs" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=Ak1_69dbfJs" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=Ak1_69dbfJs" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, February 11, 2026 · 35m 1s*
 

--- a/community/2026-02-11-community-meeting.mdx
+++ b/community/2026-02-11-community-meeting.mdx
@@ -40,13 +40,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=Ak1_69dbfJs" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=Ak1_69dbfJs" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=Ak1_69dbfJs" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The February 11, 2026 wasmCloud community call is anchored by **Jeremy Fleitz's live demo of the WASI OTel host plugin** — tracing, logging, and metrics emitted directly from inside a Wasm component into an Aspire collector, with the host adding workload-ID context so component-level spans line up cleanly with host-level spans. **Eric** walks through new **TypeScript templates** for HTTP clients and services with **`wasi-keyvalue` and Blobstore backends**, plus an expanded **services documentation page** and a fresh **custom hosts / host plugins** guide. **Bailey** updates the community on **WASI 0.2.10** (hopefully the final 0.2.x release) and **WASI P3 release-candidate progress**, and **Yordis Prieto** confirms he's two code reviews away from landing **map support** in WIT and is heading for **struct** next.
 

--- a/community/2026-02-18-community-meeting-transcript.mdx
+++ b/community/2026-02-18-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=-8FoV7pnWgg" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=-8FoV7pnWgg" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=-8FoV7pnWgg" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, February 18, 2026 · 36m 4s*
 

--- a/community/2026-02-18-community-meeting.mdx
+++ b/community/2026-02-18-community-meeting.mdx
@@ -37,13 +37,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=-8FoV7pnWgg" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=-8FoV7pnWgg" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=-8FoV7pnWgg" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The February 18, 2026 wasmCloud community call leans into v2 architecture and tooling. **Lucas Fontes** demos new wasmCloud v2 templates that center the *full application* (cargo workspaces, multiple components per project) and shows off **TCP socket binding inside components** with **per-workload localhost** isolation — two workloads can bind the same port without conflict. **Eric** opens a PR adding **Excalidraw diagram tooling** to the wasmcloud.com repo, including a Claude skill, custom PNG export, and brand-aligned diagram workflow. **Bailey Hayes** updates the community on WASI P3 progress (new release candidate, significant `wasi-cli` reshaping), the upcoming **Bytecode Alliance Plumbers Summit**, and the imminent reference-implementation completion. **Aditya** raises a great question about dynamic config updates mid-deployment, which leads to a NATS-backed plus virtualization design discussion.
 

--- a/community/2026-02-25-community-meeting-transcript.mdx
+++ b/community/2026-02-25-community-meeting-transcript.mdx
@@ -18,13 +18,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=WfZCHymKZ-Q" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=WfZCHymKZ-Q" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=WfZCHymKZ-Q" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, February 25, 2026 · 5m 46s · co-host with the Bytecode Alliance Plumbers Summit*
 

--- a/community/2026-02-25-community-meeting.mdx
+++ b/community/2026-02-25-community-meeting.mdx
@@ -25,13 +25,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=WfZCHymKZ-Q" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=WfZCHymKZ-Q" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=WfZCHymKZ-Q" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 A deliberately brief February 25, 2026 wasmCloud Wednesday: Liam Randall and Jeremy Fleitz acknowledge that the **Bytecode Alliance Plumbers Summit** is happening live at the same time, point the community to Joel Dice's talk on core Wasm proposals and the rest of the Plumbers Summit thread, and tease new updates coming to CNCF wasmCloud next week. The call wraps in under 6 minutes so attendees can rejoin the Plumbers Summit live stream.
 

--- a/community/2026-03-04-community-meeting-transcript.mdx
+++ b/community/2026-03-04-community-meeting-transcript.mdx
@@ -20,13 +20,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=pehuX0gewdk" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=pehuX0gewdk" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=pehuX0gewdk" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, March 4, 2026 · 23m 53s*
 

--- a/community/2026-03-04-community-meeting.mdx
+++ b/community/2026-03-04-community-meeting.mdx
@@ -34,13 +34,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=pehuX0gewdk" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=pehuX0gewdk" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=pehuX0gewdk" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The March 4, 2026 wasmCloud community call recaps the Bytecode Alliance Summit (Luke Wagner's road to component-model 1.0, Cy Brand on cooperative threads, Joel Dice on guest languages, Alex Crichton on landing proposals, Victor Adossi on JCO), introduces wasmCloud v2's **named interfaces** feature for using the same WIT interface multiple times under different names, explains why the **wash CLI component-plugin system** is being removed in favor of shell hooks, and walks through the repo migration from `wasmcloud/wash` into `wasmcloud/wasmcloud` with a separate `wasmcloud-v1` repo for the v1 branch.
 

--- a/community/2026-03-11-community-meeting-transcript.mdx
+++ b/community/2026-03-11-community-meeting-transcript.mdx
@@ -20,13 +20,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=IwAeQxahqgA" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=IwAeQxahqgA" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=IwAeQxahqgA" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, March 11, 2026 · 29m 11s*
 

--- a/community/2026-03-11-community-meeting.mdx
+++ b/community/2026-03-11-community-meeting.mdx
@@ -35,13 +35,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=IwAeQxahqgA" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=IwAeQxahqgA" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=IwAeQxahqgA" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The March 11, 2026 wasmCloud Wednesday is hosted by Jeremy Fleitz for the first time (in the spirit of a rotating "host group" for the meeting). Jeremy demos a new **Couchbase host plugin** that ports the old wasmCloud Couchbase provider into the v2 host-plugin model, walks through the **repo reorganization** that moves `wash` into the main `wasmCloud/wasmCloud` monorepo with a `release-1.9.x` branch preserved, and Lucas Fontes shares the plan for **v2 RC9** — the last RC, with Wasmtime 42, WASI P3 experimental support, and Pavel's fuel-tracking metrics. Eric introduces the new [v2 templates and examples page](/docs/examples) as a single canonical source for component examples across languages.
 

--- a/community/2026-03-18-community-meeting-transcript.mdx
+++ b/community/2026-03-18-community-meeting-transcript.mdx
@@ -21,13 +21,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=miaCGsUHo38" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=miaCGsUHo38" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=miaCGsUHo38" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, March 18, 2026 · 34m*
 

--- a/community/2026-03-18-community-meeting.mdx
+++ b/community/2026-03-18-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=miaCGsUHo38" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=miaCGsUHo38" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=miaCGsUHo38" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The March 18, 2026 wasmCloud Wednesday is a short conference-week call dominated by **Victor Adossi's deep dive on the JavaScript ecosystem**. Bailey Hayes is calling in from Wasm I/O in Barcelona finalizing the wasmCloud v2 release cut. Victor walks through the new StarlingMonkey 0.30 release with the Weval optimization layer re-enabled, Joel Dice's rewrite of componentize-js to Rust using `wit-dylib`, Tomasz's parallel componentize-qjs effort built on QuickJS-NG, JCO's freshly-landed stream support for WASI P3, and a fully vibe-coded JavaScript host for the WebAssembly component model — complete with a Go-in-the-browser demo.
 

--- a/community/2026-03-25-community-meeting-transcript.mdx
+++ b/community/2026-03-25-community-meeting-transcript.mdx
@@ -20,13 +20,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=DFYtiTgKmPA" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=DFYtiTgKmPA" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=DFYtiTgKmPA" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, March 25, 2026 · 3m 26s · from KubeCon EU Amsterdam*
 

--- a/community/2026-03-25-community-meeting.mdx
+++ b/community/2026-03-25-community-meeting.mdx
@@ -25,13 +25,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=DFYtiTgKmPA" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=DFYtiTgKmPA" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=DFYtiTgKmPA" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 A short March 25, 2026 wasmCloud Wednesday hosted by Jeremy Fleitz from KubeCon EU in Amsterdam. The main news: **wasmCloud v2.0.1 is out** (a quick follow-up to v2.0 to move `wash` into the wasmCloud monorepo and clean up the release build), the docs site is updated to match the v2 release, and WebAssembly is getting markedly more attention at the conferences this year — at both the Cosmonic booth and the CNCF wasmCloud Project Pavilion booth.
 

--- a/community/2026-04-01-community-meeting-transcript.mdx
+++ b/community/2026-04-01-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zaDiEcB-Lfc" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zaDiEcB-Lfc" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zaDiEcB-Lfc" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, April 1, 2026 · 1h 0m*
 

--- a/community/2026-04-01-community-meeting.mdx
+++ b/community/2026-04-01-community-meeting.mdx
@@ -44,13 +44,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zaDiEcB-Lfc" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zaDiEcB-Lfc" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zaDiEcB-Lfc" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The April 1, 2026 wasmCloud community call opens with Jeremy Fleitz demoing a host pod finalizer change that cuts wasmCloud's reconciliation loop from over two minutes to roughly four seconds when a host pod dies — a bug found at KubeCon. Bailey Hayes walks through wasmCloud v2's scheduling architecture, kicks off Q2 planning with a tracked WASI P3 implementation behind a feature flag, and shares progress on the JCO reference implementation, cooperative threads in LLVM, and Joel's just-landed WASI socket support in Tokio and Mio. The call wraps with takeaways from KubeCon Europe and Wasm I/O, including a clear shift in the conversation from "what is WebAssembly?" to "how do I deploy it in production?"
 

--- a/community/2026-04-08-community-meeting-transcript.mdx
+++ b/community/2026-04-08-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=qXr5bM4JVR8" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=qXr5bM4JVR8" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=qXr5bM4JVR8" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, April 8, 2026 · 59m 38s*
 

--- a/community/2026-04-08-community-meeting.mdx
+++ b/community/2026-04-08-community-meeting.mdx
@@ -45,13 +45,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=qXr5bM4JVR8" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=qXr5bM4JVR8" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=qXr5bM4JVR8" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The April 8, 2026 wasmCloud community call is a full Q2 roadmap planning session, run as a collaborative Excalidraw whiteboard with DIY dot-voting. Bailey Hayes seeds high-level themes — componentize-the-world, WASI P3 readiness, LLM fuzzing, operator/platform experience — and the community fills in the gaps: SQLite/Lightstream integrations, microcontroller and tiny-device support via a slimmer Wasmtime, sandboxed MCP workloads on WebAssembly, multipath routing for workloads, named interfaces for backend selection, and a richer cron job provider. Jeremy Fleitz walks attendees through wasmCloud v2's built-in SIG store attestation and provenance for OCI artifacts, and the session closes with attendees voting on which initiatives shape the Q2 plan.
 

--- a/community/2026-04-15-community-meeting-transcript.mdx
+++ b/community/2026-04-15-community-meeting-transcript.mdx
@@ -26,13 +26,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=DwmoGmXHdDM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=DwmoGmXHdDM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=DwmoGmXHdDM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 {/* truncate */}
 

--- a/community/2026-04-15-community-meeting.mdx
+++ b/community/2026-04-15-community-meeting.mdx
@@ -44,13 +44,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=DwmoGmXHdDM" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=DwmoGmXHdDM" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=DwmoGmXHdDM" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The April 15, 2026 wasmCloud community call centered on the finalized Q2 roadmap, with full **WASI P3** support as the headline goal for the quarter. The team walked through HTTP routing changes using the component model's External ID spec, introduced a new **wasmCloud secrets plugin** with typed declarative resource management, and discussed a proposed NATS-specific WIT interface for durable messaging beyond the generic event bus.
 

--- a/community/2026-04-22-community-meeting-transcript.mdx
+++ b/community/2026-04-22-community-meeting-transcript.mdx
@@ -23,13 +23,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=18VFhGzObdY" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=18VFhGzObdY" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=18VFhGzObdY" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, April 22, 2026 · 1h 48m (live stream ~1h 23m)*
 

--- a/community/2026-04-22-community-meeting.mdx
+++ b/community/2026-04-22-community-meeting.mdx
@@ -46,13 +46,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=18VFhGzObdY" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=18VFhGzObdY" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=18VFhGzObdY" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The April 22, 2026 wasmCloud community call opens with Colin Murphy's WASI WebGPU demo running an Adobe TrustMark watermarking model as a Wasm component — about 20% faster than the CPU path and the first end-to-end WebGPU-from-a-component demo on wasmCloud. Bailey Hayes then walks through the proposed two-week automated train release model, micro-benchmark results showing a 5x throughput win from Wasmtime's HTTP reuse path, and the plan to push WebAssembly component composition into the workload deploy step. Aditya opens up his proposed first-class NATS WIT interface, which leads into a long, deep discussion with Yordis Prieto and Frank Schaffa about specifying capabilities, non-functional behavior, idempotency, and how Protobuf could become a strict subset of WIT for event sourcing.
 

--- a/community/2026-04-29-community-meeting-transcript.mdx
+++ b/community/2026-04-29-community-meeting-transcript.mdx
@@ -25,13 +25,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=BNxpgMFdcBo" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=BNxpgMFdcBo" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=BNxpgMFdcBo" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 {/* truncate */}
 

--- a/community/2026-04-29-community-meeting.mdx
+++ b/community/2026-04-29-community-meeting.mdx
@@ -39,13 +39,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=BNxpgMFdcBo" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=BNxpgMFdcBo" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=BNxpgMFdcBo" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The April 29, 2026 wasmCloud community call covered a template refactor bringing Rust language support into parity with TypeScript using new handler terminology, a detailed proposal for workload configuration supporting environment variables and secrets in the wash dev loop, roadmap updates on microbenchmarking infrastructure and automated releases, and discussions on WASI TLS adoption and host component plugin architecture.
 

--- a/community/2026-05-06-community-meeting-transcript.mdx
+++ b/community/2026-05-06-community-meeting-transcript.mdx
@@ -26,13 +26,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=0Ju3PCGyJqk" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=0Ju3PCGyJqk" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=0Ju3PCGyJqk" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 {/* truncate */}
 

--- a/community/2026-05-06-community-meeting.mdx
+++ b/community/2026-05-06-community-meeting.mdx
@@ -40,13 +40,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=0Ju3PCGyJqk" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=0Ju3PCGyJqk" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=0Ju3PCGyJqk" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 6, 2026 wasmCloud community call packed in four demos showcasing WebGPU integration with TensorFlow.js and raw GPU compute, a major Kubernetes deployment change that moves wasmCloud hosts to namespace-level scope, a new workload configuration system for environment variables and secrets, and a MySQL connection pooling component built on WASI sockets. The call also covered the first successful automated release of wasmCloud v2.07 with CI hardening improvements.
 

--- a/community/2026-05-13-community-meeting-transcript.mdx
+++ b/community/2026-05-13-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=y6Zo09oqyJ4" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=y6Zo09oqyJ4" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=y6Zo09oqyJ4" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, May 13, 2026 · 38 minutes*
 

--- a/community/2026-05-13-community-meeting.mdx
+++ b/community/2026-05-13-community-meeting.mdx
@@ -38,13 +38,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=y6Zo09oqyJ4" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=y6Zo09oqyJ4" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=y6Zo09oqyJ4" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 13, 2026 wasmCloud community call covers CI security hardening — including cryptographic attestations for OCI artifacts, zizmor-based workflow linting, and status gates — alongside a deep look at the new cache artifact pre-compilation pipeline that offloads CPU-intensive Cranelift AOT compilation to a dedicated process. Bailey Hayes demos the "Are We Fast Yet?" performance dashboard with Criterion and Cachegrind benchmarks, and the team discusses Pulley interpreter performance (10x vs native, compared to 60x for JS/Python interpreters), WASI TLS progress, and the path to WASI P3.
 

--- a/community/2026-05-20-community-meeting-transcript.mdx
+++ b/community/2026-05-20-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zzJuhDYRSKc" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zzJuhDYRSKc" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zzJuhDYRSKc" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, May 20, 2026 · 47 minutes*
 

--- a/community/2026-05-20-community-meeting.mdx
+++ b/community/2026-05-20-community-meeting.mdx
@@ -36,13 +36,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=zzJuhDYRSKc" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=zzJuhDYRSKc" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=zzJuhDYRSKc" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 20, 2026 wasmCloud community call opens with the launch of AI-generated meeting notes and transcripts for every wasmCloud Wednesday, then digs into security: Bailey Hayes walks through the wasmCloud 2.2 release, CI hardening with CodeQL and OpenSSF Scorecard, and a new continuous-fuzzing story for the Kubernetes runtime operator. Aditya demos component socket tunneling — a forked SQLx driver talking to MySQL over WASI sockets — which leads into a deep discussion of cross-component streams and futures in the **Wasm component model**, where Bailey argues that composing components is both simpler and ~5x faster than wiring them through the Wasmtime linker.
 

--- a/community/2026-05-27-community-meeting-transcript.mdx
+++ b/community/2026-05-27-community-meeting-transcript.mdx
@@ -22,13 +22,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=QyVyD37cvrw" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '2rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=QyVyD37cvrw" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=QyVyD37cvrw" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 *wasmCloud Weekly Community Call — Wed, May 27, 2026 · 54 minutes*
 

--- a/community/2026-05-27-community-meeting.mdx
+++ b/community/2026-05-27-community-meeting.mdx
@@ -39,13 +39,11 @@ import YouTube from 'react-player/youtube';
 
 <YouTube url="https://www.youtube.com/watch?v=QyVyD37cvrw" />
 
-<p style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
+<div style={{textAlign: 'right', marginTop: '0.25rem', marginBottom: '1.5rem'}}>
   <small>
-    <a href="https://www.youtube.com/watch?v=QyVyD37cvrw" target="_blank" rel="noopener noreferrer">
-      Watch on YouTube ↗
-    </a>
+    <a href="https://www.youtube.com/watch?v=QyVyD37cvrw" target="_blank" rel="noopener noreferrer">Watch on YouTube ↗</a>
   </small>
-</p>
+</div>
 
 The May 27, 2026 wasmCloud community call centers on the **Wasm component model** and the languages reaching it. Bailey Hayes demos **Endive** — the Bytecode Alliance's newly announced Java WebAssembly runtime — by building a wasmCloud host in Java that schedules workloads over NATS, and by embedding Wasm functions alongside plain Java handlers in an Eclipse Vert.x app. Victor Adossi shares that **JCO 1.20** now passes all 46 upstream Wasmtime WASI P3 tests with a new Preview Three Shim, putting WASI P3 on track to launch in about two weeks, and the team walks its Q2 roadmap toward that release.
 


### PR DESCRIPTION
fixes noisy Docusaurus build warnings on community pages.

On `main`, `npm run build` throws `Docusaurus static site generation process emitted warnings for 115 paths`. The repeated `Watch on YouTube` MDX block uses a `<p>` wrapper, so it compiles into busted HTML around that link.

This swaps that wrapper to `<div>`. Same link, same text, just valid markup now.

Repro
1. `npm ci`
2. `npm run build`
3. See the 115-path warning block
4. Check `build/community/2025-05-14-community-meeting/index.html` and find malformed HTML around `Watch on YouTube`

After this branch, `npm run build` is clean. pretty small fix, but it kills a bunch of noise.
