### PR TITLE
docs: update wasmCloud version to 2.4.0

### DIFF
--- a/docs/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
+++ b/docs/kubernetes-operator/operator-manual/filesystems-and-volumes.mdx
@@ -69,6 +69,26 @@ spec:
 * The `name` field assigns a unique name to the volume.
 * The `hostPath.path` field specifies the target path for the file or directory on the host machine.
 
+### Declarative alternative: `runtime.hostGroups[].volumes`
+
+Starting in 2.4.0, the runtime-operator Helm chart accepts pod-level `volumes` and host-container `volumeMounts` directly on each host group entry, so the volume survives a `helm upgrade` instead of being re-applied as a manual patch on the rendered `Deployment`:
+
+```yaml
+runtime:
+  hostGroups:
+    - name: default
+      replicas: 3
+      volumes:
+        - name: wasmcloud-data
+          hostPath:
+            path: /var/data
+      volumeMounts:
+        - name: wasmcloud-data
+          mountPath: /var/data
+```
+
+The `WorkloadDeployment` half of the wiring is unchanged — components still reference the volume by name via `spec.volumes` + `localResources.volumeMounts`, as shown in the next section. See [`runtime.hostGroups[].volumes`, `volumeMounts`, and `ports`](./helm-values.mdx#runtimehostgroupsvolumes-volumemounts-and-ports) for the full schema.
+
 ## Deploying components with filesystem access
 
 To access filesystem resources via the preopens and the wasmCloud host, a component should import `wasi:filesystem`. You can use the Wasm Shell (`wash`) CLI to check your component's imports:

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -71,6 +71,24 @@ When `global.tls.enabled` is `false`, the chart ignores `global.certificates.gen
 
 Controls whether the chart generates self-signed TLS certificates for NATS and the control plane. Set to `false` when bringing your own certificate secrets. See the [TLS: bring your own certificates](../../recipes/tls-bring-your-own-certificates.mdx) recipe for the full BYOC flow.
 
+### `global.nats.schedulerUrl` and `global.nats.dataUrl`
+
+Introduced in 2.4.0. The chart now exposes two NATS URLs separately:
+
+- `global.nats.schedulerUrl` — the **control-plane** URL the operator (`-nats-url`) and the host runtime (`--scheduler-nats-url`) connect to for workload scheduling and host heartbeats.
+- `global.nats.dataUrl` — the **data-plane** URL the host runtime (`--data-nats-url`) uses for Wasm workload messaging, key-value, and blobstore backends.
+
+Both default to `nats://nats.<release-namespace>.svc.cluster.local:4222` when left empty (matching pre-2.4 behavior). Splitting them lets workloads target a separate NATS cluster from the scheduler — useful when application traffic and operator coordination live on different brokers.
+
+```yaml
+global:
+  nats:
+    schedulerUrl: "nats://control-plane.example.internal:4222"
+    dataUrl: "nats://data-plane.example.internal:4222"
+```
+
+Per-host-group overrides are also available via [`runtime.hostGroups[].schedulerNatsUrl`](#runtimehostgroupsschedulernatsurl-and-runtimehostgroupsdatanatsurl) and `runtime.hostGroups[].dataNatsUrl`.
+
 ## `operator`, `nats`, `runtime` — pod labels and annotations
 
 Introduced in 2.0.3. Each deployment accepts `podLabels` and `podAnnotations` that are merged into the pod template. This is most commonly used for service mesh injection:
@@ -147,6 +165,26 @@ Set to `false` when namespace boundaries are part of your tenant isolation model
 
 See [Troubleshooting: Workload stays unscheduled with `allowSharedHosts: false`](../../troubleshooting.mdx#workload-stays-unscheduled-with-allowsharedhosts-false) for the symptom and resolution patterns.
 
+### `operator.env`, `operator.envFrom`, and `operator.extraArgs`
+
+Introduced in 2.4.0. Three passthrough fields that let chart users wire operator-side configuration without forking the chart:
+
+- `operator.env` — additional environment variables for the operator container, appended after the chart-managed vars. Standard Kubernetes env shape (supports `valueFrom` with `secretKeyRef` / `configMapKeyRef`).
+- `operator.envFrom` — populate the operator container's environment from ConfigMaps or Secrets, using the standard Kubernetes `envFrom` shape.
+- `operator.extraArgs` — additional CLI args appended verbatim to the operator container, for operator flags the chart does not template (e.g. `-leader-elect`, `-cpu-backpressure-threshold=75`).
+
+```yaml
+operator:
+  env:
+    - name: LOG_LEVEL
+      value: debug
+  envFrom:
+    - secretRef:
+        name: operator-extra-config
+  extraArgs:
+    - "-leader-elect"
+```
+
 ### `operator.image.tag`
 
 Defaults to the chart's `appVersion`. Override only when you need to pin to a specific operator build that differs from the chart release:
@@ -173,6 +211,26 @@ gateway:
 ```
 
 ## `runtime`
+
+### `runtime.env`, `runtime.envFrom`, and `runtime.extraArgs`
+
+Introduced in 2.4.0. Chart-wide host configuration applied to **every** host group's container. Per-host-group values (see [`runtime.hostGroups[].env`](#runtimehostgroupsenv-envfrom-and-extraargs) etc.) are appended after these, letting one group extend the chart-wide defaults without redefining them.
+
+- `runtime.env` — additional environment variables applied to every host group container, appended after the chart-managed vars (`WASMCLOUD_HOST_IP`, `WASMCLOUD_HOST_ENVIRONMENT`) and before any per-host-group `env`.
+- `runtime.envFrom` — populate every host group container's environment from ConfigMaps or Secrets.
+- `runtime.extraArgs` — additional CLI args appended to every host group container, for host flags the chart does not template. Merged with per-host-group `extraArgs`.
+
+```yaml
+runtime:
+  env:
+    - name: RUST_LOG
+      value: info
+  envFrom:
+    - configMapRef:
+        name: shared-host-config
+  extraArgs:
+    - "--max-concurrent-workloads=64"
+```
 
 ### `runtime.hostGroups`
 
@@ -214,6 +272,68 @@ runtime:
 ```
 
 When you override this, ensure the namespace exists and is included in [`operator.hostNamespaces`](#operatorhostnamespaces) so the operator has the pod RBAC and informer cache access it needs to manage host pod lifecycle there. Each host's `Host.environment` will reflect the namespace where its pod runs, which is what `allowSharedHosts: false` matches against for namespace-scoped scheduling.
+
+### `runtime.hostGroups[].schedulerNatsUrl` and `runtime.hostGroups[].dataNatsUrl`
+
+Introduced in 2.4.0. Per-host-group overrides for the NATS URLs the host runtime connects to. Both fall back to the chart-wide [`global.nats.schedulerUrl` / `global.nats.dataUrl`](#globalnatsschedulerurl-and-globalnatsdataurl) when empty, which in turn fall back to the in-cluster NATS service.
+
+```yaml
+runtime:
+  hostGroups:
+    - name: edge
+      replicas: 2
+      dataNatsUrl: "nats://edge-data.example.internal:4222"
+```
+
+Use this when a single chart release runs host groups against different data-plane brokers (for example, regional NATS clusters for an edge group while the default group stays on the in-cluster broker).
+
+### `runtime.hostGroups[].env`, `envFrom`, and `extraArgs`
+
+Introduced in 2.4.0. Per-host-group versions of the chart-wide [`runtime.env`](#runtimeenv-runtimeenvfrom-and-runtimeextraargs) / `envFrom` / `extraArgs` fields. These are **appended** after the chart-wide values, so a group can extend the shared defaults without redeclaring them.
+
+```yaml
+runtime:
+  env:
+    - name: RUST_LOG
+      value: info
+  hostGroups:
+    - name: gpu
+      replicas: 1
+      env:
+        - name: RUST_LOG
+          value: debug   # overrides the chart-wide value for this group only
+      extraArgs:
+        - "--wasi-webgpu-debug"
+```
+
+### `runtime.hostGroups[].volumes`, `volumeMounts`, and `ports`
+
+Introduced in 2.4.0. Optional passthrough fields rendered directly into the host group's pod and container spec, letting chart users mount ConfigMaps / Secrets / persistent volumes and expose extra container ports without forking the chart.
+
+- `runtime.hostGroups[].volumes` — appended to the pod's `spec.volumes`. Standard Kubernetes volume shape.
+- `runtime.hostGroups[].volumeMounts` — appended to the host container's `volumeMounts`. Pair each entry with a matching `volumes` entry above.
+- `runtime.hostGroups[].ports` — appended to the host container's `ports`. Typically used to expose a metrics scrape port for Prometheus.
+
+```yaml
+runtime:
+  hostGroups:
+    - name: default
+      replicas: 3
+      volumes:
+        - name: app-config
+          configMap:
+            name: my-host-config
+      volumeMounts:
+        - name: app-config
+          mountPath: /etc/wasmcloud/config
+          readOnly: true
+      ports:
+        - name: metrics
+          containerPort: 9090
+          protocol: TCP
+```
+
+All three fields render unconditionally, so they survive a `global.tls.enabled: false` install. **Do not re-list the HTTP port in `ports`** — the chart already renders it from `.http.port`, and a duplicate `containerPort` fails Deployment validation. See [Filesystems and Volumes](./filesystems-and-volumes.mdx) for the broader volume story.
 
 ### `runtime.hostGroups[].http.port`
 

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -50,6 +50,7 @@ The wasmCloud operator (`runtime-operator`) is the control-plane entity that wat
 - **Status reporting**: Updates the `status` subresource of each CRD to reflect whether scheduling succeeded or failed, and surfaces Kubernetes events for observability.
 - **Leader election**: When enabled and running with multiple replicas, uses a `coordination.k8s.io/v1` Lease in the operator's own namespace to elect a single active instance and avoid split-brain reconciliation.
 - **Metrics endpoint**: Exposes a `/metrics` endpoint (Prometheus format) protected by Kubernetes token review and subject access review, suitable for scraping by monitoring tools.
+- **NATS-backed liveness probe**: Starting in 2.4.0, the operator deployment exposes a dedicated health port whose liveness and readiness probes reflect the operator's NATS connection status. If the NATS service becomes unreachable — for example during a NATS rolling restart — the kubelet restarts the operator pod, which reconnects automatically once NATS is back. No manual intervention is required to recover from a control-plane broker hiccup.
 
 The operator runs with the `wasmcloud-runtime-operator` ServiceAccount. See [Roles and Role Bindings](./roles-and-rolebindings.mdx) for the full set of permissions required.
 

--- a/docs/kubernetes-operator/operator-manual/overview.mdx
+++ b/docs/kubernetes-operator/operator-manual/overview.mdx
@@ -50,7 +50,7 @@ The wasmCloud operator (`runtime-operator`) is the control-plane entity that wat
 - **Status reporting**: Updates the `status` subresource of each CRD to reflect whether scheduling succeeded or failed, and surfaces Kubernetes events for observability.
 - **Leader election**: When enabled and running with multiple replicas, uses a `coordination.k8s.io/v1` Lease in the operator's own namespace to elect a single active instance and avoid split-brain reconciliation.
 - **Metrics endpoint**: Exposes a `/metrics` endpoint (Prometheus format) protected by Kubernetes token review and subject access review, suitable for scraping by monitoring tools.
-- **NATS-backed liveness probe**: Starting in 2.4.0, the operator deployment exposes a dedicated health port whose liveness and readiness probes reflect the operator's NATS connection status. If the NATS service becomes unreachable — for example during a NATS rolling restart — the kubelet restarts the operator pod, which reconnects automatically once NATS is back. No manual intervention is required to recover from a control-plane broker hiccup.
+- **NATS-backed liveness probe**: Starting in 2.4.0, the operator deployment exposes a dedicated health port whose liveness and readiness probes reflect the operator's NATS connection status. If the NATS service becomes unreachable (for example during a NATS rolling restart) the kubelet restarts the operator pod, which reconnects automatically once NATS is back. No manual intervention is required to recover from a control-plane broker hiccup.
 
 The operator runs with the `wasmcloud-runtime-operator` ServiceAccount. See [Roles and Role Bindings](./roles-and-rolebindings.mdx) for the full set of permissions required.
 

--- a/docs/runtime/creating-host-plugins.mdx
+++ b/docs/runtime/creating-host-plugins.mdx
@@ -54,7 +54,7 @@ pub trait HostPlugin: Any + Send + Sync + 'static {
     async fn on_workload_bind(
         &self,
         workload: &UnresolvedWorkload,
-        interfaces: HashSet<WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -65,7 +65,7 @@ pub trait HostPlugin: Any + Send + Sync + 'static {
     async fn on_workload_item_bind<'a>(
         &self,
         item: &mut WorkloadItem<'a>,
-        interfaces: HashSet<WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -83,7 +83,7 @@ pub trait HostPlugin: Any + Send + Sync + 'static {
     async fn on_workload_unbind(
         &self,
         workload_id: &str,
-        interfaces: HashSet<WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         Ok(())
     }
@@ -112,9 +112,26 @@ The `HostPlugin` trait uses several types from the `wash_runtime` crate:
 
 - **`WitWorld`** - Contains `imports` and `exports` as `HashSet<WitInterface>`, representing the WIT interfaces the plugin provides.
 - **`WitInterface`** - Describes a specific interface with `namespace`, `package`, `interfaces` (a set of interface names), an optional `version`, an optional `name` (used for multi-backend binding), and a `config` map.
+- **`WitInterfaces<'a>`** - A borrowed wrapper around `&HashSet<WitInterface>` passed to `on_workload_bind`, `on_workload_item_bind`, and `on_workload_unbind`. Provides `iter()`, `get(namespace, package, interfaces)`, and `contains(namespace, package, interfaces)` lookup helpers, avoiding a clone of the interface set per callback. Introduced in 2.4.0; earlier releases passed an owned `HashSet<WitInterface>` by value.
 - **`UnresolvedWorkload`** - A workload that has been initialized but not yet bound to plugins.
 - **`WorkloadItem<'a>`** - An enum passed to `on_workload_item_bind`. Variants are `WorkloadItem::Component(&mut WorkloadComponent)` and `WorkloadItem::Service(&mut WorkloadService)`. Implements `Deref<Target = WorkloadMetadata>`, so `item.linker()` is accessible directly without pattern matching. Use `item.is_component()` / `item.is_service()` when you need to handle the two variants differently.
 - **`ResolvedWorkload`** - A fully bound workload ready for execution.
+
+### Looking up other plugins
+
+Plugins that delegate to another plugin (for example, a custom backend that wraps `wasi:keyvalue` storage) can resolve siblings by ID from the runtime `Ctx`:
+
+```rust
+// Fallible: composes with `?` and returns a descriptive error if the
+// plugin isn't registered or the type doesn't match.
+let kv = ctx.try_get_plugin::<WasiKeyvalue>("wasi-keyvalue")?;
+
+// Infallible: panics on missing plugin or type mismatch. Use only
+// when the plugin is guaranteed by your host's registration logic.
+let kv = ctx.get_plugin::<WasiKeyvalue>("wasi-keyvalue");
+```
+
+Introduced in 2.4.0 ([#5237](https://github.com/wasmCloud/wasmCloud/pull/5237)). Earlier releases exposed only `get_plugin(id) -> Option<Arc<T>>`, which forced callers to write a guard block on every lookup; the new pair is the recommended pattern going forward.
 
 ### Example: Custom logging plugin
 
@@ -125,7 +142,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use wash_runtime::{
     engine::workload::WorkloadItem,
-    plugin::HostPlugin,
+    plugin::{HostPlugin, WitInterfaces},
     wit::{WitInterface, WitWorld},
 };
 
@@ -167,7 +184,7 @@ impl HostPlugin for CustomLogger {
     async fn on_workload_item_bind<'a>(
         &self,
         item: &mut WorkloadItem<'a>,
-        interfaces: HashSet<WitInterface>,
+        interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
         // WorkloadItem implements Deref<Target = WorkloadMetadata>, so linker()
         // is accessible directly without pattern matching:
@@ -175,6 +192,9 @@ impl HostPlugin for CustomLogger {
         //
         // Use item.is_component() / item.is_service() if you need to
         // handle components and services differently.
+        //
+        // Use interfaces.contains("wasi", "logging", &["logging"]) to gate
+        // bind logic on which interfaces the workload actually requires.
         Ok(())
     }
 

--- a/docs/runtime/creating-host-plugins.mdx
+++ b/docs/runtime/creating-host-plugins.mdx
@@ -122,14 +122,18 @@ The `HostPlugin` trait uses several types from the `wash_runtime` crate:
 Plugins that delegate to another plugin (for example, a custom backend that wraps `wasi:keyvalue` storage) can resolve siblings by ID from the runtime `Ctx`:
 
 ```rust
+use wash_runtime::plugin::wasi_keyvalue::InMemoryKeyValue;
+
 // Fallible: composes with `?` and returns a descriptive error if the
 // plugin isn't registered or the type doesn't match.
-let kv = ctx.try_get_plugin::<WasiKeyvalue>("wasi-keyvalue")?;
+let kv = ctx.try_get_plugin::<InMemoryKeyValue>("wasi-keyvalue")?;
 
 // Infallible: panics on missing plugin or type mismatch. Use only
 // when the plugin is guaranteed by your host's registration logic.
-let kv = ctx.get_plugin::<WasiKeyvalue>("wasi-keyvalue");
+let kv = ctx.get_plugin::<InMemoryKeyValue>("wasi-keyvalue");
 ```
+
+The type parameter is the concrete backend your host registered for the looked-up plugin. The built-in `wasi:keyvalue` plugin ships four interchangeable backends — `InMemoryKeyValue`, `FilesystemKeyValue`, `NatsKeyValue`, and `RedisKeyValue` — all under the same plugin ID `"wasi-keyvalue"`; substitute whichever your `HostBuilder::with_plugin()` call registered. A type mismatch surfaces through the descriptive error from `try_get_plugin`.
 
 Introduced in 2.4.0 ([#5237](https://github.com/wasmCloud/wasmCloud/pull/5237)). Earlier releases exposed only `get_plugin(id) -> Option<Arc<T>>`, which forced callers to write a guard block on every lookup; the new pair is the recommended pattern going forward.
 

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -187,15 +187,29 @@ This build command will execute the `install-and-build` script defined in your T
 | `wasi_webgpu` | boolean | `false` | Enable WASI WebGPU support |
 | `wasi_keyvalue_path` | string | - | Path for WASI key-value store data |
 | `wasi_blobstore_path` | string | - | Path for WASI blob store data |
+| `data_nats_url` | string | - | Unified NATS URL for blobstore, keyvalue, and messaging plugins (introduced in 2.4.0). Per-plugin URLs override it. |
+
+:::info[2.4.0: unified `data_nats_url`]
+Setting `dev.data_nats_url` points the blobstore, keyvalue, and messaging plugins at a single NATS endpoint at once, mirroring the production host's `--data-nats-url`. The existing per-plugin URLs (`wasi_keyvalue_nats_url`, `wasi_blobstore_nats_url`, etc.) still work and take precedence when set. This release also brings a NATS-backed blobstore to `wash dev` for the first time.
+:::
 
 ##### `dev.components[]`
 
-Additional components to load alongside your main component.
+Additional components to load alongside your main component. Starting in 2.4.0, each entry accepts per-component overrides of the workload-wide environment, config, and allowed-host lists; the override fields mirror the `localResources` shape on a `WorkloadDeployment`.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | Name identifier for the component |
 | `file` | string | Path to the component Wasm file |
+| `environment` | object | Environment variables (`wasi:cli/env`) merged over `workload.environment`. This component wins on key conflicts. *Introduced in 2.4.0.* |
+| `config` | map | Opaque key-value config merged over `workload.config`. This component wins on key conflicts. *Introduced in 2.4.0.* |
+| `allowedHosts` | array | Outbound HTTP allowlist. When set, **replaces** `workload.allowedHosts` for this component (`[]` denies all egress); when omitted the workload list applies. *Introduced in 2.4.0.* |
+
+:::info[2.4.0: workload values apply to every component]
+Workload-wide `workload.environment`, `workload.config`, and `workload.allowedHosts` are now the base layer for every component in a dev workload, including sidecars loaded via `dev.components[]` and the service from `dev.service_file`. Before 2.4.0, only the main dev component received these values; sidecars saw default `LocalResources` and were silently missing env vars and allowed-host policy.
+
+Multi-component messaging workloads also become possible in this release: more than one component in the same workload can now export the same host-invoked interface (for example, two NATS subscription handlers), where workload linking previously rejected duplicates.
+:::
 
 ##### `dev.volumes[]`
 

--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,1 +1,1 @@
-export const WASMCLOUD_VERSION = '2.3.0';
+export const WASMCLOUD_VERSION = '2.4.0';


### PR DESCRIPTION
Manual version bump for the 2.4.0 release, since automation isn't working.