### PR TITLE
update to ver 8.1.1

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -37,7 +37,7 @@ jobs:
           grep WASMCLOUD_VERSION src/wasmcloud-version.ts
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d1b9cd0f26de2b553b # v7.0.8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.WASMCLOUD_BOT_PAT }}
           commit-message: "docs: update wasmCloud version to ${{ env.NEW_VERSION }}"


### PR DESCRIPTION
There is a SHA error with version 7.0.8. This updates the plugin version to 8.1.1 for create-pull-request gh action