### PR TITLE
docs: added copy-as-markdown/open-in-LLM dropdown to v2 docs

### DIFF
--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Content from '@theme-original/DocItem/Content';
+import type ContentType from '@theme/DocItem/Content';
+import type { WrapperProps } from '@docusaurus/types';
+import { useDocsVersion } from '@docusaurus/plugin-content-docs/client';
+import { CopyPageDropdown } from '@theme/wasmcloud/components/copy-page-dropdown';
+import styles from './styles.module.css';
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): React.JSX.Element {
+  // Only the latest docs version (v2) gets the copy/LLM dropdown.
+  const { isLast } = useDocsVersion();
+
+  return (
+    <div className={styles.wrapper}>
+      {isLast && (
+        <div className={styles.toolbar}>
+          <CopyPageDropdown />
+        </div>
+      )}
+      <Content {...props} />
+    </div>
+  );
+}

--- a/src/theme/DocItem/Content/styles.module.css
+++ b/src/theme/DocItem/Content/styles.module.css
@@ -1,0 +1,5 @@
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}

--- a/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
+++ b/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
@@ -1,0 +1,199 @@
+import React, { useCallback, useRef, useState } from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import { useClickOutside } from '@theme/wasmcloud/hooks/use-click-outside';
+import { useKeypress } from '@theme/wasmcloud/hooks/use-keypress';
+import styles from './styles.module.css';
+
+// Converts a GitHub "edit this page" URL into a raw.githubusercontent.com URL
+// so we can fetch the page's original Markdown/MDX source.
+function editUrlToRawUrl(editUrl: string): string | undefined {
+  const match = editUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/edit\/([^/]+)\/(.+)$/);
+  if (!match) return undefined;
+  const [, org, repo, branch, path] = match;
+  return `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${path}`;
+}
+
+function stripFrontMatter(source: string): string {
+  return source.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
+}
+
+async function fetchPageMarkdown(rawUrl: string): Promise<string> {
+  const response = await fetch(rawUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${rawUrl}: ${response.status}`);
+  }
+  return stripFrontMatter(await response.text());
+}
+
+function CopyPageDropdown(): React.JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+  const { metadata } = useDoc();
+  const [isOpen, setIsOpen] = useState(false);
+  const [copyState, setCopyState] = useState<'idle' | 'copying' | 'copied' | 'error'>('idle');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const copyResetTimeout = useRef<number | undefined>(undefined);
+
+  const close = useCallback(() => setIsOpen(false), []);
+  useClickOutside(containerRef, close);
+  useKeypress('Escape', close);
+
+  const pageUrl = `${siteConfig.url}${metadata.permalink}`;
+  const rawUrl = metadata.editUrl ? editUrlToRawUrl(metadata.editUrl) : undefined;
+
+  const copyPage = useCallback(async () => {
+    if (!rawUrl) return;
+    window.clearTimeout(copyResetTimeout.current);
+    setCopyState('copying');
+    try {
+      const markdown = await fetchPageMarkdown(rawUrl);
+      await navigator.clipboard.writeText(markdown);
+      setCopyState('copied');
+    } catch (error) {
+      console.error('Failed to copy page as Markdown', error);
+      setCopyState('error');
+    }
+    copyResetTimeout.current = window.setTimeout(() => setCopyState('idle'), 2000);
+    setIsOpen(false);
+  }, [rawUrl]);
+
+  const chatGptUrl = `https://chatgpt.com/?q=${encodeURIComponent(
+    `Read ${pageUrl} so I can ask questions about it.`,
+  )}`;
+  const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(
+    `Read ${pageUrl} so I can ask questions about it.`,
+  )}`;
+
+  const copyLabel =
+    copyState === 'copied'
+      ? 'Copied!'
+      : copyState === 'error'
+        ? 'Copy failed'
+        : copyState === 'copying'
+          ? 'Copying...'
+          : 'Copy';
+
+  return (
+    <div className={styles.container} ref={containerRef}>
+      <button
+        type="button"
+        className={styles.trigger}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        {copyLabel}
+        <ChevronIcon className={clsx(styles.chevron, isOpen && styles.chevronOpen)} />
+      </button>
+      {isOpen && (
+        <div className={styles.menu} role="menu">
+          <button
+            type="button"
+            role="menuitem"
+            className={styles.menuItem}
+            onClick={copyPage}
+            disabled={!rawUrl}
+          >
+            <div className={styles.menuItemText}>
+              <span className={styles.menuItemLabel}>Copy page</span>
+              <span className={styles.menuItemDescription}>Copy page as Markdown for LLMs</span>
+            </div>
+          </button>
+          {rawUrl && (
+            <a
+              role="menuitem"
+              className={styles.menuItem}
+              href={rawUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={close}
+            >
+              <div className={styles.menuItemText}>
+                <span className={styles.menuItemLabel}>
+                  View as Markdown <ExternalLinkIcon className={styles.externalIcon} />
+                </span>
+                <span className={styles.menuItemDescription}>View this page as plain text</span>
+              </div>
+            </a>
+          )}
+          <div className={styles.menuDivider} />
+          <a
+            role="menuitem"
+            className={styles.menuItem}
+            href={chatGptUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={close}
+          >
+            <div className={styles.menuItemText}>
+              <span className={styles.menuItemLabel}>
+                Open in ChatGPT <ExternalLinkIcon className={styles.externalIcon} />
+              </span>
+              <span className={styles.menuItemDescription}>Ask ChatGPT about this page</span>
+            </div>
+          </a>
+          <a
+            role="menuitem"
+            className={styles.menuItem}
+            href={claudeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={close}
+          >
+            <div className={styles.menuItemText}>
+              <span className={styles.menuItemLabel}>
+                Open in Claude <ExternalLinkIcon className={styles.externalIcon} />
+              </span>
+              <span className={styles.menuItemDescription}>Ask Claude about this page</span>
+            </div>
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChevronIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  );
+}
+
+function ExternalLinkIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+      <path d="M15 3h6v6" />
+      <path d="M10 14L21 3" />
+    </svg>
+  );
+}
+
+export { CopyPageDropdown };

--- a/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
+++ b/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import { useClickOutside } from '@theme/wasmcloud/hooks/use-click-outside';
 import { useKeypress } from '@theme/wasmcloud/hooks/use-keypress';
@@ -28,7 +27,6 @@ async function fetchPageMarkdown(rawUrl: string): Promise<string> {
 }
 
 function CopyPageDropdown(): React.JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
   const { metadata } = useDoc();
   const [isOpen, setIsOpen] = useState(false);
   const [copyState, setCopyState] = useState<'idle' | 'copying' | 'copied' | 'error'>('idle');
@@ -38,8 +36,8 @@ function CopyPageDropdown(): React.JSX.Element {
   const close = useCallback(() => setIsOpen(false), []);
   useClickOutside(containerRef, close);
   useKeypress('Escape', close);
+  useEffect(() => () => window.clearTimeout(copyResetTimeout.current), []);
 
-  const pageUrl = `${siteConfig.url}${metadata.permalink}`;
   const rawUrl = metadata.editUrl ? editUrlToRawUrl(metadata.editUrl) : undefined;
 
   const copyPage = useCallback(async () => {
@@ -58,12 +56,17 @@ function CopyPageDropdown(): React.JSX.Element {
     setIsOpen(false);
   }, [rawUrl]);
 
-  const chatGptUrl = `https://chatgpt.com/?q=${encodeURIComponent(
-    `Read ${pageUrl} so I can ask questions about it.`,
-  )}`;
-  const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(
-    `Read ${pageUrl} so I can ask questions about it.`,
-  )}`;
+  const viewAsMarkdown = useCallback(async () => {
+    if (!rawUrl) return;
+    try {
+      const markdown = await fetchPageMarkdown(rawUrl);
+      const blobUrl = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      console.error('Failed to open page as Markdown', error);
+    }
+    setIsOpen(false);
+  }, [rawUrl]);
 
   const copyLabel =
     copyState === 'copied'
@@ -101,13 +104,11 @@ function CopyPageDropdown(): React.JSX.Element {
             </div>
           </button>
           {rawUrl && (
-            <a
+            <button
+              type="button"
               role="menuitem"
               className={styles.menuItem}
-              href={rawUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={close}
+              onClick={viewAsMarkdown}
             >
               <div className={styles.menuItemText}>
                 <span className={styles.menuItemLabel}>
@@ -115,39 +116,8 @@ function CopyPageDropdown(): React.JSX.Element {
                 </span>
                 <span className={styles.menuItemDescription}>View this page as plain text</span>
               </div>
-            </a>
+            </button>
           )}
-          <div className={styles.menuDivider} />
-          <a
-            role="menuitem"
-            className={styles.menuItem}
-            href={chatGptUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={close}
-          >
-            <div className={styles.menuItemText}>
-              <span className={styles.menuItemLabel}>
-                Open in ChatGPT <ExternalLinkIcon className={styles.externalIcon} />
-              </span>
-              <span className={styles.menuItemDescription}>Ask ChatGPT about this page</span>
-            </div>
-          </a>
-          <a
-            role="menuitem"
-            className={styles.menuItem}
-            href={claudeUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={close}
-          >
-            <div className={styles.menuItemText}>
-              <span className={styles.menuItemLabel}>
-                Open in Claude <ExternalLinkIcon className={styles.externalIcon} />
-              </span>
-              <span className={styles.menuItemDescription}>Ask Claude about this page</span>
-            </div>
-          </a>
         </div>
       )}
     </div>

--- a/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
+++ b/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
@@ -58,11 +58,21 @@ function CopyPageDropdown(): React.JSX.Element {
 
   const viewAsMarkdown = useCallback(async () => {
     if (!rawUrl) return;
+    // Open the tab synchronously so the user gesture isn't lost across the
+    // await — popup blockers (Safari especially) block window.open otherwise.
+    // No `noopener`: it would make window.open return null, and the tab only
+    // ever hosts an inert text blob we create ourselves.
+    const tab = window.open('about:blank', '_blank');
     try {
       const markdown = await fetchPageMarkdown(rawUrl);
-      const blobUrl = URL.createObjectURL(new Blob([markdown], { type: 'text/markdown' }));
-      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      // text/plain renders inline; text/markdown triggers a download in Chrome.
+      const blobUrl = URL.createObjectURL(
+        new Blob([markdown], { type: 'text/plain;charset=utf-8' }),
+      );
+      if (tab) tab.location.href = blobUrl;
+      window.setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
     } catch (error) {
+      tab?.close();
       console.error('Failed to open page as Markdown', error);
     }
     setIsOpen(false);

--- a/src/theme/wasmcloud/components/copy-page-dropdown/styles.module.css
+++ b/src/theme/wasmcloud/components/copy-page-dropdown/styles.module.css
@@ -96,8 +96,3 @@
 .externalIcon {
   color: var(--ifm-color-emphasis-500);
 }
-
-.menuDivider {
-  margin: 0.375rem 0.25rem;
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-}

--- a/src/theme/wasmcloud/components/copy-page-dropdown/styles.module.css
+++ b/src/theme/wasmcloud/components/copy-page-dropdown/styles.module.css
@@ -1,0 +1,103 @@
+.container {
+  position: relative;
+  display: inline-block;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  cursor: pointer;
+  transition: background var(--ifm-transition-fast);
+}
+
+.trigger:hover {
+  background: var(--ifm-menu-color-background-hover);
+}
+
+.chevron {
+  transition: transform var(--ifm-transition-fast);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  right: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  min-width: 15rem;
+  padding: 0.375rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  text-align: left;
+  color: var(--ifm-font-color-base);
+  background: none;
+  border: none;
+  border-radius: calc(var(--ifm-global-radius) / 2);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.menuItem:hover {
+  background: var(--ifm-menu-color-background-hover);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+}
+
+.menuItem:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.menuItem:disabled:hover {
+  background: none;
+}
+
+.menuItemText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.menuItemLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.menuItemDescription {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+}
+
+.externalIcon {
+  color: var(--ifm-color-emphasis-500);
+}
+
+.menuDivider {
+  margin: 0.375rem 0.25rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}

--- a/src/theme/wasmcloud/index.ts
+++ b/src/theme/wasmcloud/index.ts
@@ -2,6 +2,10 @@ declare module '@theme/wasmcloud/components/video-modal' {
   export * from '@site/src/theme/wasmcloud/components/video-modal';
 }
 
+declare module '@theme/wasmcloud/components/copy-page-dropdown' {
+  export * from '@site/src/theme/wasmcloud/components/copy-page-dropdown';
+}
+
 declare module '@theme/wasmcloud/hooks/use-body-scroll-lock' {
   export * from '@site/src/theme/wasmcloud/hooks/use-body-scroll-lock';
 }


### PR DESCRIPTION
#997 
Adds a 'Copy' dropdown to the top-right of every v2 (current) doc page:
- Copy page— copies the page's raw Markdown source to your clipboard
- View as Markdown— opens the raw source in a new tab
- Open in ChatGPT / Open in Claude — opens the LLM with a prompt pre-filled with the page URL

Scoped to v2/current docs only (v1 and 0.82 are unaffected).

Markdown source is pulled from the page's own GitHub \`editUrl\` at request time — no new backend/build step needed.
