### PR TITLE
docs: update wasmCloud version to 2.5.2

### DIFF
--- a/docs/kubernetes-operator/crds.mdx
+++ b/docs/kubernetes-operator/crds.mdx
@@ -166,7 +166,7 @@ Use the `hostInterfaces` field to define host interfaces used by the workload. E
 
 The optional `name` field enables **multi-backend binding**, meaning a component can import the same interface twice under distinct labels and have each labeled import routed to its own backend. This uses the Component Model's `implements` clause: the component declares each labeled import in its WIT world, and the runtime routes calls through the labeled namespace to the matching `hostInterfaces` entry.
 
-Enabled in 2.5.0, the Component Model's `implements` proposal (Cargo feature `wasm_component_model_implements`) is what allows the runtime to bind the labeled imports at start time.
+Introduced in 2.5.0, the Component Model's `implements` proposal (Cargo feature `wasm_component_model_implements`) is what allows the runtime to bind the labeled imports at start time. As of 2.5.2 the feature is enabled by default in the published `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` image and in the wash CLI binaries — no custom build required.
 
 A component that needs two `wasi:keyvalue` backends declares two labeled imports in its WIT world:
 
@@ -180,10 +180,10 @@ world my-app {
 
 Inside the guest, each label surfaces as its own import namespace: `cache::open("kv-bucket")` and `sessions::open("session-bucket")` reach two different backends without the guest needing to know which is which. The string passed to `open()` is the bucket name; the routing label is the WIT namespace, not an argument.
 
-:::info[Feature flag required]
-Multi-backend binding via `(implements ..)` requires a `wash-runtime` build with the `wasm_component_model_implements` Cargo feature enabled, which in turn requires a Wasmtime build with `resource-implements`. The default `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` and `ghcr.io/wasmcloud/runtime-operator:{{WASMCLOUD_VERSION}}` images ship without this feature. To use multi-backend binding today, build a custom host image with `CARGO_FEATURES=wasm_component_model_implements` (the source Dockerfile accepts this as a build arg) and point the chart at it via [`runtime.image.tag`](./operator-manual/helm-values.mdx#runtimeimagetag). The `implements` clause is a Component Model spec addition currently being finalized upstream in the WebAssembly Component Model repository. Once Wasmtime ships it in a tagged release, this feature will move onto the default surface.
+:::info[Feature-flag status]
+Multi-backend binding via `(implements ..)` depends on the Component Model's `implements` proposal, exposed on the `wash-runtime` crate as the `wasm_component_model_implements` Cargo feature (which in turn depends on a Wasmtime build with `resource-implements`). As of 2.5.2 the feature is compiled into `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` and the wash CLI binaries — the default install path just works. Embedders building their own host image can enable it explicitly by passing `CARGO_FEATURES=wasm_component_model_implements` as a Docker build arg (or `--features wasm_component_model_implements` on `cargo build`). The `implements` clause is still a Component Model spec addition being finalized upstream; once Wasmtime ships it in a tagged release, this Cargo feature moves onto the default surface and the flag goes away entirely.
 
-As of 2.5.1, multiplexed backends ship for `wasi:keyvalue`, `wasi:blobstore`, `wasmcloud:keyvalue`, `wasmcloud:blobstore`, `wasmcloud:postgres`, and `wasmcloud:messaging/consumer`.
+As of 2.5.2, multiplexed backends ship for `wasi:keyvalue`, `wasi:blobstore`, `wasmcloud:keyvalue`, `wasmcloud:blobstore`, `wasmcloud:postgres`, and `wasmcloud:messaging/consumer`. In 2.5.2, unlabeled imports of `wasmcloud:blobstore` and `wasmcloud:keyvalue/store` also work: they bind to the workload's default (unnamed) backend, so a component that needs only one backend can drop the `(implements ..)` label and still get a working binding.
 :::
 
 ```yaml

--- a/docs/kubernetes-operator/crds.mdx
+++ b/docs/kubernetes-operator/crds.mdx
@@ -166,7 +166,7 @@ Use the `hostInterfaces` field to define host interfaces used by the workload. E
 
 The optional `name` field enables **multi-backend binding**, meaning a component can import the same interface twice under distinct labels and have each labeled import routed to its own backend. This uses the Component Model's `implements` clause: the component declares each labeled import in its WIT world, and the runtime routes calls through the labeled namespace to the matching `hostInterfaces` entry.
 
-Introduced in 2.5.0, the Component Model's `implements` proposal (Cargo feature `wasm_component_model_implements`) is what allows the runtime to bind the labeled imports at start time. As of 2.5.2 the feature is enabled by default in the published `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` image and in the wash CLI binaries — no custom build required.
+Enabled in 2.5.0, the Component Model's `implements` proposal (Cargo feature `wasm_component_model_implements`) is what allows the runtime to bind the labeled imports at start time.
 
 A component that needs two `wasi:keyvalue` backends declares two labeled imports in its WIT world:
 
@@ -180,8 +180,8 @@ world my-app {
 
 Inside the guest, each label surfaces as its own import namespace: `cache::open("kv-bucket")` and `sessions::open("session-bucket")` reach two different backends without the guest needing to know which is which. The string passed to `open()` is the bucket name; the routing label is the WIT namespace, not an argument.
 
-:::info[Feature-flag status]
-Multi-backend binding via `(implements ..)` depends on the Component Model's `implements` proposal, exposed on the `wash-runtime` crate as the `wasm_component_model_implements` Cargo feature (which in turn depends on a Wasmtime build with `resource-implements`). As of 2.5.2 the feature is compiled into `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` and the wash CLI binaries — the default install path just works. Embedders building their own host image can enable it explicitly by passing `CARGO_FEATURES=wasm_component_model_implements` as a Docker build arg (or `--features wasm_component_model_implements` on `cargo build`). The `implements` clause is still a Component Model spec addition being finalized upstream; once Wasmtime ships it in a tagged release, this Cargo feature moves onto the default surface and the flag goes away entirely.
+:::info[Feature flag required]
+Multi-backend binding via `(implements ..)` requires a `wash-runtime` build with the `wasm_component_model_implements` Cargo feature enabled, which in turn requires a Wasmtime build with `resource-implements`. Release images `ghcr.io/wasmcloud/wash:{{WASMCLOUD_VERSION}}` do not commit to shipping this feature. The canary tag `ghcr.io/wasmcloud/wash:canary` is built with the flag on for wasmCloud's own multi-backend CI, and can be pointed at via the chart's [`runtime.image.tag`](./operator-manual/helm-values.mdx#runtimeimagetag) for evaluation, though the canary manifest moves with every merge to `main`. For a pinned surface, build a custom host image with `CARGO_FEATURES=wasm_component_model_implements` (the source Dockerfile accepts this as a build arg) and pin the chart at that tag. The `implements` clause is a Component Model spec addition currently being finalized upstream in the WebAssembly Component Model repository. Once Wasmtime ships it in a tagged release, this feature will move onto the default surface.
 
 As of 2.5.2, multiplexed backends ship for `wasi:keyvalue`, `wasi:blobstore`, `wasmcloud:keyvalue`, `wasmcloud:blobstore`, `wasmcloud:postgres`, and `wasmcloud:messaging/consumer`. In 2.5.2, unlabeled imports of `wasmcloud:blobstore` and `wasmcloud:keyvalue/store` also work: they bind to the workload's default (unnamed) backend, so a component that needs only one backend can drop the `(implements ..)` label and still get a working binding.
 :::

--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,1 +1,1 @@
-export const WASMCLOUD_VERSION = '2.5.1';
+export const WASMCLOUD_VERSION = '2.5.2';


### PR DESCRIPTION
Automated version bump from the wasmCloud release pipeline.

Updates `src/wasmcloud-version.ts` to `2.5.2`.
The remark plugin propagates the new value to all `{{WASMCLOUD_VERSION}}` placeholders
in code blocks across the docs at build time — no other files need editing.

Merging this PR with the `release-bump` label will auto-cut `docs-v2.5.2`
(via `.github/workflows/tag-after-merge.yml`), which fires `release-docs.yml` and
publishes the offline docs image + tarball.