### PR TITLE
docs(wash): correct wash dev patterns

### DIFF
--- a/docs/wash/developer-guide/create-services.mdx
+++ b/docs/wash/developer-guide/create-services.mdx
@@ -125,7 +125,11 @@ Services are developed using the `wash dev` command. From the project directory,
 wash dev
 ```
 
-The `wash dev` command compiles your service and runs it in a local wasmCloud environment. `wash dev` does not watch for source changes on its own; to auto-rebuild on save, wrap it with an external watcher — see the [quickstart](../../quickstart/index.mdx) for the `watchexec` pattern.
+The `wash dev` command compiles your service and runs it in a local wasmCloud environment. To auto-rebuild on save, you can wrap the command with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
+
+```shell
+watchexec -c -r 'wash dev'
+```
 
 ## Considerations
 

--- a/docs/wash/developer-guide/create-services.mdx
+++ b/docs/wash/developer-guide/create-services.mdx
@@ -125,7 +125,7 @@ Services are developed using the `wash dev` command. From the project directory,
 wash dev
 ```
 
-The `wash dev` command compiles your service, starts the runtime, and watches for changes.
+The `wash dev` command compiles your service and runs it in a local wasmCloud environment. `wash dev` does not watch for source changes on its own; to auto-rebuild on save, wrap it with an external watcher — see the [quickstart](../../quickstart/index.mdx) for the `watchexec` pattern.
 
 ## Considerations
 

--- a/docs/wash/developer-guide/language-support/go/index.mdx
+++ b/docs/wash/developer-guide/language-support/go/index.mdx
@@ -407,7 +407,7 @@ Start a development loop that builds your component and runs it in a local wasmC
 wash dev
 ```
 
-`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. It does not watch for source changes on its own — to pick up edits, rerun the command, or wrap it with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
+`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. In order to watch for source changes, you can wrap it with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
 
 ```shell
 watchexec -c -r 'wash dev'

--- a/docs/wash/developer-guide/language-support/go/index.mdx
+++ b/docs/wash/developer-guide/language-support/go/index.mdx
@@ -407,17 +407,13 @@ Start a development loop that builds your component and runs it in a local wasmC
 wash dev
 ```
 
-`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. In order to watch for source changes, you can wrap it with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
+`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. In order to watch for source changes, you can wrap the command with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
 
 ```shell
 watchexec -c -r 'wash dev'
 ```
 
-The [quickstart](../../../quickstart/index.mdx) shows the full watched-loop pattern. Send a request to test:
-
-```shell
-curl localhost:8000
-```
+The [quickstart](../../../quickstart/index.mdx) shows the full watched-loop pattern.
 
 ### Build a component
 

--- a/docs/wash/developer-guide/language-support/go/index.mdx
+++ b/docs/wash/developer-guide/language-support/go/index.mdx
@@ -401,13 +401,19 @@ TinyGo supports most of the Go standard library, but some packages have limitati
 
 ### Development loop
 
-Start a development loop that builds, runs, and watches for changes:
+Start a development loop that builds your component and runs it in a local wasmCloud environment:
 
 ```shell
 wash dev
 ```
 
-Send a request to test:
+`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. It does not watch for source changes on its own — to pick up edits, rerun the command, or wrap it with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
+
+```shell
+watchexec -c -r 'wash dev'
+```
+
+The [quickstart](../../../quickstart/index.mdx) shows the full watched-loop pattern. Send a request to test:
 
 ```shell
 curl localhost:8000

--- a/docs/wash/developer-guide/language-support/go/index.mdx
+++ b/docs/wash/developer-guide/language-support/go/index.mdx
@@ -413,7 +413,7 @@ wash dev
 watchexec -c -r 'wash dev'
 ```
 
-The [quickstart](../../../quickstart/index.mdx) shows the full watched-loop pattern.
+The [quickstart](../../../../quickstart/index.mdx) shows the full watched-loop pattern.
 
 ### Build a component
 

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -503,17 +503,13 @@ Start a development loop that builds your component and runs it in a local wasmC
 wash dev
 ```
 
-`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. It does not watch for source changes on its own — to pick up edits, rerun the command, or wrap it with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
+`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. In order to watch for source changes, you can wrap the command with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
 
 ```shell
 watchexec -c -r 'wash dev'
 ```
 
-The [quickstart](../../../quickstart/index.mdx) shows the full watched-loop pattern. Send a request to test:
-
-```shell
-curl localhost:8000
-```
+The [quickstart](../../../quickstart/index.mdx) demonstrates the full watched-loop pattern. 
 
 ### Build a component
 

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -497,13 +497,19 @@ wash new https://github.com/wasmCloud/wasmCloud.git --name hello --subfolder tem
 
 ### Development loop
 
-Start a development loop that builds, runs, and watches for changes:
+Start a development loop that builds your component and runs it in a local wasmCloud environment:
 
 ```shell
 wash dev
 ```
 
-Send a request to test:
+`wash dev` compiles the component using the build command from `.wash/config.yaml`, deploys it to a local host, and serves it. It does not watch for source changes on its own — to pick up edits, rerun the command, or wrap it with an external watcher like [`watchexec`](https://github.com/watchexec/watchexec):
+
+```shell
+watchexec -c -r 'wash dev'
+```
+
+The [quickstart](../../../quickstart/index.mdx) shows the full watched-loop pattern. Send a request to test:
 
 ```shell
 curl localhost:8000

--- a/docs/wash/developer-guide/language-support/rust/index.mdx
+++ b/docs/wash/developer-guide/language-support/rust/index.mdx
@@ -509,7 +509,7 @@ wash dev
 watchexec -c -r 'wash dev'
 ```
 
-The [quickstart](../../../quickstart/index.mdx) demonstrates the full watched-loop pattern. 
+The [quickstart](../../../../quickstart/index.mdx) demonstrates the full watched-loop pattern. 
 
 ### Build a component
 


### PR DESCRIPTION
Removes stale references claiming `wash dev` watches files in Rust, Go, and services pages and replaces with explanation of external watcher pattern.