### PR TITLE
ci: opt into Node 24 for bundled-JS actions

### DIFF
--- a/.github/workflows/agenda.yml
+++ b/.github/workflows/agenda.yml
@@ -10,6 +10,12 @@ on:
         description: "URL of YouTube livestream for community meeting"
         required: true
         type: string
+
+# Opt into Node 24 for bundled-JS actions ahead of GitHub's June 16, 2026 cutoff.
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   create_agenda:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -6,6 +6,11 @@ on:
 permissions:
   contents: read
 
+# Opt into Node 24 for bundled-JS actions ahead of GitHub's June 16, 2026 cutoff.
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_structured_data.yml
+++ b/.github/workflows/ci_structured_data.yml
@@ -15,6 +15,11 @@ concurrency:
   group: structured-data-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Opt into Node 24 for bundled-JS actions ahead of GitHub's June 16, 2026 cutoff.
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -11,6 +11,11 @@ concurrency:
 
 # Workflow-level permissions: nothing. Each job declares only what it needs.
 
+# Opt into Node 24 for bundled-JS actions ahead of GitHub's June 16, 2026 cutoff.
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   version:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-after-merge.yml
+++ b/.github/workflows/tag-after-merge.yml
@@ -14,6 +14,11 @@ on:
 permissions:
   contents: write
 
+# Opt into Node 24 for bundled-JS actions ahead of GitHub's June 16, 2026 cutoff.
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   tag:
     if: >-

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -17,6 +17,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Opt into Node 24 for bundled-JS actions ahead of GitHub's June 16, 2026 cutoff.
+# https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Opts our workflows into Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` ahead of [GitHub's June 16, 2026 runner cutoff](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).