### PR TITLE
docs: update wasmCloud version to 2.5.999

### DIFF
--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,1 +1,1 @@
-export const WASMCLOUD_VERSION = '2.5.1';
+export const WASMCLOUD_VERSION = '2.5.999';


### PR DESCRIPTION
Automated version bump from the wasmCloud release pipeline.

Updates `src/wasmcloud-version.ts` to `2.5.999`.
The remark plugin propagates the new value to all `{{WASMCLOUD_VERSION}}` placeholders
in code blocks across the docs at build time — no other files need editing.

Merging this PR with the `release-bump` label will auto-cut `docs-v2.5.999`
(via `.github/workflows/tag-after-merge.yml`), which fires `release-docs.yml` and
publishes the offline docs image + tarball.