### PR TITLE
feat(docs): split CI/CD docs into a category and add GitLab CI page

### DIFF
--- a/docs/kubernetes-operator/operator-manual/cicd/github-actions.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd/github-actions.mdx
@@ -1,17 +1,9 @@
 ---
-title: 'CI/CD and GitOps for wasmCloud'
-sidebar_label: 'CI/CD and GitOps'
-sidebar_position: 2
-description: 'Build CI/CD and GitOps pipelines for wasmCloud — publish components to OCI registries, roll out to Kubernetes, and integrate with Argo CD or Flux.'
+title: 'wasmCloud GitHub Actions'
+sidebar_label: 'GitHub Actions'
+sidebar_position: 1
+description: 'Build, publish, and attest wasmCloud components from GitHub Actions using the official setup-wash-action and wasmCloud/actions toolkit.'
 ---
-
-## Overview
-
-wasmCloud components are distributed as [OCI artifacts](https://opencontainers.org/), so a CI/CD pipeline for wasmCloud follows a familiar pattern: build `.wasm` binaries, push them to an OCI registry, and update Kubernetes manifests to reference the new image.
-
-The wasmCloud project provides a set of official [GitHub Actions](#wasmcloud-github-actions) that handle building components, publishing to OCI registries, and generating supply-chain attestations. For teams using GitOps, [Argo CD](#gitops-with-argo-cd) or Flux can close the loop by reconciling Kubernetes state with a Git repository.
-
-![Deployment pipeline from developer push through CI, OCI registry, GitOps, and Kubernetes](../../images/deployment-pipeline.webp)
 
 ## wasmCloud GitHub Actions
 
@@ -89,7 +81,7 @@ permissions:
 
 When attestation is enabled, the `wash-oci-publish` action generates cryptographically signed metadata that links a published artifact back to the source code, build environment, and dependency tree that produced it. This enables consumers to verify that an artifact was built from a specific commit in a trusted CI pipeline.
 
-![Attestation flow](../../images/attestation.webp)
+![Attestation flow](../../../images/attestation.webp)
 
 The attestation flow works as follows:
 
@@ -146,101 +138,7 @@ jobs:
 
 This pipeline triggers on version tags (e.g. `v1.0.0`). The published image will be tagged with both `latest` and the Git tag.
 
-## GitOps with Argo CD
-
-For production deployments, a GitOps workflow keeps Kubernetes state in sync with a Git repository. [Argo CD](https://argo-cd.readthedocs.io/) is a popular GitOps tool for Kubernetes and pairs well with the wasmCloud operator.
-
-### Two-application pattern
-
-A common pattern uses two Argo CD Applications:
-
-1. **Infrastructure Application** &mdash; deploys the wasmCloud platform (operator, NATS, hosts) from the [Helm chart](../index.mdx).
-2. **Workloads Application** &mdash; deploys `WorkloadDeployment` manifests from a dedicated Git repository.
-
-This separation lets infrastructure and workload teams operate independently, each managing their own deployment cadence.
-
-### Example Argo CD Applications
-
-**Infrastructure Application** &mdash; installs the wasmCloud operator via Helm:
-
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: wasmcloud-platform
-  namespace: argocd
-spec:
-  project: default
-  source:
-    chart: runtime-operator
-    repoURL: ghcr.io/wasmcloud/charts
-    targetRevision: v2-canary
-    helm:
-      releaseName: wasmcloud
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: default
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-```
-
-**Workloads Application** &mdash; syncs `WorkloadDeployment` manifests from a Git repository:
-
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: wasmcloud-workloads
-  namespace: argocd
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/<org>/wasmcloud-workloads.git
-    targetRevision: main
-    path: manifests
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: default
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-```
-
-### Automating manifest updates
-
-After the CI pipeline publishes a new component image, a second workflow job can update the `WorkloadDeployment` manifest in the workloads repository and open a pull request:
-
-```yaml
-  update-manifests:
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          repository: <org>/wasmcloud-workloads
-          token: ${{ secrets.WORKLOADS_REPO_TOKEN }}
-
-      - name: Update image tag
-        run: |
-          sed -i "s|image: ghcr.io/<org>/my-component:.*|image: ghcr.io/<org>/my-component:${{ github.ref_name }}|" \
-            manifests/my-component.yaml
-
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          title: "Update my-component to ${{ github.ref_name }}"
-          commit-message: "chore: update my-component to ${{ github.ref_name }}"
-          branch: "update-my-component-${{ github.ref_name }}"
-```
-
-Once merged, Argo CD detects the change and rolls out the new version automatically.
-
-:::info[]
-This pattern works with any GitOps tool that watches a Git repository for changes, including [Flux](https://fluxcd.io/).
-:::
+For closing the loop with Argo CD or Flux, see [GitOps with Argo CD](./index.mdx#gitops-with-argo-cd).
 
 ## Supply chain security
 

--- a/docs/kubernetes-operator/operator-manual/cicd/gitlab-ci.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd/gitlab-ci.mdx
@@ -1,0 +1,180 @@
+---
+title: 'wasmCloud on GitLab CI'
+sidebar_label: 'GitLab CI'
+sidebar_position: 2
+description: 'Build, publish, attest, and deploy wasmCloud components from GitLab CI using the cosmonic-labs/ci-components/wash CI/CD Catalog.'
+---
+
+## wasmCloud GitLab CI components
+
+The [`cosmonic-labs/ci-components/wash`](https://gitlab.com/cosmonic-labs/ci-components/wash) project is a GitLab [CI/CD Catalog](https://docs.gitlab.com/ee/ci/components/) of reusable CI components for building, publishing, signing, and attesting Wasm components. It mirrors the capabilities of the [wasmCloud GitHub Actions](./github-actions.mdx) toolkit for teams running on GitLab.
+
+:::note[Note on vocabulary]
+GitLab refers to units of CI activity as "components," which can lead to some confusion when we're talking about operations related to [WebAssembly components](../../../overview/workloads/components.mdx). On this page, we will always use the term **CI components** to refer to GitLab's components, and **Wasm components** to refer to WebAssembly binaries that conform to the Component Model.
+:::
+
+A complete production-style pipeline that uses every CI component together (i.e., merge-request workflow rules, security scanning, environments, Kubernetes deployment, and GitLab Releases) lives at [`cosmonic-labs/wasm-component-sample`](https://gitlab.com/cosmonic-labs/wasm-component-sample).
+
+The catalog is split into a language-agnostic core and a Rust layer:
+
+| Component | Purpose |
+|-----------|---------|
+| **Language-agnostic core** | |
+| [`setup`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/setup/README.md) | Installs the `wash` CLI and exposes it on `PATH` for downstream jobs |
+| [`build`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/build/README.md) | Runs `wash build`, validates the output, and copies the `.wasm` to a stable artifact path |
+| [`oci-publish`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/oci-publish/README.md) | Pushes the Wasm component to an OCI registry under one or more tags; optional cosign keyless signing |
+| **Rust layer** | |
+| [`setup-rust`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/setup-rust/README.md) | Adds the `wasm32-wasip2` Rust target and exposes a `.rust-cache` template |
+| [`setup-cargo-auditable`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/setup-cargo-auditable/README.md) | Configures `wash build` to use `cargo auditable` so Wasm components ship with an embedded SBOM |
+| [`attest-cargo-sbom`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/attest-cargo-sbom/README.md) | Extracts the CycloneDX SBOM and attaches it as a Sigstore attestation on the published image |
+
+CI components are versioned via semver tags on the catalog repository and pinned through the `include: component:` reference (`@~latest`, `@1`, `@1.2.3`).
+
+### setup
+
+The [`setup`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/setup/README.md) CI component installs `wash` and exposes `WASH_BIN_DIR` as a [dotenv report](https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportsdotenv) so downstream jobs can pick it up:
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/setup@~latest
+    inputs:
+      wash_version: "v{{WASMCLOUD_VERSION}}"
+      stage: validate
+```
+
+### build
+
+The [`build`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/build/README.md) CI component runs `wash build` and copies the resulting `.wasm` to a stable artifact path. It is language-agnostic; attach a language-specific cache (e.g. `.rust-cache` from `setup-rust`) via `extends:`.
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/build@~latest
+    inputs:
+      stage: build
+      component_artifact_path: "build/greeter.wasm"
+```
+
+### oci-publish
+
+The [`oci-publish`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/oci-publish/README.md) CI component pushes the Wasm component to an OCI registry under one or more tags. With `sign: "true"` it runs [`cosign`](https://docs.sigstore.dev/cosign/overview/) keyless signing against the published image using a GitLab-issued OIDC token; see [Attestation](#attestation) below.
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/oci-publish@~latest
+    inputs:
+      stage: publish
+      image_tags: "${CI_COMMIT_REF_SLUG},${CI_COMMIT_SHORT_SHA}"
+      sign: "true"
+```
+
+### setup-rust
+
+The [`setup-rust`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/setup-rust/README.md) CI component adds the `wasm32-wasip2` Rust target and exposes a hidden `.rust-cache` job template that downstream jobs (clippy, `wash-build`) extend to share the cargo registry and target cache:
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/setup-rust@~latest
+    inputs:
+      stage: validate
+
+wash-build:
+  extends: .rust-cache
+```
+
+### setup-cargo-auditable
+
+The [`setup-cargo-auditable`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/setup-cargo-auditable/README.md) CI component rewrites `.wash/config.yaml` so that `wash build` invokes `cargo auditable build`. Every released Wasm component ships its full dependency graph embedded in the Wasm binary, ready for SBOM extraction.
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/setup-cargo-auditable@~latest
+    inputs:
+      stage: validate
+```
+
+### attest-cargo-sbom
+
+The [`attest-cargo-sbom`](https://gitlab.com/cosmonic-labs/ci-components/wash/-/blob/main/templates/attest-cargo-sbom/README.md) CI component extracts the CycloneDX SBOM from the auditable build and attaches it as a [Sigstore attestation](https://docs.sigstore.dev/cosign/attestation/) to the published image. Like `oci-publish` with `sign: "true"`, it uses a GitLab-issued OIDC token; no signing keys are stored.
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/attest-cargo-sbom@~latest
+    inputs:
+      stage: publish
+```
+
+## Attestation
+
+Sigstore keyless signing on GitLab is driven by the [`id_tokens:`](https://docs.gitlab.com/ee/ci/yaml/index.html#id_tokens) keyword, which mints a short-lived OIDC token scoped to the running job. `cosign` exchanges that token for a code-signing certificate from the Sigstore Fulcio CA, signs the artifact, and records the signature in the Rekor transparency log. There are no long-lived signing keys to manage or rotate.
+
+The two attestation flows in this catalog are:
+
+- **Image signing** &mdash; `oci-publish` with `sign: "true"` signs the published OCI image. Consumers verify with `cosign verify --certificate-identity ... --certificate-oidc-issuer https://gitlab.com`.
+- **SBOM attestation** &mdash; `attest-cargo-sbom` extracts the CycloneDX SBOM from the auditable build and attaches it to the image as a Sigstore attestation, verifiable with `cosign verify-attestation --type cyclonedx`.
+
+GitLab Ultimate users also get a parallel scanning path for free: publishing the CycloneDX SBOM as an [`artifacts:reports:cyclonedx`](https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscyclonedx) report registers the dependencies in the project's Dependency List and runs them through GitLab's own SBOM vulnerability scanner against the GitLab Advisory Database. The [sample pipeline](https://gitlab.com/cosmonic-labs/wasm-component-sample) layers [Trivy](https://aquasecurity.github.io/trivy/) on top as a third-party second opinion that gates on HIGH/CRITICAL findings.
+
+## Example: Build and publish pipeline
+
+The following pipeline assembles the core and Rust layers to build a Rust-based Wasm component with auditable dependency metadata, publish it to the project's container registry with a cosign-signed image and SBOM attestation, and cache the cargo registry/target between runs:
+
+```yaml
+stages:
+  - validate
+  - build
+  - publish
+
+include:
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/setup@~latest
+    inputs:
+      wash_version: "v{{WASMCLOUD_VERSION}}"
+      stage: validate
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/setup-rust@~latest
+    inputs:
+      stage: validate
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/setup-cargo-auditable@~latest
+    inputs:
+      stage: validate
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/build@~latest
+    inputs:
+      stage: build
+      component_artifact_path: "build/greeter.wasm"
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/oci-publish@~latest
+    inputs:
+      stage: publish
+      image_tags: "${CI_COMMIT_REF_SLUG},${CI_COMMIT_SHORT_SHA}"
+      sign: "true"
+  - component: $CI_SERVER_FQDN/cosmonic-labs/ci-components/wash/attest-cargo-sbom@~latest
+    inputs:
+      stage: publish
+
+# Attach the Rust cargo cache and auditable build outputs to wash-build.
+wash-build:
+  extends: .rust-cache
+  needs:
+    - job: setup-wash
+      artifacts: true
+    - job: setup-rust
+    - job: setup-wash-cargo-auditable
+      artifacts: true
+```
+
+The [`wasm-component-sample`](https://gitlab.com/cosmonic-labs/wasm-component-sample) repository extends this with merge-request workflow rules, `cargo fmt`/`cargo clippy` validation, a Wasm component smoke test, GitLab Secret Detection, CycloneDX + Trivy SBOM scanning, a Kubernetes `WorkloadDeployment` apply job, and a GitLab Release job tied to semver tags. Clone it as a starting point for new projects.
+
+## Required project configuration
+
+For the pipeline above to run cleanly in a fresh project:
+
+1. **Enable the GitLab container registry** for the project (Settings → General → Visibility) so `oci-publish` has a registry to push to.
+2. **Mask any external registry credentials** (e.g. `GHCR_TOKEN`, `ARTIFACTORY_TOKEN`) as CI/CD variables if the publish target isn't the project registry.
+
+For the Kubernetes deploy story shown in the sample repository, you'll additionally need:
+
+3. **Protected environments** (`staging`, `production`) so that only the right people can deploy.
+4. **File-type CI/CD variables** for cluster access:
+    - `KUBECONFIG_DRYRUN` &mdash; any cluster with the runtime-operator [CRDs](../../crds.mdx) installed; used by `manifest:validate` for `kubectl apply --dry-run=server`.
+    - `KUBECONFIG_STAGING` / `KUBECONFIG_PRODUCTION` &mdash; clusters running the [runtime-operator Helm chart](../../index.mdx) that will actually run the Wasm component.
+
+No other configuration is required &mdash; the CI components use GitLab built-ins for the container registry, OIDC, and release tooling.
+
+For closing the loop with Argo CD or Flux instead of `kubectl apply`, see [GitOps with Argo CD](./index.mdx#gitops-with-argo-cd).

--- a/docs/kubernetes-operator/operator-manual/cicd/index.mdx
+++ b/docs/kubernetes-operator/operator-manual/cicd/index.mdx
@@ -1,0 +1,130 @@
+---
+title: 'CI/CD and GitOps for wasmCloud'
+sidebar_label: 'CI/CD and GitOps'
+sidebar_position: 2
+description: 'Build CI/CD and GitOps pipelines for wasmCloud — publish components to OCI registries, roll out to Kubernetes, and integrate with Argo CD or Flux.'
+---
+
+## Overview
+
+wasmCloud components are distributed as [OCI artifacts](https://opencontainers.org/), so a CI/CD pipeline for wasmCloud follows a familiar pattern: build `.wasm` binaries, push them to an OCI registry, and update Kubernetes manifests to reference the new image.
+
+Reusable CI building blocks are available for both major hosted CI platforms:
+
+- **GitHub Actions** &mdash; the [`wasmCloud/setup-wash-action`](https://github.com/wasmCloud/setup-wash-action) and [`wasmCloud/actions`](https://github.com/wasmCloud/actions) repositories. See [wasmCloud GitHub Actions](./github-actions.mdx).
+- **GitLab CI** &mdash; the [`cosmonic-labs/ci-components/wash`](https://gitlab.com/cosmonic-labs/ci-components/wash) CI component catalog. See [wasmCloud on GitLab CI](./gitlab-ci.mdx).
+
+The two toolkits are designed for feature parity: equivalent build steps, OCI publishing, and Sigstore-keyless supply-chain attestations. The platform-specific pages above cover the per-job recipes. This page covers the cross-platform pieces: GitOps reconciliation with Argo CD and the shared supply-chain story.
+
+![Deployment pipeline from developer push through CI, OCI registry, GitOps, and Kubernetes](../../../images/deployment-pipeline.webp)
+
+## GitOps with Argo CD
+
+For production deployments, a GitOps workflow keeps Kubernetes state in sync with a Git repository. [Argo CD](https://argo-cd.readthedocs.io/) is a popular GitOps tool for Kubernetes and pairs well with the wasmCloud operator.
+
+### Two-application pattern
+
+A common pattern uses two Argo CD Applications:
+
+1. **Infrastructure Application** &mdash; deploys the wasmCloud platform (operator, NATS, hosts) from the [Helm chart](../../index.mdx).
+2. **Workloads Application** &mdash; deploys `WorkloadDeployment` manifests from a dedicated Git repository.
+
+This separation lets infrastructure and workload teams operate independently, each managing their own deployment cadence.
+
+### Example Argo CD Applications
+
+**Infrastructure Application** &mdash; installs the wasmCloud operator via Helm:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wasmcloud-platform
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: runtime-operator
+    repoURL: ghcr.io/wasmcloud/charts
+    targetRevision: v2-canary
+    helm:
+      releaseName: wasmcloud
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+**Workloads Application** &mdash; syncs `WorkloadDeployment` manifests from a Git repository:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wasmcloud-workloads
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/<org>/wasmcloud-workloads.git
+    targetRevision: main
+    path: manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+### Automating manifest updates
+
+After the CI pipeline publishes a new component image, a follow-up job updates the `WorkloadDeployment` manifest in the workloads repository and opens a pull request. Once merged, Argo CD detects the change and rolls out the new version automatically.
+
+The pattern is identical on both CI platforms; only the YAML changes. GitHub Actions example:
+
+```yaml
+  update-manifests:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: <org>/wasmcloud-workloads
+          token: ${{ secrets.WORKLOADS_REPO_TOKEN }}
+
+      - name: Update image tag
+        run: |
+          sed -i "s|image: ghcr.io/<org>/my-component:.*|image: ghcr.io/<org>/my-component:${{ github.ref_name }}|" \
+            manifests/my-component.yaml
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "Update my-component to ${{ github.ref_name }}"
+          commit-message: "chore: update my-component to ${{ github.ref_name }}"
+          branch: "update-my-component-${{ github.ref_name }}"
+```
+
+On GitLab CI, the same job is expressed as a `script:` block that uses [`glab mr create`](https://gitlab.com/gitlab-org/cli) (or the REST API) against a separate workloads project. The [`wasm-component-sample`](https://gitlab.com/cosmonic-labs/wasm-component-sample) repository ships a `deploy:staging` job that applies the manifest directly &mdash; useful when Argo CD isn't in the picture.
+
+:::info[]
+This pattern works with any GitOps tool that watches a Git repository for changes, including [Flux](https://fluxcd.io/).
+:::
+
+## Supply chain security
+
+Both CI toolkits assemble the same supply-chain story end-to-end:
+
+1. **Embedded SBOM at build time** &mdash; `cargo-auditable` is configured via `.wash/config.yaml` so that `wash build` produces a `.wasm` carrying its full dependency graph inside the binary.
+2. **CycloneDX extraction** &mdash; the published artifact ships with a CycloneDX SBOM derived directly from the embedded data, ready for vulnerability scanning and downstream attestation.
+3. **Sigstore keyless signing** &mdash; both platforms use OIDC tokens (GitHub Actions OIDC, GitLab `id_tokens:`) to sign attestations via Sigstore, with no long-lived signing keys to manage.
+
+The per-platform details &mdash; permissions, attestation storage, and verification commands &mdash; live on the platform pages:
+
+- [GitHub Actions attestation flow](./github-actions.mdx#attestation) &mdash; SBOM + SLSA build provenance via [`actions/attest-sbom`](https://github.com/actions/attest-sbom) and [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance), stored in the GitHub Attestation Store and verified with `gh attestation verify`.
+- [GitLab CI attestation flow](./gitlab-ci.mdx#attestation) &mdash; Sigstore keyless signing via `cosign` driven by GitLab `id_tokens:`, plus CycloneDX SBOM ingestion into GitLab's own SBOM vulnerability scanner.

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -77,4 +77,4 @@ See the [Expose a Workload via Kubernetes Service](../../recipes/expose-workload
 - [Filesystems and Volumes](./filesystems-and-volumes.mdx) — how to mount volumes into host pods
 - [Secrets and Configuration Management](./secrets-and-configuration.mdx) — supplying environment variables, ConfigMaps, and Secrets to components
 - [Private Registries](./private-registries.mdx) — how to pull Wasm component images from private OCI registries
-- [CI/CD](./cicd.mdx) — integrating wasmCloud workload deployments into CI/CD pipelines
+- [CI/CD and GitOps](./cicd/index.mdx) — integrating wasmCloud workload deployments into CI/CD pipelines

--- a/sidebars.js
+++ b/sidebars.js
@@ -84,7 +84,15 @@ const sidebars = {
           items: [
             'kubernetes-operator/operator-manual/overview',
             'kubernetes-operator/operator-manual/helm-values',
-            'kubernetes-operator/operator-manual/cicd',
+            {
+              type: 'category',
+              label: 'CI/CD and GitOps',
+              link: { type: 'doc', id: 'kubernetes-operator/operator-manual/cicd/index' },
+              items: [
+                'kubernetes-operator/operator-manual/cicd/github-actions',
+                'kubernetes-operator/operator-manual/cicd/gitlab-ci',
+              ],
+            },
             'kubernetes-operator/operator-manual/roles-and-rolebindings',
             'kubernetes-operator/operator-manual/secrets-and-configuration',
             'kubernetes-operator/operator-manual/private-registries',


### PR DESCRIPTION
Splits the operator-manual CI/CD page into a category with shared GitOps and supply-chain content, an existing GitHub Actions page, and a new GitLab CI page based on cosmonic-labs/ci-components/wash.