### PR TITLE
docs: cover wasmCloud 2.3.0 features

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -273,7 +273,7 @@ Complete example applications are available in the [`examples/` directory of `wa
 |---|---|---|
 | [Blobby](#blobby) | Rust | [`ghcr.io/wasmcloud/components/blobby`](https://github.com/orgs/wasmCloud/packages/container/package/components%2Fblobby) |
 | [gRPC Hello World](#grpc-hello-world) | Rust | [`components/grpc-hello-world-client`](https://github.com/orgs/wasmCloud/packages/container/package/components%2Fgrpc-hello-world-client), [`components/grpc-hello-world-server`](https://github.com/orgs/wasmCloud/packages/container/package/components%2Fgrpc-hello-world-server) |
-| [OpenTelemetry HTTP Counter](#opentelemetry-http-counter) | Rust | [`ghcr.io/wasmcloud/components/otel-http`](https://github.com/orgs/wasmCloud/packages/container/package/components%2Fotel-http) |
+| [OpenTelemetry Config](#opentelemetry-config) | Rust | [`ghcr.io/wasmcloud/components/otel-config`](https://github.com/orgs/wasmCloud/packages/container/package/components%2Fotel-config) |
 | [QR Code Generator](#qr-code-generator) | Rust | [`ghcr.io/wasmcloud/components/qrcode`](https://github.com/orgs/wasmCloud/packages/container/package/components%2Fqrcode) |
 | [HTTP Axios](#http-axios) | TypeScript | — |
 | [HTTP Password Checker](#http-password-checker) | TypeScript | — |
@@ -302,13 +302,17 @@ Two components demonstrating how to make and serve gRPC calls from a wasmCloud c
 - **`component-client` interfaces**: Imports `wasi:http/outgoing-handler`; exports `wasi:http/incoming-handler` (via `wstd`)
 - **`component-server` interfaces**: Exports `wasi:http/incoming-handler` (via `wstd`)
 
-#### OpenTelemetry HTTP Counter
+#### OpenTelemetry Config
 
-An HTTP counter service instrumented with OpenTelemetry through the `wasi:otel` interfaces. Each request creates a parent server span, emits child spans for downstream HTTP / blobstore / keyvalue operations, records structured log entries correlated with the active trace, and exports request-count and response-size metrics.
+A component instrumented with OpenTelemetry through the `wasi:otel` interfaces, with its OTel `Resource` (service name, environment, etc.) sourced from `wasi:config/store`. Each operation emits tracing, log, and metric data; the same component identifies itself differently per environment because `workload.config` and the OTel `Resource` are wired together at deploy time rather than at compile time.
 
-- **Source**: [`wasmCloud/wasmCloud — examples/otel-http`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/otel-http)
-- **OCI artifact**: `ghcr.io/wasmcloud/components/otel-http`
-- **Interfaces**: Imports `wasi:otel/{tracing,logs,metrics,types}@0.2.0-rc.1`, `wasi:http/outgoing-handler@0.2.2`, `wasi:blobstore/{blobstore,container}@0.2.0-draft`, `wasi:keyvalue/{store,atomics}@0.2.0-draft`, `wasi:config/store@0.2.0-rc.1`, `wasi:clocks/wall-clock@0.2.0`, `wasi:logging/logging@0.1.0-draft`; exports `wasi:http/incoming-handler@0.2.2`
+The example's [`chain/`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/otel-config/chain) subdirectory wires three instances of the same component (`frontend → middle → backend`) into a call graph that exports to a shared OTLP endpoint, so the collector stitches every hop into a single end-to-end trace — a reference for the cross-workload trace roll-up pattern.
+
+The `.wash/config.yaml` in this example also exercises the [workload env / config / secrets manifest schema](./kubernetes-operator/operator-manual/secrets-and-configuration.mdx) introduced in 2.3.0 (`configs:` / `secrets:` source blocks referenced from `workload.environment.{configFrom,secretFrom}`).
+
+- **Source**: [`wasmCloud/wasmCloud — examples/otel-config`](https://github.com/wasmCloud/wasmCloud/tree/main/examples/otel-config)
+- **OCI artifact**: `ghcr.io/wasmcloud/components/otel-config`
+- **Interfaces**: Imports `wasi:otel/{tracing,logs,metrics,types}@0.2.0-rc.2`, `wasi:blobstore/{blobstore,container}@0.2.0-draft`, `wasi:keyvalue/{store,atomics}@0.2.0-draft`, `wasi:config/store@0.2.0-rc.1`, `wasi:clocks/wall-clock@0.2.0`, `wasi:random/random@0.2.2`; HTTP I/O via `wstd`'s `#[http_server]` proc macro (`wasi:http/incoming-handler` exported, `wasi:http/outgoing-handler` imported)
 
 #### QR Code Generator
 

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -93,9 +93,17 @@ operator:
     - team-b
 ```
 
-When `watchNamespaces` is populated, the chart narrows the operator's reach into per-workload resources. The rules for `configmaps`, `secrets`, `events`, and `services` move out of the operator's main `ClusterRole` and into a separate `ClusterRole` (`<release>-workload-namespace`) that's bound via a `RoleBinding` in each listed namespace. The operator's core grants (workload, host, and CRD APIs) stay on the main `ClusterRole` + `ClusterRoleBinding`, since they need to be cluster-wide regardless of which namespaces hold workloads.
+When `watchNamespaces` is populated, the chart drops the operator's cluster-wide `ClusterRole` and `ClusterRoleBinding` entirely and renders a set of `Role` + `RoleBinding` pairs in each watched namespace instead. Per watched namespace:
 
-The net effect is that the operator's read/write access to namespaced workload inputs (config, secrets) and outputs (events, services) is scoped to exactly the namespaces in `watchNamespaces`, while the cluster-scoped resources it manages remain available everywhere.
+- `<release>-workload-crd` covers the `runtime.wasmcloud.dev` workload resources — `artifacts`, `workloads`, `workloadreplicasets`, `workloaddeployments`, plus their `/status` and `/finalizers` subresources
+- `<release>-workload-namespace` covers per-workload core resources — `configmaps`, `secrets`, `events`, `services` (plus `services/finalizers`)
+- `<release>-endpointslice` covers `endpointslices` for Kubernetes-native traffic routing
+
+`Host` CRD grants stay on the namespaced `Role` in the operator's own namespace (host pods aren't tenant-scoped), and `<release>-leader-election` continues to live there too. The net effect: an `operator.watchNamespaces` install holds no cluster-wide permissions for workload resources and can be deployed with namespace-admin RBAC alone for those namespaces.
+
+:::info
+This namespaced-by-default behavior for the `runtime.wasmcloud.dev` apiGroup landed in 2.3.0 ([#5208](https://github.com/wasmCloud/wasmCloud/pull/5208)). Earlier releases bound the workload CRD verbs cluster-wide even when `watchNamespaces` was set.
+:::
 
 ### `operator.hostNamespaces`
 

--- a/docs/kubernetes-operator/operator-manual/roles-and-rolebindings.mdx
+++ b/docs/kubernetes-operator/operator-manual/roles-and-rolebindings.mdx
@@ -148,6 +148,10 @@ rules:
 
 In some cases, it may be desired to restrict the Operator to only processing Workloads deployed in certain namespaces. This can be achieved by modifying the ClusterRole `wasmcloud-runtime-operator` to only have the following permissions:
 
+:::tip
+On 2.3.0 and later, setting [`operator.watchNamespaces`](./helm-values.mdx#operatorwatchnamespaces) in the Helm chart performs the equivalent reshaping automatically — the workload-side `ClusterRole`/`ClusterRoleBinding` are omitted, and per-namespace `Role` + `RoleBinding` pairs cover the workload CRDs, core resources, and `endpointslices` in each watched namespace. The manual recipe below is still useful for installs that don't use the chart or that need a different namespace mapping than `watchNamespaces` produces.
+:::
+
 ### ClusterRole: `wasmcloud-runtime-operator`
 | API Group | Resources | Verbs | Reason |
 |---|---|---|---|

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -110,7 +110,7 @@ Specify the `wash` version for this project.
 Example:
 
 ```yaml
-version: 2.2.0
+version: 2.3.0
 ```
 
 ### `build` configuration

--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,1 +1,1 @@
-export const WASMCLOUD_VERSION = '2.2.0';
+export const WASMCLOUD_VERSION = '2.3.0';


### PR DESCRIPTION
Pins the docs to wasmCloud 2.3.0 and refreshes the OTel example, helm-values `watchNamespaces` description, and namespace-restriction recipe to reflect the new workload env/config/secrets schema ([#5117](https://github.com/wasmCloud/wasmCloud/pull/5117)), namespaced `runtime.wasmcloud.dev` RBAC ([#5208](https://github.com/wasmCloud/wasmCloud/pull/5208)), wasi:otel rc.2 ([#5205](https://github.com/wasmCloud/wasmCloud/pull/5205)), and cross-workload trace roll-up ([#5226](https://github.com/wasmCloud/wasmCloud/pull/5226)).