### PR TITLE
feat(docs): offline docs image + tarball + auto-tag on version bump

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,114 @@
+name: Release - Docs (offline image + tarball)
+
+on:
+  push:
+    tags:
+      - 'docs-v*'
+
+concurrency:
+  group: release-docs-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create GitHub Release + upload tarball asset
+  packages: write   # push image to ghcr.io
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - id: extract
+        shell: bash
+        run: |
+          # tag form: docs-v2.1.0 -> 2.1.0
+          version="${GITHUB_REF_NAME#docs-v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match docs-vMAJOR.MINOR.PATCH(-prerelease)"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  tarball:
+    needs: version
+    runs-on: ubuntu-latest
+    env:
+      OFFLINE_BUILD: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build offline docs
+        run: npm run build
+
+      - name: Create tarball
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          tar czf "wasmcloud-docs-${VERSION}.tar.gz" -C build .
+          sha256sum "wasmcloud-docs-${VERSION}.tar.gz" > "wasmcloud-docs-${VERSION}.tar.gz.sha256"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          name: Offline docs ${{ needs.version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            wasmcloud-docs-${{ needs.version.outputs.version }}.tar.gz
+            wasmcloud-docs-${{ needs.version.outputs.version }}.tar.gz.sha256
+          body: |
+            Air-gapped wasmCloud documentation bundle, version ${{ needs.version.outputs.version }}.
+
+            **Container image:** `ghcr.io/wasmcloud/docs:${{ needs.version.outputs.version }}` (also tagged `:latest`).
+
+            **Tarball:** extract anywhere and serve as static files. The site is built with `trailingSlash: true`, so URLs end in `/` and resolve to `<dir>/index.html`. Example:
+
+            ```shell
+            tar xzf wasmcloud-docs-${{ needs.version.outputs.version }}.tar.gz -C /var/www/docs
+            python -m http.server 8080 --directory /var/www/docs
+            ```
+
+            See the [Private Registries and Air-Gapped Deployments guide](https://wasmcloud.com/docs/kubernetes-operator/operator-manual/private-registries/) for the in-cluster pattern.
+
+  image:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/wasmcloud/docs:${{ needs.version.outputs.version }}
+            ghcr.io/wasmcloud/docs:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -9,13 +9,12 @@ concurrency:
   group: release-docs-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write   # create GitHub Release + upload tarball asset
-  packages: write   # push image to ghcr.io
+# Workflow-level permissions: nothing. Each job declares only what it needs.
 
 jobs:
   version:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       version: ${{ steps.extract.outputs.version }}
     steps:
@@ -33,6 +32,8 @@ jobs:
   tarball:
     needs: version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub Release + upload tarball asset
     env:
       OFFLINE_BUILD: '1'
     steps:
@@ -81,6 +82,8 @@ jobs:
   image:
     needs: version
     runs-on: ubuntu-latest
+    permissions:
+      packages: write   # push image to ghcr.io
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tag-after-merge.yml
+++ b/.github/workflows/tag-after-merge.yml
@@ -1,0 +1,64 @@
+name: Tag after release-bump merge
+
+# When a `release-bump`-labeled PR (opened by update-version.yml) merges to
+# main, push `docs-v<version>`. That tag triggers release-docs.yml, which
+# publishes the offline docs image + tarball matching the new docs pin.
+#
+# Version is extracted from the PR title set by update-version.yml:
+#   "docs: update wasmCloud version to 2.1.0"
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release-bump')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from PR title
+        id: ver
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          prefix='docs: update wasmCloud version to '
+          if [[ "$PR_TITLE" != "${prefix}"* ]]; then
+            echo "::error::PR title does not match expected prefix; got '$PR_TITLE'"
+            exit 1
+          fi
+          version="${PR_TITLE#${prefix}}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::extracted version '$version' is not valid semver"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Push docs-v${{ steps.ver.outputs.version }} tag
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -euo pipefail
+          tag="docs-v${VERSION}"
+          if git rev-parse --verify --quiet "refs/tags/${tag}"; then
+            echo "::notice::tag ${tag} already exists; skipping"
+            exit 0
+          fi
+          git tag -a "${tag}" -m "Offline docs release ${tag} (cuts ghcr.io/wasmcloud/docs:${VERSION})"
+          git push origin "${tag}"
+          echo "Pushed ${tag}; release-docs.yml will take over."

--- a/.github/workflows/tag-after-merge.yml
+++ b/.github/workflows/tag-after-merge.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # Use bot PAT so the tag push triggers release-docs.yml. A tag pushed
+          # by the default GITHUB_TOKEN does not fire downstream workflows.
+          token: ${{ secrets.WASMCLOUD_BOT_PAT }}
 
       - name: Extract version from PR title
         id: ver

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -49,4 +49,11 @@ jobs:
             Updates `src/wasmcloud-version.ts` to `${{ env.NEW_VERSION }}`.
             The remark plugin propagates the new value to all `{{WASMCLOUD_VERSION}}` placeholders
             in code blocks across the docs at build time — no other files need editing.
-          labels: "automated,documentation"
+
+            Merging this PR with the `release-bump` label will auto-cut `docs-v${{ env.NEW_VERSION }}`
+            (via `.github/workflows/tag-after-merge.yml`), which fires `release-docs.yml` and
+            publishes the offline docs image + tarball.
+          # `release-bump` gates .github/workflows/tag-after-merge.yml, which
+          # pushes `docs-v<version>` once this PR merges so the offline docs
+          # image and tarball get cut for the new wasmCloud version.
+          labels: "automated,documentation,release-bump"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,13 @@
 FROM node:24-alpine AS build
 
 WORKDIR /repo
-COPY . .
 
+# Copy dependency manifests first so the `npm ci` layer is reused across
+# doc-content-only rebuilds. Any change to package*.json busts the cache.
+COPY package.json package-lock.json ./
 RUN npm ci
+
+COPY . .
 
 ENV OFFLINE_BUILD=1
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Air-gapped wasmCloud docs image. Builds the docs site with external
+# integrations disabled (OFFLINE_BUILD=1 — see docusaurus.config.ts) and
+# serves it from nginx:alpine. Published to ghcr.io/wasmcloud/docs:X.Y.Z
+# when a `docs-v*` tag is pushed; see .github/workflows/release-docs.yml.
+#
+# Build:
+#   docker build -t wasmcloud-docs:test .
+
+# --- Stage 1: build the static site -------------------------------------------
+FROM node:24-alpine AS build
+
+WORKDIR /repo
+COPY . .
+
+RUN npm ci
+
+ENV OFFLINE_BUILD=1
+RUN npm run build
+
+# --- Stage 2: serve via nginx -------------------------------------------------
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /repo/build /usr/share/nginx/html
+
+EXPOSE 80

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/build
+**/.docusaurus
+**/.next
+**/.env
+**/.env.*
+.git
+.github
+.DS_Store

--- a/docs/kubernetes-operator/operator-manual/private-registries.mdx
+++ b/docs/kubernetes-operator/operator-manual/private-registries.mdx
@@ -262,3 +262,83 @@ These are the image-related values you can configure:
 | `nats.image.registry` | `docker.io` | NATS image registry |
 | `nats.image.repository` | `nats` | NATS image repository |
 | `nats.image.tag` | `2.11.3-alpine` | NATS image tag |
+
+## Offline documentation
+
+These docs are also published as a container image and a static tarball so
+operators can read them inside an air-gapped environment.
+
+Mirror the docs image alongside the other images:
+
+```shell
+export REGISTRY=my-registry.corp.com
+export DOCS_VERSION={{WASMCLOUD_VERSION}}
+
+oras copy ghcr.io/wasmcloud/docs:${DOCS_VERSION} \
+  ${REGISTRY}/wasmcloud/docs:${DOCS_VERSION}
+```
+
+Then run the docs as a single `Deployment` with a `ClusterIP` `Service`. Front
+it with whatever ingress your environment already uses (Traefik, Istio, your
+existing reverse proxy):
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasmcloud-docs
+  namespace: wasmcloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wasmcloud-docs
+  template:
+    metadata:
+      labels:
+        app: wasmcloud-docs
+    spec:
+      imagePullSecrets:
+        - name: registry-credentials
+      containers:
+        - name: nginx
+          image: my-registry.corp.com/wasmcloud/docs:{{WASMCLOUD_VERSION}}
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wasmcloud-docs
+  namespace: wasmcloud
+spec:
+  selector:
+    app: wasmcloud-docs
+  ports:
+    - port: 80
+      targetPort: 80
+```
+
+The image bakes only the current (v2) docs — the archived `v1` and `0.82`
+versions are stripped at build time. It is a sealed snapshot built with
+external integrations disabled, so it makes no outbound requests to Google
+Analytics, HubSpot, Reo, Algolia, Google Fonts, or `api.github.com`. Links to
+external sites (GitHub, Slack, social) will not resolve from an air-gapped
+browser.
+
+For environments without Kubernetes, the same content is published as a
+static tarball on the [docs release page](https://github.com/wasmCloud/wasmcloud.com/releases?q=docs-v):
+
+```shell
+tar xzf wasmcloud-docs-{{WASMCLOUD_VERSION}}.tar.gz -C /var/www/docs
+# serve /var/www/docs with any static web server
+```
+
+The static site is built with `trailingSlash: true`, so URLs end in `/` and
+resolve to `<dir>/index.html`. Any HTTP server that serves `index.html` for
+directory requests will work; `python -m http.server` and the default nginx
+`try_files $uri $uri/ $uri/index.html` configuration both do.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -22,6 +22,12 @@ import rehypeNameToId from 'rehype-name-to-id';
 import { WASMCLOUD_VERSION } from './src/wasmcloud-version';
 import wasmCloudVersionPlugin from './src/remark/wasmcloud-version';
 
+// When OFFLINE_BUILD=1 (used by the `docs-v*` release workflow that builds the
+// air-gapped container image and tarball), skip every plugin and head tag that
+// would cause an air-gapped browser to call out — analytics, search, fonts —
+// and trim the build to the current docs version only.
+const offlineBuild = process.env.OFFLINE_BUILD === '1';
+
 const rehypeShikiPlugin = [
   rehypeShiki,
   {
@@ -76,7 +82,10 @@ const config = (async (): Promise<Config> => {
     url: siteBaseUrl(),
     baseUrl: '/',
     trailingSlash: true,
-    onBrokenLinks: 'throw',
+    // Offline build excludes v1 / 0.82 docs; links from current → those
+    // versions become unresolvable, so downgrade to warn for this build path
+    // only. The production build keeps the throw behavior.
+    onBrokenLinks: offlineBuild ? 'warn' : 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: '/favicon.ico',
 
@@ -111,6 +120,9 @@ const config = (async (): Promise<Config> => {
             beforeDefaultRehypePlugins: [rehypeShikiPlugin],
             rehypePlugins: [rehypeNameToId],
             lastVersion: 'current',
+            // Air-gapped image only ships the current (v2) docs; v1 and 0.82
+            // are skipped to keep image size sane.
+            ...(offlineBuild ? { onlyIncludeVersions: ['current'] } : {}),
             versions: {
               current: {
                 label: 'v2',
@@ -247,12 +259,21 @@ const config = (async (): Promise<Config> => {
 
     plugins: [
       communitySpeakersPlugin,
-      [
-        '@wasmcloud/docusaurus-github-stars',
-        {
-          preloadRepo: process.env.NODE_ENV === 'production' ? 'wasmCloud/wasmCloud' : undefined,
-        } satisfies PluginGithubStarsOptions,
-      ],
+      // github-stars: both the build-time prefetch and the runtime
+      // <github-count> custom element call api.github.com. Skip the plugin
+      // entirely in offline builds (no usages outside the navbar, which is
+      // also gated above).
+      ...(offlineBuild
+        ? []
+        : [
+            [
+              '@wasmcloud/docusaurus-github-stars',
+              {
+                preloadRepo:
+                  process.env.NODE_ENV === 'production' ? 'wasmCloud/wasmCloud' : undefined,
+              } satisfies PluginGithubStarsOptions,
+            ],
+          ]),
       [
         '@wasmcloud/docusaurus-seo-checks',
         {
@@ -280,25 +301,29 @@ const config = (async (): Promise<Config> => {
           onUntruncatedBlogPosts: 'ignore',
         } satisfies PluginContentBlogOptions,
       ],
-      [
-        '@docusaurus/plugin-google-analytics',
-        {
-          trackingID: process.env.GOOGLE_ANALYTICS_ID || 'localdev',
-          anonymizeIP: true,
-        } satisfies PluginGoogleAnalyticsOptions,
-      ],
-      [
-        '@wasmcloud/docusaurus-hubspot-analytics',
-        {
-          hubspotId: process.env.HUBSPOT_ID || 'localdev',
-        } satisfies PluginHubspotAnalyticsOptions,
-      ],
-      [
-        '@wasmcloud/docusaurus-reo-analytics',
-        {
-          clientID: process.env.REO_CLIENT_ID || 'localdev',
-        } satisfies PluginReoAnalyticsOptions,
-      ],
+      ...(offlineBuild
+        ? []
+        : [
+            [
+              '@docusaurus/plugin-google-analytics',
+              {
+                trackingID: process.env.GOOGLE_ANALYTICS_ID || 'localdev',
+                anonymizeIP: true,
+              } satisfies PluginGoogleAnalyticsOptions,
+            ],
+            [
+              '@wasmcloud/docusaurus-hubspot-analytics',
+              {
+                hubspotId: process.env.HUBSPOT_ID || 'localdev',
+              } satisfies PluginHubspotAnalyticsOptions,
+            ],
+            [
+              '@wasmcloud/docusaurus-reo-analytics',
+              {
+                clientID: process.env.REO_CLIENT_ID || 'localdev',
+              } satisfies PluginReoAnalyticsOptions,
+            ],
+          ]),
       customPostCssPlugin, // PostCSS plugin function registration
       [
         'docusaurus-plugin-llms',
@@ -332,13 +357,20 @@ const config = (async (): Promise<Config> => {
             // used for styling, see src/styles/theme/_navbar.css
             className: 'navbar__link--version-dropdown',
           },
-          {
-            href: 'https://github.com/wasmcloud/wasmcloud',
-            'aria-label': 'Star wasmCloud on GitHub',
-            position: 'right',
-            html: `<span class="badge badge--outline">Star us! ★ <github-count repo="wasmcloud/wasmcloud">1500</github-count></span>`,
-            className: 'sidebar-hidden',
-          },
+          // The <github-count> custom element fetches api.github.com at runtime
+          // to populate the live star count. Dropped in offline builds so
+          // air-gapped browsers do not attempt that request.
+          ...(offlineBuild
+            ? []
+            : [
+                {
+                  href: 'https://github.com/wasmcloud/wasmcloud',
+                  'aria-label': 'Star wasmCloud on GitHub',
+                  position: 'right' as const,
+                  html: `<span class="badge badge--outline">Star us! ★ <github-count repo="wasmcloud/wasmcloud">1500</github-count></span>`,
+                  className: 'sidebar-hidden',
+                },
+              ]),
           await svgIconNavItem({
             svgIconPath: './static/icons/github.svg',
             label: 'GitHub',
@@ -427,11 +459,15 @@ const config = (async (): Promise<Config> => {
         ],
         copyright: `Copyright © ${new Date().getFullYear()} wasmCloud LLC. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage. Built with Docusaurus.`,
       },
-      algolia: {
-        apiKey: 'f0ef30f3d98ce5e9a7dd7579bb221dfc',
-        indexName: 'wasmcloud',
-        appId: '2IM4TMH501',
-      },
+      ...(offlineBuild
+        ? {}
+        : {
+            algolia: {
+              apiKey: 'f0ef30f3d98ce5e9a7dd7579bb221dfc',
+              indexName: 'wasmcloud',
+              appId: '2IM4TMH501',
+            },
+          }),
     } satisfies PresetClassicThemeConfig,
 
     markdown: {
@@ -482,25 +518,33 @@ const config = (async (): Promise<Config> => {
           inLanguage: 'en-US',
         }),
       },
-      {
-        tagName: 'link',
-        attributes: { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-      },
-      {
-        tagName: 'link',
-        attributes: {
-          rel: 'preconnect',
-          href: 'https://fonts.gstatic.com',
-          crossorigin: 'crossorigin',
-        },
-      },
-      {
-        tagName: 'link',
-        attributes: {
-          href: 'https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Lexend:wght@100..900&family=Inter:wght@100..900&display=swap',
-          rel: 'stylesheet',
-        },
-      },
+      // Google Fonts: skipped in the offline build so air-gapped browsers do
+      // not request fonts.googleapis.com / fonts.gstatic.com. Falls back to
+      // the OS sans-serif via the CSS stack already declared in
+      // src/styles/index.css.
+      ...(offlineBuild
+        ? []
+        : [
+            {
+              tagName: 'link',
+              attributes: { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+            },
+            {
+              tagName: 'link',
+              attributes: {
+                rel: 'preconnect',
+                href: 'https://fonts.gstatic.com',
+                crossorigin: 'crossorigin',
+              },
+            },
+            {
+              tagName: 'link',
+              attributes: {
+                href: 'https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Lexend:wght@100..900&family=Inter:wght@100..900&display=swap',
+                rel: 'stylesheet',
+              },
+            },
+          ]),
     ],
 
     onBrokenAnchors: 'throw',

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Docusaurus emits trailing-slash routes (trailingSlash: true). The
+  # try_files fallback resolves /foo/, /foo, and bare /foo/index.html alike.
+  location / {
+    try_files $uri $uri/ $uri/index.html =404;
+  }
+}


### PR DESCRIPTION
Adds an offline-distribution path for the wasmCloud docs so air-gapped operators can mirror them alongside the other wasmCloud images they already mirror with ORAS.

Pushing a `docs-v*` tag triggers a release workflow that:
- Publishes a multi-arch container image to `ghcr.io/wasmcloud/docs:X.Y.Z` (also tagged `:latest`).
- Creates a GitHub Release with `wasmcloud-docs-X.Y.Z.tar.gz` (+ `.sha256`) attached.

Tags are pushed automatically by a new `tag-after-merge.yml` workflow when an `update-version.yml`-opened PR (now carrying a new `release-bump` label) is merged, so the offline docs image lines up with each wasmCloud release without any manual step beyond the existing PR review.

You can see how it integrates with the existing flow below:

```
wasmCloud/wasmCloud cuts vX.Y.Z release
  ↓ repository_dispatch(wasmcloud-release)
update-version.yml
  ↓ opens PR labeled [automated, documentation, release-bump]  ← one-line addition
  ↓ title: "docs: update wasmCloud version to X.Y.Z"
human reviews, merges
  ↓ pull_request: closed (merged=true) with release-bump label
tag-after-merge.yml  ← new
  ↓ extracts X.Y.Z from PR title
  ↓ pushes tag docs-vX.Y.Z
release-docs.yml  ← new
publishes ghcr.io/wasmcloud/docs:X.Y.Z (+ :latest) and the tarball Release
```