### PR TITLE
fix: generate per-page Markdown files so llms.txt links resolve

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -375,6 +375,8 @@ const config = (async (): Promise<Config> => {
         {
           generateLlmsTxt: true,
           generateLlmsFullTxt: true,
+          // Emit a Markdown file per page so the .md links in llms.txt resolve.
+          generateMarkdownFiles: true,
           docsPluginIds: ['default'],
           blogPluginIds: ['default'],
         },


### PR DESCRIPTION
Enables `generateMarkdownFiles` in docusaurus-plugin-llms so the per-page `.md` URLs listed in `llms.txt` (currently 404s) are actually emitted at build time.