### PR TITLE
fix: remove Babel build warning in seo checks

### DIFF
--- a/packages/docusaurus-seo-checks/src/checks/underscores.ts
+++ b/packages/docusaurus-seo-checks/src/checks/underscores.ts
@@ -1,5 +1,6 @@
 import { stripIndents } from 'common-tags';
-import generateCheck, { DefaultCheckOptions } from './generate-check';
+import generateCheck from './generate-check';
+import type { DefaultCheckOptions } from './generate-check';
 
 export type UnderscoresCheckOptions = DefaultCheckOptions<{}>;
 

--- a/packages/docusaurus-seo-checks/src/index.ts
+++ b/packages/docusaurus-seo-checks/src/index.ts
@@ -1,5 +1,5 @@
-import { PluginOptions } from './options';
-import { Plugin, LoadContext } from '@docusaurus/types';
+import type { PluginOptions } from './options';
+import type { Plugin, LoadContext } from '@docusaurus/types';
 import rootLogger from './utils/logger';
 import { PLUGIN_NAME } from './utils/constants';
 import importChecks from './checks/import-checks';

--- a/packages/docusaurus-seo-checks/src/options.ts
+++ b/packages/docusaurus-seo-checks/src/options.ts
@@ -1,7 +1,7 @@
 import { Joi } from '@docusaurus/utils-validation';
 import type { OptionValidationContext } from '@docusaurus/types';
-import { CheckLevel, DefaultCheckOptions } from './checks/generate-check';
-import { ImportedChecksOptions } from './checks/import-checks';
+import type { CheckLevel, DefaultCheckOptions } from './checks/generate-check';
+import type { ImportedChecksOptions } from './checks/import-checks';
 
 type Options = ImportedChecksOptions;
 


### PR DESCRIPTION
Tiny cleanup but it hits every build, kinda noisy.

On `main`, `npm run build` prints the `DefaultCheckOptions` Babel scope tracker warning twice from the local seo checks package.
This swaps type-only imports to `import type`, so Babel stops treating that type like runtime code. Build output is clean again.

Repro
1. `npm ci`
2. `npm run build`
3. See the `DefaultCheckOptions` warning twice

Checks
1. Reverted this patch locally and reproduced the warning
2. Re-applied it and ran `npm run build` again
3. Warning is gone, build still passes
