### PR TITLE
fix(community): remove two transcript image tags pointing at missing files

### DIFF
--- a/community/2025-07-16-community-meeting-transcript.mdx
+++ b/community/2025-07-16-community-meeting-transcript.mdx
@@ -212,6 +212,4 @@ Thank you so much for taking the initiative on this one — let us know if you h
 
 The last but certainly not least, very exciting **documentation of the week** is under our contributing guide. Thank you so much, Eric. We now have a community wasmCloud room in Excalidraw. If you're making diagrams about wasmCloud — whether you want to contribute a diagram to the wasmCloud documentation or show off wasmCloud inside your organization — you can take a look at our shared Excalidraw room. Some of the diagrams from the roadmapping session are in the actual documentation now. This is what we use, and it's a great place to grab assets and make diagrams; you should be able to copy and paste these into your own canvas. The only thing left is to get Aditya in as an editor so he can add the component-based diagrams. So thank you, Eric, for getting this in — it's under the contributing documentation guide.
 
-<img src="/img/community/2025-07-16/image015.webp" alt="The shared community wasmCloud Excalidraw room for diagrams" />
-
 Woohoo, we did it. We're actually over time now, so thanks everybody for coming and listening for a while. Exciting stuff — the roadmap is going pretty well, exciting moves on wash and the community in general. Thanks everybody. Hope you have a great rest of your week. Have a wasmCloud day.

--- a/community/2025-08-20-community-meeting-transcript.mdx
+++ b/community/2025-08-20-community-meeting-transcript.mdx
@@ -58,8 +58,6 @@ If you're interested in testing out `wash` in your GitHub Action — if you're r
 
 I think that's really all I had on the shortlist of the agenda — just talking about the newest things we've been working on. Work on `wash` and on wasmCloud has been going really well. wasmCloud itself just got a new minor release last week, I believe, for version 1.9. I'll go back and share that, just to give folks a shout-out. We had a lot of good work go into this one, including Jacob's work to get wash working with the XDG base-directory specification. This was awesome — it's a standard way of organizing local files on the machine, and it really helps because now we don't have this bespoke dot-wash directory that clutters up the user's home directory.
 
-<img src="/img/community/2025-08-20/image004.webp" alt="The wasmCloud 1.9 release notes on GitHub" />
-
 We're also adding a dashboard option for `wash dev`, to ensure that when you run `wash dev`, the dashboard essentially launches from there. And it looks like me, but it's not me — it's OSS Fellow Massoud, who put in the HTTP client built-in provider, which I've heard from folks has been working well. You just use the built-in and skip a little network hop to go make your outgoing HTTP request. So that's been really cool to see. And a shout-out to all of our folks who made their first contribution in this release — I shouted everybody out here in the wasmCloud Slack. Awesome stuff. It's really cool to see more and more contributors come in every release.
 
 So other than that, I really think that's it. Do folks have any other agenda items, things they wanted to discuss in wasmCloud, or from the broader WebAssembly ecosystem today?


### PR DESCRIPTION
Two community transcript pages reference screenshots that were never committed, so they 404 on prod and render as broken image icons

- `community/2025-07-16-community-meeting-transcript.mdx` -> `/img/community/2025-07-16/image015.webp`
- `community/2025-08-20-community-meeting-transcript.mdx` -> `/img/community/2025-08-20/image004.webp`

Docusaurus doesnt validate `<img>` src paths so the build stays green. 
This removes the two dead tags

## Repro

```
curl -sI https://wasmcloud.com/img/community/2025-07-16/image015.webp | head -1
# HTTP/2 404
curl -s https://wasmcloud.com/community/2025-07-16-community-meeting-transcript/ | grep -o image015.webp
# image015.webp   (still in the shipped page)
```
