### PR TITLE
docs: Fix quickstart HTTP handler version

### DIFF
--- a/docs/quickstart/develop-a-webassembly-component.mdx
+++ b/docs/quickstart/develop-a-webassembly-component.mdx
@@ -180,7 +180,7 @@ world hello {
   import wasi:keyvalue/atomics@0.2.0-draft;
   // [!code ++]
 
-  export wasi:http/incoming-handler@0.2.6;
+  export wasi:http/incoming-handler@0.2.9;
 }
 ```
   </TabItem>
@@ -198,7 +198,7 @@ world typescript-http-hello-world-hono {
   import wasi:keyvalue/atomics@0.2.0-draft;
   // [!code ++]
 
-  export wasi:http/incoming-handler@0.2.6;
+  export wasi:http/incoming-handler@0.2.9;
 }
 ```
 
@@ -229,6 +229,12 @@ If you prefer working in a language that isn't listed here, let us know!
 
   </TabItem>
 </Tabs>
+
+To fetch the new WIT dependencies, we also need to run:
+
+```bash
+wash wit fetch
+```
 
 <Tabs groupId="lang" queryString>
 


### PR DESCRIPTION
Two fixes to the docs that took me way longer to figure out than I would have liked them to.

Involved docs:

- [Quickstart](https://wasmcloud.com/docs/quickstart/)
- [Develop a Wasm Component for wasmCloud](https://wasmcloud.com/docs/quickstart/develop-a-webassembly-component/)

The quickstart builds off of [wasmCloud/templates/http-hello-world](https://github.com/wasmCloud/wasmCloud/tree/main/templates/http-hello-world) which exports `wasi:http/incoming-handler@0.2.2` in its [`world.wit`](https://github.com/wasmCloud/wasmCloud/blob/main/templates/http-hello-world/wit/world.wit)

Under [Add persistent storage](https://wasmcloud.com/docs/quickstart/develop-a-webassembly-component/#add-persistent-storage), the diff currently indicates a previous version of `0.2.6`, so the versions have already diverged.

But neither version works.

Following the error message, it seems like it needs 0.2.9. I don't fully understand where that version comes from, but that version works. :)

The example was also missing a `wash wit fetch` command to fetch the newly defined interface types, or else it fails with the error message I copied into a comment.