### PR TITLE
docs: add "Copy llms.txt link" item to copy-page dropdown

### DIFF
--- a/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
+++ b/src/theme/wasmcloud/components/copy-page-dropdown/index.tsx
@@ -56,6 +56,20 @@ function CopyPageDropdown(): React.JSX.Element {
     setIsOpen(false);
   }, [rawUrl]);
 
+  const copyLlmsTxtLink = useCallback(async () => {
+    window.clearTimeout(copyResetTimeout.current);
+    setCopyState('copying');
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/llms.txt`);
+      setCopyState('copied');
+    } catch (error) {
+      console.error('Failed to copy llms.txt link', error);
+      setCopyState('error');
+    }
+    copyResetTimeout.current = window.setTimeout(() => setCopyState('idle'), 2000);
+    setIsOpen(false);
+  }, []);
+
   const viewAsMarkdown = useCallback(async () => {
     if (!rawUrl) return;
     // Open the tab synchronously so the user gesture isn't lost across the
@@ -128,6 +142,19 @@ function CopyPageDropdown(): React.JSX.Element {
               </div>
             </button>
           )}
+          <button
+            type="button"
+            role="menuitem"
+            className={styles.menuItem}
+            onClick={copyLlmsTxtLink}
+          >
+            <div className={styles.menuItemText}>
+              <span className={styles.menuItemLabel}>Copy llms.txt link</span>
+              <span className={styles.menuItemDescription}>
+                Copy a link to this site&apos;s llms.txt for AI tools
+              </span>
+            </div>
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Follow-up to #1233 (copy-page-dropdown) — splits out the "Copy llms.txt link"
  item per review discussion (vendor-neutral alternative to direct
  assistant links).
- Adds a "Copy llms.txt link" item to the dropdown that copies
  `<origin>/llms.txt` to the clipboard — the link itself, not the file's
  contents — so people can hand it to whichever AI tool they use.
- Reuses the existing copy/timeout state machine already used by "Copy page."

## Note for reviewer
Currently links only to `llms.txt` (the index), not `llms-full.txt`. Happy
to add a second item for `llms-full.txt` too if you'd rather have both —
let me know.