### PR TITLE
Removing 2025 community pages from no-index, setting to lower priorit…

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -161,13 +161,17 @@ const config = (async (): Promise<Config> => {
                 }
 
                 // Community meeting/transcript dated content:
-                //   2026 → priority 0.9 (current cadence we want indexed)
-                //   pre-2026 → noindex (handled in CommunityPostPage swizzle); drop from sitemap
+                //   2026 → priority 0.9 (current cadence)
+                //   2025 → priority 0.8 (indexed; content-rich backfilled pages)
+                //   pre-2025 → noindex (handled in CommunityPostPage swizzle); drop from sitemap
                 const communityYearMatch = path.match(COMMUNITY_YEAR_RE);
                 if (communityYearMatch) {
                   const year = Number(communityYearMatch[1]);
                   if (year >= 2026) {
                     return [{ ...item, priority: 0.9, changefreq: 'monthly' }];
+                  }
+                  if (year >= 2025) {
+                    return [{ ...item, priority: 0.8, changefreq: 'yearly' }];
                   }
                   return [];
                 }

--- a/src/theme/wasmcloud/community/post-page/index.tsx
+++ b/src/theme/wasmcloud/community/post-page/index.tsx
@@ -14,14 +14,14 @@ import CommunityPostItem from '../post-item';
 import Link from '@docusaurus/Link';
 import VideoSEO from '../video-seo';
 
-// Community meetings & transcripts older than 2026 are no longer current. Tell
+// Community meetings & transcripts older than 2025 are no longer current. Tell
 // search engines not to index them, but keep `follow` so they still pass link
 // equity to current pages they reference. Sitemap config (docusaurus.config.ts)
 // drops these URLs from sitemap.xml in parallel.
 function NoindexIfArchived(): JSX.Element | null {
   const { metadata } = useBlogPost();
   const year = new Date(metadata.date).getUTCFullYear();
-  if (year >= 2026) return null;
+  if (year >= 2025) return null;
   return (
     <Head>
       <meta name="robots" content="noindex, follow" />


### PR DESCRIPTION
This pull request completes the following:

- updates the "no index" command blocking all community meeting summaries and transcripts to include 2025, no-index everything before 2025; it was set at 2026
- Adds the 2025 community pages to the sitemap, with a slighly lower priority than 2026
