### PR TITLE
docs: update wasmCloud version to 2.8.0

### DIFF
--- a/docs/kubernetes-operator/crds.mdx
+++ b/docs/kubernetes-operator/crds.mdx
@@ -162,7 +162,7 @@ spec:
 
 ### Host Interfaces
 
-Use the `hostInterfaces` field to define host interfaces used by the workload. Each entry requires `namespace`, `package`, and `interfaces`, and may optionally include `config` and `name`.
+Use the `hostInterfaces` field to define host interfaces used by the workload. Each entry requires `namespace`, `package`, and `interfaces`, and may optionally include `version`, `config`, and `name`.
 
 The optional `name` field enables **multi-backend binding**, meaning a component can import the same interface twice under distinct labels and have each labeled import routed to its own backend. This uses the Component Model's `implements` clause: the component declares each labeled import in its WIT world, and the runtime routes calls through the labeled namespace to the matching `hostInterfaces` entry.
 
@@ -220,10 +220,14 @@ Naming rules:
 
 ### Messaging subscriptions and consumer groups
 
-The built-in NATS `wasmcloud:messaging` plugin reads two config keys, each from the component's `localResources.config` first, falling back to the `config` on the workload's `wasmcloud:messaging` `hostInterfaces` entry (so workers in one workload can override the workload-scoped values):
+As of wasmCloud 2.8.0, the `version` on a `wasmcloud:messaging` entry selects which `consumer` and `types` revision is linked for the component's imports: `"0.3.0"` binds the async surface, while `"0.2.0"` or an omitted version binds sync `0.2.0`. The handler revision follows the component's own export: the host invokes `handler@0.3.0` when the component exports it, falling back to `@0.2.0`. See [Interfaces](../overview/interfaces.mdx#wasmcloud-interfaces) for the differences. The config keys below apply to both revisions.
+
+The built-in NATS `wasmcloud:messaging` plugin reads its config keys from the component's `localResources.config` first, falling back to the `config` on the workload's `wasmcloud:messaging` `hostInterfaces` entry (so workers in one workload can override the workload-scoped values):
 
 - **`subscriptions`**: A comma-separated list of NATS subjects the component's `wasmcloud:messaging/handler` export subscribes to.
-- **`consumer_group`**: Controls delivery when a component runs with multiple replicas (as of wasmCloud 2.6.0). When omitted, replicas join a consumer group derived from the workload namespace, workload name, and component name, so exactly one replica handles each message. Set it to the special value `broadcast` to deliver every message to every replica (the pre-2.6.0 behavior — e.g., for cache invalidation), or to any other NATS-safe name (no whitespace, `*`, or `>`) to place subscribers in an explicitly named group (e.g., to share one group across components).
+- **`consumer_group`**: Controls delivery when a component runs with multiple replicas (as of wasmCloud 2.6.0). When omitted, replicas join a consumer group derived from the workload namespace, workload name, and component name, so exactly one replica handles each message. Set it to the special value `broadcast` to deliver every message to every replica (the pre-2.6.0 behavior, useful for cache invalidation), or to any other NATS-safe name (no whitespace, `*`, or `>`) to place subscribers in an explicitly named group (e.g., to share one group across components).
+- **`max_in_flight`** (as of wasmCloud 2.8.0): Caps how many deliveries to the component may be in flight at once on a host, counted across the component's replicas on that host. When omitted, the host's per-component ceiling applies. The key can only lower a component below that ceiling; a value above it is clamped to it with a warning. Raising a component past the stock ceiling requires raising the host's per-component flag. See [Messaging admission control](#messaging-admission-control) below.
+- **`admission_wait`** (as of wasmCloud 2.8.0): How long a delivery waits for an in-flight slot before it is dropped. Accepts values like `45s`, `2m`, or bare seconds. Default `30s`, maximum `600s`.
 
 ```yaml
 spec:
@@ -241,6 +245,19 @@ spec:
           package: messaging
           interfaces: [consumer, handler]
 ```
+
+#### Messaging admission control
+
+As of wasmCloud 2.8.0, the host admits messaging deliveries to per-message components through an in-flight limit, applied before an instance is created. When a component is at its limit, further deliveries wait up to `admission_wait` for a slot; a delivery that cannot be admitted in time is dropped with a warning. There is no negative acknowledgment on core NATS, so size the limit for peak load rather than relying on redelivery.
+
+Two host-level ceilings back the per-component limit, set as flags or environment variables on the host (on Kubernetes, via [`runtime.hostGroups[].env`](./operator-manual/helm-values.mdx#runtimehostgroupsenv-envfrom-and-extraargs)):
+
+| Flag | Environment variable | Default |
+| --- | --- | --- |
+| `--wasmcloud-messaging-max-in-flight` | `WASH_WASMCLOUD_MESSAGING_MAX_IN_FLIGHT` | Derived from the instance pool (133 on a stock host) |
+| `--wasmcloud-messaging-max-in-flight-per-component` | `WASH_WASMCLOUD_MESSAGING_MAX_IN_FLIGHT_PER_COMPONENT` | A quarter of the host total (33 on a stock host) |
+
+The in-flight limit is distinct from [`maxConcurrency`](#component-resource-controls), which bounds calls on one warm instance, and from the [connection quotas](./operator-manual/concurrency-and-connections.mdx): it bounds how many messaging deliveries may be executing for the component at all.
 
 ### Runtime Configuration
 

--- a/docs/kubernetes-operator/operator-manual/concurrency-and-connections.mdx
+++ b/docs/kubernetes-operator/operator-manual/concurrency-and-connections.mdx
@@ -107,6 +107,12 @@ So the tuning workflow is:
 These quotas are per host process. A workload scaled to several `replicas` gets the quota once per replica, not divided across them, so scaling out multiplies the workload's total connection budget the same way it multiplies throughput.
 :::
 
+## Messaging admission (per component)
+
+As of wasmCloud 2.8.0, messaging-triggered components have their own in-flight limit, applied before an instance is created. The `max_in_flight` config key on the component (default: the host's per-component ceiling) caps concurrent deliveries across the component's replicas on a host. A delivery over the limit waits up to `admission_wait` (default `30s`) for a slot, then is dropped with a warning.
+
+This limit is separate from `maxConcurrency`: `maxConcurrency` bounds calls on one warm instance, while `max_in_flight` bounds total messaging deliveries executing for the component. For messaging workloads, size `max_in_flight` first, then the instance limits beneath it. See [Messaging admission control](/docs/kubernetes-operator/crds#messaging-admission-control) for the config keys and host flags.
+
 ## Replicas
 
 `replicas` is the third scaling axis: copies of the whole workload spread across the host group (the pool of hosts the operator manages). It scales throughput past what one host's instance pool can serve, and it is the axis a `HorizontalPodAutoscaler` or KEDA drives through the `/scale` subresource. See [Autoscaling](/docs/kubernetes-operator/operator-manual/autoscaling) for how to scale `replicas` automatically, and why the host group is a precondition for it.
@@ -118,3 +124,4 @@ These quotas are per host process. A workload scaled to several `replicas` gets 
 - The keep-alive pool is sized automatically from declared concurrency, so you tune concurrency and the quota, not the pool directly.
 - Outbound HTTP over quota waits up to `--http-connection-wait` (default `5s`) then fails; raw sockets and inbound connections are refused immediately.
 - The connection quota applies once per replica, so scaling out multiplies the total connection budget.
+- Messaging deliveries have their own admission limit (`max_in_flight`, as of 2.8.0), applied before instance limits come into play.

--- a/docs/kubernetes-operator/operator-manual/helm-values.mdx
+++ b/docs/kubernetes-operator/operator-manual/helm-values.mdx
@@ -376,6 +376,28 @@ Prefer this over `--allow-insecure-registries`, which switches every registry to
 
 For trusting private CAs on components' *outbound HTTPS* (a separate mechanism from OCI pulls), pass `--http-client-ca-path`/`--http-client-trust-roots` via [`runtime.hostGroups[].extraArgs`](#runtimehostgroupsenv-envfrom-and-extraargs) with the bundle mounted the same way.
 
+### `runtime.resources.defaultHeapMemory` and `runtime.resources.coreInstances`
+
+Introduced in 2.8.0. Wasmtime engine sizing for hosts, set inside the `resources` block alongside the Kubernetes requests and limits (the chart strips them out before rendering the container `resources`). Both are passed to the host as environment variables, so older host images ignore them.
+
+- **`defaultHeapMemory`**: Ceiling on any single guest linear memory. Defaults to wasmtime's 4 GiB.
+- **`coreInstances`**: Number of instance slots in wasmtime's pooling allocator. Defaults to 1000.
+
+Sizes accept Kubernetes quantity suffixes (`Gi`/`GiB` binary, `G`/`GB` decimal, bare values are bytes):
+
+```yaml
+runtime:
+  resources:
+    limits:
+      memory: "2Gi"
+    defaultHeapMemory: "512Mi"
+    coreInstances: "500"
+```
+
+As of 2.8.0 the chart also forwards `resources.limits.memory` to the host as its guest memory budget (`--max-guest-memory`). At 2.8.0 the budget is advisory: the host logs it at startup and warns when the heap ceiling or pool reservation looks inconsistent with it, but does not enforce it. When no limit is set, the host derives the budget from the cgroup limit or physical memory.
+
+These values size the engine for the whole host; they are not per-workload limits. A host group with its own `resources` block replaces the chart-wide `runtime.resources` wholesale, so repeat these keys per group if you use both.
+
 ### `runtime.hostGroups[].http.tls.certificate.generate.ipAddresses`
 
 Introduced in 2.7.0. Additional IP SANs for the host group's generated TLS certificate; needed when clients reach the host group by IP rather than name. Note that the chart reuses an existing `hostgroup-<name>-http-tls` Secret if one exists, so adding `ipAddresses` to a live release takes effect only after that Secret is deleted and the certificate regenerated.

--- a/docs/overview/hosts/plugins.mdx
+++ b/docs/overview/hosts/plugins.mdx
@@ -128,7 +128,7 @@ For details on authoring, packaging, and deploying a host component plugin, see 
 
 ### Feature-gated
 
-Host component plugins shipped in wasmCloud 2.6.0 and remain opt-in as of 2.7.0: release images are built with default features only, which do not include the plugin support, so enable the `host-component-plugins` Cargo feature when building a host. If you embed `wash-runtime`, enable the feature on a Git dependency (the crate on crates.io is a stale early snapshot that predates the current API):
+Host component plugins shipped in wasmCloud 2.6.0 and remain opt-in as of 2.8.0: release images are built with default features only, which do not include the plugin support, so enable the `host-component-plugins` Cargo feature when building a host. If you embed `wash-runtime`, enable the feature on a Git dependency (the crate on crates.io is a stale early snapshot that predates the current API):
 
 ```toml
 [dependencies]

--- a/docs/overview/hosts/trigger-services.mdx
+++ b/docs/overview/hosts/trigger-services.mdx
@@ -46,7 +46,9 @@ When a service runs with multiple replicas on a host, the HTTP ingress distribut
 
 ### Messaging ingress
 
-A trigger service that exports `wasmcloud:messaging/handler@0.2.0` receives inbound messages through the messaging ingress. As of wasmCloud 2.6.0, the built-in messaging plugins deliver through this ingress for **service** workloads: a service exporting the handler receives every message on its pinned instance, while a plain component exporting the same handler is instantiated fresh per message.
+A trigger service that exports `wasmcloud:messaging/handler` receives inbound messages through the messaging ingress. As of wasmCloud 2.6.0, the built-in messaging plugins deliver through this ingress for **service** workloads: a service exporting the handler receives every message on its pinned instance, while a plain component exporting the same handler is instantiated fresh per message.
+
+As of wasmCloud 2.8.0, the messaging ingress invokes the async `wasmcloud:messaging/handler@0.3.0` interface. A service must export `handler@0.3.0`; a service exporting only the sync `handler@0.2.0` fails to start at 2.8.0. Plain components still run per message and may export either revision (the host prefers `0.3.0` when a component exports both). Messaging deliveries are bounded by `WASH_MESSAGING_DELIVER_TIMEOUT_SECS` (default 600 seconds, added in 2.8.0). See [Interfaces](../interfaces.mdx#wasmcloud-interfaces) for the differences between the revisions.
 
 ### Capability ingress
 
@@ -64,6 +66,8 @@ A trigger service is instantiated when its owning workload starts. The runtime i
 
 **Supervision.** If the guest instance traps, the runtime re-instantiates it within a bounded restart budget; in-flight invocations to the failed incarnation fail promptly rather than hanging. The budget is spent only on the trigger service's *own* faults — as of wasmCloud 2.7.0, a failure in a workload that a plugin calls via `workload-call` is reported to the plugin as an error value and never traps the pinned instance or consumes its restart budget.
 
+**Runaway guests.** As of wasmCloud 2.8.0, guest code that spins the CPU without yielding is subject to a host backstop. When a call passes its ingress deadline (or its client disconnects), no other call on the instance is still wanted, and the guest is measurably pinned, the host traps the instance: a pooled warm instance is replaced, a service is restarted under supervision, and a host component plugin is warned first and restarted only after an escalation window (losing its in-memory state). The caller sees an error at roughly the ingress deadline instead of a hang. A guest that yields normally is never affected, and a slow guest with a disconnected client is not trapped as long as it keeps yielding. Capability calls into plugins are bounded by `WASH_PLUGIN_CAPABILITY_CALL_TIMEOUT_SECS` (default 600 seconds); the grace and escalation windows are tunable with `WASH_ABANDONED_CALL_GRACE_SECS` (default 10) and `WASH_ABANDONED_CALL_ESCALATION_SECS` (default 60).
+
 ## Cancellation and host awareness
 
 Trigger services can import [`wasmcloud:host`](../interfaces.mdx) to observe and cooperate with their environment:
@@ -78,7 +82,7 @@ See the [authoring guide](../../runtime/creating-host-component-plugins.mdx) for
 
 - **Single instance, not a pool.** A trigger service is one instance. Blocking work in a handler blocks the tasks scheduled on the same async runtime; use non-blocking APIs and structured concurrency.
 - **Shared state.** All ingress handlers, `wasi:cli/run`, and any inter-handler background tasks share the instance's linear memory. Guard shared mutable state accordingly.
-- **WASI target.** The HTTP ingress requires WASI P3 (`wasi:http/handler@0.3.0`); the messaging ingress uses `wasmcloud:messaging/handler@0.2.0`; the capability ingress uses the capability's own package. A trigger service that only exports `wasi:cli/run` can target P2 or P3 to match its imports.
+- **WASI target.** The HTTP ingress requires WASI P3 (`wasi:http/handler@0.3.0`); the messaging ingress uses `wasmcloud:messaging/handler@0.3.0` as of wasmCloud 2.8.0; the capability ingress uses the capability's own package. A trigger service that only exports `wasi:cli/run` can target P2 or P3 to match its imports.
 
 ## Keep reading
 

--- a/docs/overview/interfaces.mdx
+++ b/docs/overview/interfaces.mdx
@@ -181,14 +181,14 @@ Well-known interfaces include six APIs built specifically for wasmCloud:
 
 | API                                                                                        | Versions    | Interfaces |
 | ------------------------------------------------------------------------------------------ | ----------- | ---------- |
-| [wasmcloud:messaging](https://github.com/wasmCloud/wasmCloud/tree/main/wit/messaging)      | 0.2.0       | `consumer`, `handler`, `types` |
+| [wasmcloud:messaging](https://github.com/wasmCloud/wasmCloud/tree/main/wit/messaging)      | 0.2.0 (sync), 0.3.0 (async) | `consumer`, `handler`, `types` |
 | [wasmcloud:keyvalue](https://github.com/wasmCloud/wasmCloud/tree/main/wit/keyvalue)        | 0.1.0       | `store`, `atomics`, `batch`, `cas`, `watcher`, `types` |
 | [wasmcloud:blobstore](https://github.com/wasmCloud/wasmCloud/tree/main/wit/blobstore)      | 0.1.0       | `blobstore`, `container`, `types` |
 | [wasmcloud:postgres](https://github.com/wasmCloud/wasmCloud/tree/main/wit/postgres)        | 0.1.1-draft (sync), 0.2.0 (async) | `query`, `prepared`, `types` |
 | [wasmcloud:host](https://github.com/wasmCloud/wasmCloud/tree/main/wit/host)                | 0.1.3       | `types`, `identity`, `cancel`, `workload-call`, `workload-lifecycle` |
 | [wasmcloud:secrets](https://github.com/wasmCloud/wasmCloud/tree/main/wit/secrets)          | 2.1.0       | `store`, `reveal`, `secret` |
 
-* **`wasmcloud:messaging`** facilitates communication through message brokers: `consumer` for publishing and request/reply, `handler` for receiving deliveries. A service that exports `wasmcloud:messaging/handler@0.2.0` receives messages through the [messaging ingress](./hosts/trigger-services.mdx#messaging-ingress).
+* **`wasmcloud:messaging`** facilitates communication through message brokers: `consumer` for publishing and request/reply, `handler` for receiving deliveries. As of wasmCloud 2.8.0 the package ships in two revisions: the sync `0.2.0` interfaces (vendored with the runtime) and an async `0.3.0` counterpart in `wit/messaging` (see the callout below). A service that exports `wasmcloud:messaging/handler@0.3.0` receives messages through the [messaging ingress](./hosts/trigger-services.mdx#messaging-ingress).
 * **`wasmcloud:keyvalue`** is the async-shaped key-value package (see the callout below), extending `wasi:keyvalue` with TTL on `set`, compare-and-swap, batch operations, and typed errors. A `watcher` interface is defined in the package, but watch delivery is not yet implemented by the runtime plugin. Runtime support for the package is carried by `wash-runtime` builds with the `wasm_component_model_implements` Cargo feature, part of the default feature set (and stock release images) as of wasmCloud 2.7.0; earlier releases required a custom build. See [Host Interfaces](../kubernetes-operator/crds.mdx#host-interfaces) for details.
 * **`wasmcloud:blobstore`** is the async-shaped blob/object storage package, the streaming counterpart to `wasi:blobstore`. Runtime support carries the same `wasm_component_model_implements` feature requirement as `wasmcloud:keyvalue` (default as of 2.7.0).
 * **`wasmcloud:postgres`** provides direct PostgreSQL access — one-shot `query`, `prepared` statements, and shared `types` — in a sync (`0.1.1-draft`) and an async (`0.2.0`) shape, both served by the built-in Postgres [host plugin](./hosts/plugins.mdx). The async package lives in `wit/postgres`; the sync package is vendored with the runtime.
@@ -203,6 +203,12 @@ These packages are published as [OCI artifacts](./packaging.mdx) to `ghcr.io/was
 Starting in 2.5.0, `wasmcloud:keyvalue` and `wasmcloud:blobstore` ship async-shaped WIT packages alongside the existing sync interfaces, together with **TTL on `set`**, **CAS** (compare-and-swap), and **typed errors** for missing keys, conflicts, and backend failures. The async packages depend on the `component-model-async` proposal (implied by WASI 0.3).
 
 The `bucket` resource (and `error`, `key-response`, `set-options`) live in a shared `wasmcloud:keyvalue/types` interface, and `store`, `atomics`, `cas`, `batch`, and `watcher` all `use types.{bucket, error}`. A guest using a labeled multi-backend `store` can therefore also use `cas`/`atomics`/`batch` against the same bucket — the resource identity matches across all five interfaces. This mirrors the shape that `wasmcloud:blobstore` uses.
+:::
+
+:::info[2.8.0: async `wasmcloud:messaging`]
+Starting in 2.8.0, `wasmcloud:messaging` ships an async `0.3.0` revision alongside the sync `0.2.0` interfaces. In `0.3.0`, `consumer.publish`, `consumer.request`, and `handler.handle-message` are `async func`s, message bodies are `stream<u8>` rather than `list<u8>`, `request` takes an optional `timeout-ms`, and errors are typed variants (`timeout`, `broker-unavailable`, `message-too-large`, and more) instead of strings. A handler returns a `handle-message-error` disposition (`reject`, `retry`, or `other`); at 2.8.0 the host logs the disposition, and mapping `retry` to broker redelivery is left to future backend support.
+
+The `version` on a component's `wasmcloud:messaging` [host interface entry](../kubernetes-operator/crds.mdx#host-interfaces) selects which `consumer` and `types` revision is linked for its imports: `"0.3.0"` binds the async surface, while `"0.2.0"` or an omitted version binds sync `0.2.0`. The handler revision follows the component's own export, with `0.3.0` preferred when both are exported. Both revisions share the same backends and configuration, including `subscriptions` and `consumer_group`.
 :::
 
 ## Custom interfaces

--- a/docs/overview/workloads/services.mdx
+++ b/docs/overview/workloads/services.mdx
@@ -71,7 +71,7 @@ Services are not limited to TCP&mdash;they can use your own [custom interfaces](
 
 A service must export `wasi:cli/run` (the standard run function) **or** exactly one [WIT interface](../interfaces.mdx). This is how the runtime identifies the service's entry point. For example, a service could export `wasi:cli/run` to act as a long-running process with a `main` function, or it could export a single custom interface.
 
-A service may additionally co-export a host-invoked interface (`wasi:http/handler@0.3` or `wasmcloud:messaging/handler@0.2.0` today) to wire up the corresponding [ingress](../hosts/trigger-services.mdx#ingresses). The co-exported handler runs on the same pinned instance as `wasi:cli/run`, so long-running work in the run loop and per-invocation handler work share state.
+A service may additionally co-export a host-invoked interface (`wasi:http/handler@0.3` or, as of wasmCloud 2.8.0, `wasmcloud:messaging/handler@0.3.0`) to wire up the corresponding [ingress](../hosts/trigger-services.mdx#ingresses). The co-exported handler runs on the same pinned instance as `wasi:cli/run`, so long-running work in the run loop and per-invocation handler work share state.
 
 ### Imports and host plugins
 
@@ -159,7 +159,7 @@ When developing applications with services, it is important to consider the foll
 - **Export constraint**: Services must export `wasi:cli/run` or exactly one WIT interface, optionally alongside a host-invoked handler that wires up an [ingress](../hosts/trigger-services.mdx#ingresses).
 - **One-way communication**: Components cannot call service exports via WIT (but can use TCP).
 - **Memory usage**: Services maintain state, so they consume memory continuously.
-- **WASI target**: Services that use the HTTP ingress compile against WASI P3 (`wasi:cli/run@0.3.0` + `wasi:http/handler@0.3.0`); the messaging ingress uses `wasmcloud:messaging/handler@0.2.0`. Services that don't co-export a host-invoked handler can target P2 or P3 to match their world's other imports.
+- **WASI target**: Services that use the HTTP ingress compile against WASI P3 (`wasi:cli/run@0.3.0` + `wasi:http/handler@0.3.0`); the messaging ingress uses `wasmcloud:messaging/handler@0.3.0` as of wasmCloud 2.8.0. Services that don't co-export a host-invoked handler can target P2 or P3 to match their world's other imports.
 - **Async runtime**: Can use single-threaded async runtimes (e.g., Tokio with single-threaded executor).
 - **Restarts**: On a guest trap, the runtime re-instantiates the service within a bounded restart budget; see [Trigger services supervision](../hosts/trigger-services.mdx#instance-lifecycle).
 - **Isolation**: Service network operations are isolated within the workload boundary.

--- a/docs/runtime/building-custom-hosts.mdx
+++ b/docs/runtime/building-custom-hosts.mdx
@@ -200,6 +200,13 @@ let host = host.start().await?;
 | `with_http_handler(Arc<dyn HostHandler>)` | Register the HTTP handler (`Ingress` implements `HostHandler`, not `HostPlugin`) |
 | `with_plugin(Arc<dyn HostPlugin>)` | Register a plugin (can be called multiple times; IDs must be unique) |
 
+### Embedder defaults at 2.8.0
+
+Two embedder-facing changes in 2.8.0:
+
+- **Socket policy defaults now match the CLI.** A host built without an explicit socket policy previously ran with egress address screening off. As of 2.8.0, the default denies special address ranges, allows private ranges, uses `count` egress mode, and keeps host loopback off, matching the defaults `wash` applies. Embedders that relied on the permissive default should set a policy explicitly.
+- **OCI CA trust is settable via `HostConfig`.** The new `oci_ca_paths` field (default empty) adds CA certificates to trust when pulling from OCI registries, matching the CLI's `--oci-ca-path`.
+
 ### Customizing outgoing HTTP requests
 
 By default, every outbound HTTP request from a component flows through `wasmtime-wasi-http`'s `default_send_request`. For most embedders that's the right behavior — but if you need to thread custom TLS configuration through outgoing calls, swap in an alternative transport (an internal RPC system, for example), or insert middleware-style policy at the egress boundary, `wash-runtime` 2.2 introduced the `OutgoingHandler` trait as a pluggable extension point on the HTTP server.

--- a/docs/runtime/creating-host-component-plugins.mdx
+++ b/docs/runtime/creating-host-component-plugins.mdx
@@ -38,7 +38,7 @@ From the caller's perspective this is transparent: a workload does not know whet
 As of wasmCloud 2.7.0, calls can also flow in the other direction: a plugin can import an interface that a workload exports and invoke it via [`wasmcloud:host/workload-call`](#wasmcloudhostworkload-call) — for example, to dispatch scheduled or broker-driven work into application components. A plugin can even export no capability at all and act as a **pure trigger** that only drives workload exports from its background task.
 
 :::info[Opt-in feature]
-Host component plugins shipped in wasmCloud 2.6.0, opt-in via the `host-component-plugins` Cargo feature on `wash-runtime` (still the case as of 2.7.0). Release images are built with default features only, so running host component plugins requires a host image built with the feature enabled. Check the [wash-runtime source](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-runtime) for the current shape.
+Host component plugins shipped in wasmCloud 2.6.0, opt-in via the `host-component-plugins` Cargo feature on `wash-runtime` (still the case as of 2.8.0). Release images are built with default features only, so running host component plugins requires a host image built with the feature enabled. Check the [wash-runtime source](https://github.com/wasmCloud/wasmCloud/tree/main/crates/wash-runtime) for the current shape.
 :::
 
 ## Plugin world

--- a/docs/runtime/index.mdx
+++ b/docs/runtime/index.mdx
@@ -145,6 +145,8 @@ Starting in wasmCloud 2.5.0, the runtime is built with WASI 0.3 always on (on Wa
 
 Components targeting either P2 or P3 worlds are compatible with the runtime.
 
+The async surface extends to wasmCloud's own packages: `wasmcloud:keyvalue` and `wasmcloud:blobstore` ship async-shaped revisions as of 2.5.0, and `wasmcloud:messaging@0.3.0` (async functions, streamed bodies) ships as of 2.8.0 alongside the sync `0.2.0` interfaces. See [Interfaces](../overview/interfaces.mdx#wasmcloud-interfaces).
+
 :::info[Configurable engine proposals]
 2.5.0 also exposes the engine's top-level Wasm proposals (`component-model-async`, `gc`, `exception-handling`, `wide-arithmetic`, `threads`, `tail-call`) as a per-host, per-host-group configurable surface via `wash host --wasm-proposal`, the `dev.wasm_proposals` config field, and the [`runtime.hostGroups[].wasmProposals`](../kubernetes-operator/operator-manual/helm-values.mdx#runtimehostgroupswasmproposals) Helm value. WASI 0.3 always brings the `component-model-async` proposal along with it, so hosts have async available whether or not it's listed explicitly.
 :::

--- a/docs/wash/commands.mdx
+++ b/docs/wash/commands.mdx
@@ -385,11 +385,11 @@ Manage WIT dependencies.
 
 ## `wash wit add`
 
-Add a new WIT dependency.
+Add a WIT interface to the world's imports.
 
 **Usage**: `wash wit add [OPTIONS] <PACKAGE>`
 
-**Arguments**: `<Package>` - Package to add (e.g., `wasi:keyvalue` or `wasi:keyvalue@0.2.0-draft`)
+**Arguments**: `<Package>` - Interface to import (e.g., `wasi:keyvalue/store` or `wasi:keyvalue/store@0.2.0-draft`). As of wasmCloud 2.8.0, the reference is validated before `wit/world.wit` is modified; passing a package on its own (e.g., `wasi:keyvalue`) lists its interfaces instead of writing anything.
 
 ###### **Options:**
 
@@ -402,7 +402,7 @@ Add a new WIT dependency.
 
 ## `wash wit build`
 
-Add a new WIT dependency.
+Build a WIT package into a Wasm binary.
 
 **Usage**: `wash wit build [OPTIONS]`
 
@@ -453,7 +453,7 @@ Remove a WIT dependency.
 
 **Usage**: `wash wit remove [OPTIONS] <PACKAGE>`
 
-**Arguments**: `<Package>` - Package to remove (e.g., `wasi:keyvalue`)
+**Arguments**: `<Package>` - Interface (e.g., `wasi:keyvalue/store`) or package (e.g., `wasi:keyvalue`) to remove. A package removes every import it contributes to the world. As of wasmCloud 2.8.0, removal also drops the package from `wit/deps/` and re-fetches so the lock file no longer pins it.
 
 ###### **Options:**
 
@@ -466,7 +466,7 @@ Remove a WIT dependency.
 
 ## `wash wit update`
 
-Update dependencies to latest compatible versions.
+Update dependencies to latest compatible versions. As of wasmCloud 2.8.0, the command reports which packages moved and accepts the same interface references as `add` and `remove`.
 
 **Usage**: `wash wit update [OPTIONS] <PACKAGE>`
 

--- a/docs/wash/config.mdx
+++ b/docs/wash/config.mdx
@@ -244,7 +244,7 @@ Configuration for WIT (WebAssembly Interface Type) dependency management.
 | `registries` | array | wasm.pkg registry | Registries for WIT package fetching |
 | `skip_fetch` | boolean | `false` | Skip fetching WIT dependencies |
 | `wit_dir` | string | `./wit` | Directory where WIT files are stored |
-| `sources` | map | `{}` | Source overrides for WIT dependencies (target → source mapping) |
+| `sources` | map | `{}` | Source overrides for WIT dependencies (target → source mapping). Accepts HTTP, Git, and OCI references; absolute local paths as of wasmCloud 2.8.0 |
 
 #### `wit.registries[]`
 

--- a/docs/wash/developer-guide/language-support/rust/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/rust/messaging.mdx
@@ -38,6 +38,10 @@ The example template demonstrates a two-component request-reply pattern that may
 
 ![Messaging flow](../../../images/messaging-flow.svg)
 
+:::note[Interface revisions]
+This guide uses the sync `wasmcloud:messaging@0.2.0` interfaces, which remain the default. wasmCloud 2.8.0 adds an async `0.3.0` revision with streamed message bodies and typed errors. A component opts in by targeting the `0.3.0` interfaces in its WIT world and declaring `version: "0.3.0"` on the workload's `wasmcloud:messaging` host interface entry. See [Interfaces](/docs/overview/interfaces#wasmcloud-interfaces).
+:::
+
 :::info[NATS in production]
 `wasmcloud:messaging` uses NATS as its production transport, built into the wasmCloud runtime. During development with `wash dev`, messaging is handled in-process and no NATS server is required. In production, the runtime connects to NATS automatically when the host starts with a NATS URL.
 :::

--- a/docs/wash/developer-guide/language-support/typescript/messaging.mdx
+++ b/docs/wash/developer-guide/language-support/typescript/messaging.mdx
@@ -26,6 +26,10 @@ You can add messaging capabilities to a component with the [`wasmcloud:messaging
 
 This guide walks through the wasmCloud [`http-api-with-distributed-workloads`](https://github.com/wasmCloud/typescript/tree/main/templates/http-api-with-distributed-workloads) template, which demonstrates how to dispatch work from an HTTP API to a background component via a message broker. You can use this guide as a model for implementing `wasmcloud:messaging` in your own components.
 
+:::note[Interface revisions]
+This guide uses the sync `wasmcloud:messaging@0.2.0` interfaces, which remain the default. wasmCloud 2.8.0 adds an async `0.3.0` revision with streamed message bodies and typed errors. A component opts in by targeting the `0.3.0` interfaces in its WIT world and declaring `version: "0.3.0"` on the workload's `wasmcloud:messaging` host interface entry. See [Interfaces](/docs/overview/interfaces#wasmcloud-interfaces).
+:::
+
 ## Overview
 
 Messaging typically spans **at least two components**. A component can import `consumer` to publish events without a handler in the same deployment; for example, the component might publish audit events that an external NATS subscriber consumes. A handler can also receive from multiple senders. 

--- a/src/wasmcloud-version.ts
+++ b/src/wasmcloud-version.ts
@@ -1,1 +1,1 @@
-export const WASMCLOUD_VERSION = '2.7.0';
+export const WASMCLOUD_VERSION = '2.8.0';


### PR DESCRIPTION
Updates documentation for the wasmCloud 2.8.0 release: async `wasmcloud:messaging@0.3.0` and revision selection, messaging admission control (`max_in_flight`, `admission_wait`, host ceilings), host memory knobs in the chart (`runtime.resources.defaultHeapMemory`/`coreInstances`), the runaway-guest timeout backstop, `wash wit` behavior changes, and embedder default changes in `wash-runtime`.