### PR TITLE
docs: fix Docusaurus typo and grammar errors in roadmap pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # wasmCloud.com
 
-Repository for the wasmCloud homepage including our community, team, docs, links, and as an ingress point for interested developers. This site is built with [Docusarus](https://docusaurus.io/).
+Repository for the wasmCloud homepage including our community, team, docs, links, and as an ingress point for interested developers. This site is built with [Docusaurus](https://docusaurus.io/).
 
 ## Running the site locally
 

--- a/docs/contributing/documentation.mdx
+++ b/docs/contributing/documentation.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 type: 'docs'
 ---
 
-The wasmCloud documentation site is [hosted on GitHub](https://github.com/wasmCloud/wasmcloud.com) and built with [Docusarus](https://docusaurus.io/).
+The wasmCloud documentation site is [hosted on GitHub](https://github.com/wasmCloud/wasmcloud.com) and built with [Docusaurus](https://docusaurus.io/).
 
 Choosing a [`good first issue`](https://github.com/wasmCloud/wasmcloud.com/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) is a great way to get started. 
 

--- a/versioned_docs/version-v1/contributing/documentation.mdx
+++ b/versioned_docs/version-v1/contributing/documentation.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 type: 'docs'
 ---
 
-The wasmCloud documentation site is [hosted on GitHub](https://github.com/wasmCloud/wasmcloud.com) and built with [Docusarus](https://docusaurus.io/).
+The wasmCloud documentation site is [hosted on GitHub](https://github.com/wasmCloud/wasmcloud.com) and built with [Docusaurus](https://docusaurus.io/).
 
 Choosing a [`good first issue`](https://github.com/wasmCloud/wasmcloud.com/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) is a great way to get started. 
 

--- a/versioned_docs/version-v1/roadmap/2024-q2.md
+++ b/versioned_docs/version-v1/roadmap/2024-q2.md
@@ -45,7 +45,7 @@ Notable issues and RFCs to watch out for, which garnered the most attention duri
 
 ## Diagram
 
-The diagram below shows a loose organization of critical tasks into 3 sections: Documentation, New Features and Improvements. This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there a few smaller tasks that are not included. You can view the full-size version [here](/docs/images/2024q2roadmap.webp). This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/10) for consistent updating.
+The diagram below shows a loose organization of critical tasks into 3 sections: Documentation, New Features and Improvements. This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there are a few smaller tasks that are not included. You can view the full-size version [here](/docs/images/2024q2roadmap.webp). This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/10) for consistent updating.
 
 ![Q2 2024 Roadmap](/docs/images/2024q2roadmap.webp)
 

--- a/versioned_docs/version-v1/roadmap/2024-q3.md
+++ b/versioned_docs/version-v1/roadmap/2024-q3.md
@@ -44,7 +44,7 @@ wasmCloud as a project offers the following top features:
 
 ## Diagram
 
-This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there a few smaller tasks that are not included. You can view the full-size and links included version [here](https://excalidraw.com/#json=tAg5TkgH6bvrrq76YGEDb,MERSFwVkfKrrnEk6IXRh4g). This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/11) for consistent updating.
+This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there are a few smaller tasks that are not included. You can view the full-size and links included version [here](https://excalidraw.com/#json=tAg5TkgH6bvrrq76YGEDb,MERSFwVkfKrrnEk6IXRh4g). This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/11) for consistent updating.
 
 ![Q3 2024 Roadmap](/docs/images/2024q3roadmap.webp)
 

--- a/versioned_docs/version-v1/roadmap/2024-q4.md
+++ b/versioned_docs/version-v1/roadmap/2024-q4.md
@@ -40,7 +40,7 @@ wasmCloud as a project offers the following top features:
 
 ## Diagram
 
-This roadmap is unordered as each individual task can be completed indepedently, so no rigid order is necessary. The diagram is also not exhaustive, as there a few smaller tasks that are not included. This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/12) for consistent updating. Compared to previous roadmaps the community only planned this roadmap using the GitHub project.
+This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there are a few smaller tasks that are not included. This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/12) for consistent updating. Compared to previous roadmaps the community only planned this roadmap using the GitHub project.
 
 ## Contributing
 

--- a/versioned_docs/version-v1/roadmap/2025-q1-2025.md
+++ b/versioned_docs/version-v1/roadmap/2025-q1-2025.md
@@ -49,7 +49,7 @@ wasmCloud as a project offers the following top features:
 
 ## Diagram
 
-This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there a few smaller tasks that are not included. This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/13) for consistent updating. Compared to previous roadmaps the community only planned this roadmap using the GitHub project.
+This roadmap is unordered as each individual task can be completed independently, so no rigid order is necessary. The diagram is also not exhaustive, as there are a few smaller tasks that are not included. This roadmap is also available as a [GitHub Project](https://github.com/orgs/wasmCloud/projects/7/views/13) for consistent updating. Compared to previous roadmaps the community only planned this roadmap using the GitHub project.
 
 ## Contributing
 


### PR DESCRIPTION
Three small copy bugs spotted across the docs:

1. `Docusarus` -> `Docusaurus` (missing a 'u') in README, the contributing guide, and its v1 counterpart
2. `indepedently` -> `independently` in the Q4 2024 roadmap
3. `there a few` -> `there are a few` (missing 'are') repeats in Q2/Q3/Q4 2024 and Q1 2025 roadmap pages

How to reproduce:

- Open https://wasmcloud.com/docs/contributing/documentation or README.md and search for "Docusarus"
- Open any roadmap page under /docs/v1/roadmap/ and search for "there a few"

No logic changes, pure copy fixes.

Signed-off-by: immanuwell <pchpr.00@list.ru>