### PR TITLE
fix(sitemap): add lastmod, prioritize people pages, drop low-value URLs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -152,6 +152,11 @@ const config = (async (): Promise<Config> => {
             rehypePlugins: [rehypeNameToId],
           },
           sitemap: {
+            // Emit a per-URL <lastmod> (YYYY-MM-DD). This is the freshness
+            // signal search engines actually act on for crawl scheduling and
+            // discovery of new/updated pages (priority/changefreq are weak
+            // hints). Defaults to null in the plugin, so it must be set.
+            lastmod: 'date',
             changefreq: 'weekly',
             priority: 0.5,
             filename: 'sitemap.xml',
@@ -225,8 +230,11 @@ const config = (async (): Promise<Config> => {
                   if (path === '/blog/' || path === '/blog') {
                     return { ...item, priority: 0.8, changefreq: 'daily' };
                   }
+                  // Pagination & tag archives — thin, paginated, near-duplicate
+                  // listing pages with no standalone ranking value. Keep them
+                  // out of the sitemap so crawl budget goes to real content.
                   if (path.startsWith('/blog/page/') || path.startsWith('/blog/tags/')) {
-                    return { ...item, priority: 0.3, changefreq: 'weekly' };
+                    return [];
                   }
                   return { ...item, priority: 0.7, changefreq: 'monthly' };
                 }
@@ -246,9 +254,10 @@ const config = (async (): Promise<Config> => {
                   if (path === '/community/' || path === '/community') {
                     return { ...item, priority: 0.7, changefreq: 'monthly' };
                   }
-                  // Pagination/tag archives — low priority
+                  // Pagination & tag archives — thin listing pages, dropped
+                  // from the sitemap (see blog section above).
                   if (path.startsWith('/community/page/') || path.startsWith('/community/tags/')) {
-                    return { ...item, priority: 0.3, changefreq: 'weekly' };
+                    return [];
                   }
                   // Individual meeting notes & transcripts
                   return { ...item, priority: 0.5, changefreq: 'monthly' };
@@ -274,9 +283,11 @@ const config = (async (): Promise<Config> => {
                   return { ...item, priority: 0.3, changefreq: 'monthly' };
                 }
 
-                // 0.82 docs — already disallowed in robots.txt, minimal priority
+                // 0.82 docs — disallowed in robots.txt, so they must NOT be in
+                // the sitemap: listing a robots-blocked URL is a contradictory
+                // signal that Search Console flags. Drop them entirely.
                 if (path.startsWith('/docs/0.82/')) {
-                  return { ...item, priority: 0.1, changefreq: 'yearly' };
+                  return [];
                 }
 
                 // Everything else (standalone pages like /contact, etc.)

--- a/plugins/people-pages/index.ts
+++ b/plugins/people-pages/index.ts
@@ -355,15 +355,37 @@ export default async function peoplePagesPlugin(
       const { createData, addRoute, setGlobalData } = actions;
       setGlobalData(content.globalData);
 
+      // Most recent appearance date for a profile, as a millisecond
+      // timestamp. These routes are synthesized via addRoute and have no
+      // source file, so the sitemap plugin can't derive <lastmod> on its
+      // own — we feed it `metadata.lastUpdatedAt` (which it reads before
+      // falling back to a git lookup). A profile's content effectively
+      // changes when the person gains a new blog post or meeting, so the
+      // newest appearance is the honest freshness signal.
+      const latestAppearanceMs = (route: PersonPageData): number | undefined => {
+        const ms = [...route.blog_posts, ...route.community_meetings]
+          .map((a) => new Date(a.date).getTime())
+          .filter((t) => Number.isFinite(t));
+        return ms.length ? Math.max(...ms) : undefined;
+      };
+
+      let indexLatestMs: number | undefined;
+
       for (const route of content.routes) {
         const data = await createData(
           `person-${route.person.slug}.json`,
           JSON.stringify(route, null, 2),
         );
+        const lastUpdatedAt = latestAppearanceMs(route);
+        if (lastUpdatedAt !== undefined) {
+          indexLatestMs =
+            indexLatestMs === undefined ? lastUpdatedAt : Math.max(indexLatestMs, lastUpdatedAt);
+        }
         addRoute({
           path: `/people/${route.person.slug}/`,
           component: '@site/src/components/PersonPage/index.tsx',
           modules: { data },
+          ...(lastUpdatedAt !== undefined && { metadata: { lastUpdatedAt } }),
           exact: true,
         });
       }
@@ -378,6 +400,9 @@ export default async function peoplePagesPlugin(
         path: '/people/',
         component: '@site/src/components/PeopleIndexPage/index.tsx',
         modules: { data: indexData },
+        // The directory listing is "current" as of its most recently
+        // active profile.
+        ...(indexLatestMs !== undefined && { metadata: { lastUpdatedAt: indexLatestMs } }),
         exact: true,
       });
     },


### PR DESCRIPTION
## Summary

Sitemap optimization centered on the new `/people/` pages, plus best-practice cleanup found while auditing the generated `sitemap.xml`.

- **Enable `lastmod`** (Docusaurus defaults it to `null`, so it was absent on all 681 URLs). This is the freshness signal search engines actually act on for crawl scheduling and discovery of new pages — far more impactful than `priority`/`changefreq`.
- **Accurate `lastmod` for `/people/` routes.** These are synthesized via `addRoute()` with no source file, so the sitemap plugin can't derive a date. The `people-pages` plugin now attaches `metadata.lastUpdatedAt` = each profile's most recent blog post / meeting date; the `/people/` index uses its latest active profile.
- **Drop `/docs/0.82/*`** — they're `Disallow`'d in `robots.txt`, so listing them in the sitemap is a contradictory signal Search Console flags (99 URLs).
- **Drop blog & community pagination + tag archives** — thin, paginated, near-duplicate listing pages with no standalone ranking value (~57 URLs).

`/people/` (priority 0.8) and all 15 maintainer profiles (0.7) remain in the sitemap, now with accurate `lastmod` dates.

## Result

| | Before | After |
|---|---|---|
| Total sitemap URLs | 681 | **525** |
| URLs with `lastmod` | 0 | **514** |
| `/docs/0.82/*` (robots-blocked) | 99 | **0** |
| blog/community pagination + tags | 57 | **0** |
| `/docs/v1/*` (kept — still in use) | 190 | **190** |
| `/people/*` | 16 | **16** |

The 11 remaining URLs without `lastmod` are the blog/community index pages and 9 auto-generated `/docs/v1/category/*` index pages — no source file to date from, all real indexable pages, so expected.

## Notes / context
- `/people/` was already in the sitemap on this branch; the real gaps were the missing `lastmod` and the robots-blocked + thin pages.
- Ahrefs check showed ~0 branded demand for "wasmcloud maintainers/team" and that individual maintainer-name volume is dominated by namesakes — so no per-maintainer priority tiering was added (it would chase the wrong people). Flat 0.8/0.7 is intentional.
- Image/video sitemap extensions were considered and intentionally skipped: the site already emits `VideoObject`/`ImageObject` JSON-LD (91 pages), which is the interchangeable alternative.

## Verification
- `npm run build` passes (exit 0, SEO post-build checks included) after each change.
- Generated `build/sitemap.xml` inspected: counts above confirmed, 0 `noindex` pages leak into the sitemap.

## Follow-up (operational, not in this PR)
- Submit `sitemap.xml` in Google Search Console + Bing Webmaster Tools.
- After deploy, URL-inspect a couple of `/people/<slug>/` pages and request indexing.